### PR TITLE
Remove entry points impression event from CollectionsHubsNav

### DIFF
--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -14,15 +14,10 @@ interface CollectionsHubsHomepageNavProps {
 }
 
 export const CollectionsHubsHomepageNav = track(
-  {
-    context_page: AnalyticsSchema.PageName.HomePage,
-    context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-    subject: AnalyticsSchema.Subject.FeaturedCategories,
-  },
+  {},
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {
   const { trackEvent } = useTracking()
-  trackEvent({})
   return (
     <CSSGrid
       as="aside"

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -18,7 +18,6 @@ export const CollectionsHubsHomepageNav = track(
     context_page: AnalyticsSchema.PageName.HomePage,
     context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
     subject: AnalyticsSchema.Subject.FeaturedCategories,
-    action_type: AnalyticsSchema.ActionType.Impression,
   },
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {

--- a/src/__generated__/AcceptTestQuery.graphql.ts
+++ b/src/__generated__/AcceptTestQuery.graphql.ts
@@ -223,80 +223,6 @@ fragment Accept_order on CommerceOrder {
   ...CreditCardSummaryItem_order
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -337,6 +263,80 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -862,7 +862,7 @@ return {
     "operationKind": "query",
     "name": "AcceptTestQuery",
     "id": null,
-    "text": "query AcceptTestQuery {\n  order: commerceOrder(id: \"\") {\n    __typename\n    ...Accept_order\n    id\n  }\n}\n\nfragment Accept_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query AcceptTestQuery {\n  order: commerceOrder(id: \"\") {\n    __typename\n    ...Accept_order\n    id\n  }\n}\n\nfragment Accept_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Accept_order.graphql.ts
+++ b/src/__generated__/Accept_order.graphql.ts
@@ -24,11 +24,6 @@ export type Accept_order = {
     readonly " $fragmentRefs": FragmentRefs<"TransactionDetailsSummaryItem_order" | "ArtworkSummaryItem_order" | "ShippingSummaryItem_order" | "CreditCardSummaryItem_order">;
     readonly " $refType": "Accept_order";
 };
-export type Accept_order$data = Accept_order;
-export type Accept_order$key = {
-    readonly " $data"?: Accept_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Accept_order">;
-};
 
 
 

--- a/src/__generated__/Articles_artist.graphql.ts
+++ b/src/__generated__/Articles_artist.graphql.ts
@@ -6,11 +6,6 @@ export type Articles_artist = {
     readonly " $fragmentRefs": FragmentRefs<"ArtistArticles_artist">;
     readonly " $refType": "Articles_artist";
 };
-export type Articles_artist$data = Articles_artist;
-export type Articles_artist$key = {
-    readonly " $data"?: Articles_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"Articles_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistApp_artist.graphql.ts
+++ b/src/__generated__/ArtistApp_artist.graphql.ts
@@ -8,11 +8,6 @@ export type ArtistApp_artist = {
     readonly " $fragmentRefs": FragmentRefs<"ArtistMeta_artist" | "ArtistHeader_artist" | "NavigationTabs_artist">;
     readonly " $refType": "ArtistApp_artist";
 };
-export type ArtistApp_artist$data = ArtistApp_artist;
-export type ArtistApp_artist$key = {
-    readonly " $data"?: ArtistApp_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistApp_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistArticles_artist.graphql.ts
+++ b/src/__generated__/ArtistArticles_artist.graphql.ts
@@ -30,11 +30,6 @@ export type ArtistArticles_artist = {
     } | null;
     readonly " $refType": "ArtistArticles_artist";
 };
-export type ArtistArticles_artist$data = ArtistArticles_artist;
-export type ArtistArticles_artist$key = {
-    readonly " $data"?: ArtistArticles_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistArticles_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworkFilterQuery.graphql.ts
@@ -104,6 +104,28 @@ fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection
   ...ArtworkGrid_artworks
 }
 
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -122,6 +144,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -130,34 +181,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -198,55 +221,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  first {
-    cursor
-    page
-    isCurrent
+  partner(shallow: true) {
+    type
+    id
   }
-  last {
-    cursor
-    page
-    isCurrent
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-  previous {
-    cursor
-    page
-  }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -1123,7 +1123,7 @@ return {
     "operationKind": "query",
     "name": "ArtistArtworkFilterQuery",
     "id": null,
-    "text": "query ArtistArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_3V5iLs\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_3V5iLs on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_3V5iLs\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_3V5iLs on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistArtworkFilter_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworkFilter_artist.graphql.ts
@@ -18,11 +18,6 @@ export type ArtistArtworkFilter_artist = {
     } | null;
     readonly " $refType": "ArtistArtworkFilter_artist";
 };
-export type ArtistArtworkFilter_artist$data = ArtistArtworkFilter_artist;
-export type ArtistArtworkFilter_artist$key = {
-    readonly " $data"?: ArtistArtworkFilter_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistArtworkFilter_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistAuctionResultItem_auctionResult.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultItem_auctionResult.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistAuctionResultItem_auctionResult = {
     readonly title: string | null;
     readonly dimension_text: string | null;
@@ -22,11 +21,6 @@ export type ArtistAuctionResultItem_auctionResult = {
         readonly display: string | null;
     } | null;
     readonly " $refType": "ArtistAuctionResultItem_auctionResult";
-};
-export type ArtistAuctionResultItem_auctionResult$data = ArtistAuctionResultItem_auctionResult;
-export type ArtistAuctionResultItem_auctionResult$key = {
-    readonly " $data"?: ArtistAuctionResultItem_auctionResult$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistAuctionResultItem_auctionResult">;
 };
 
 

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -38,27 +38,6 @@ query ArtistAuctionResultsQuery(
   }
 }
 
-fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
-  title
-  dimension_text: dimensionText
-  organization
-  images {
-    thumbnail {
-      url
-    }
-  }
-  description
-  date_text: dateText
-  sale_date_text: saleDateText
-  price_realized: priceRealized {
-    display
-    cents_usd: centsUSD
-  }
-  estimate {
-    display
-  }
-}
-
 fragment ArtistAuctionResults_artist_2TjZs4 on Artist {
   slug
   auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {
@@ -98,6 +77,27 @@ fragment Pagination_pageCursors on PageCursors {
   previous {
     cursor
     page
+  }
+}
+
+fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
+  title
+  dimension_text: dimensionText
+  organization
+  images {
+    thumbnail {
+      url
+    }
+  }
+  description
+  date_text: dateText
+  sale_date_text: saleDateText
+  price_realized: priceRealized {
+    display
+    cents_usd: centsUSD
+  }
+  estimate {
+    display
   }
 }
 */
@@ -493,7 +493,7 @@ return {
     "operationKind": "query",
     "name": "ArtistAuctionResultsQuery",
     "id": null,
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2TjZs4\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_2TjZs4 on Artist {\n  slug\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2TjZs4\n    id\n  }\n}\n\nfragment ArtistAuctionResults_artist_2TjZs4 on Artist {\n  slug\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_artist.graphql.ts
@@ -21,11 +21,6 @@ export type ArtistAuctionResults_artist = {
     } | null;
     readonly " $refType": "ArtistAuctionResults_artist";
 };
-export type ArtistAuctionResults_artist$data = ArtistAuctionResults_artist;
-export type ArtistAuctionResults_artist$key = {
-    readonly " $data"?: ArtistAuctionResults_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistAuctionResults_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistBio_bio.graphql.ts
+++ b/src/__generated__/ArtistBio_bio.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistBio_bio = {
     readonly biography_blurb: {
         readonly text: string | null;
     } | null;
     readonly " $refType": "ArtistBio_bio";
-};
-export type ArtistBio_bio$data = ArtistBio_bio;
-export type ArtistBio_bio$key = {
-    readonly " $data"?: ArtistBio_bio$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistBio_bio">;
 };
 
 

--- a/src/__generated__/ArtistCard_artist.graphql.ts
+++ b/src/__generated__/ArtistCard_artist.graphql.ts
@@ -15,11 +15,6 @@ export type ArtistCard_artist = {
     readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
     readonly " $refType": "ArtistCard_artist";
 };
-export type ArtistCard_artist$data = ArtistCard_artist;
-export type ArtistCard_artist$key = {
-    readonly " $data"?: ArtistCard_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistCard_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/ArtistCollectionEntity_collection.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistCollectionEntity_collection = {
     readonly headerImage: string | null;
     readonly slug: string;
@@ -23,11 +22,6 @@ export type ArtistCollectionEntity_collection = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtistCollectionEntity_collection";
-};
-export type ArtistCollectionEntity_collection$data = ArtistCollectionEntity_collection;
-export type ArtistCollectionEntity_collection$key = {
-    readonly " $data"?: ArtistCollectionEntity_collection$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionEntity_collection">;
 };
 
 

--- a/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
+++ b/src/__generated__/ArtistCollectionsRailQuery.graphql.ts
@@ -31,6 +31,10 @@ query ArtistCollectionsRailQuery(
   }
 }
 
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  ...ArtistCollectionEntity_collection
+}
+
 fragment ArtistCollectionEntity_collection on MarketingCollection {
   headerImage
   slug
@@ -54,10 +58,6 @@ fragment ArtistCollectionEntity_collection on MarketingCollection {
     }
     id
   }
-}
-
-fragment ArtistCollectionsRail_collections on MarketingCollection {
-  ...ArtistCollectionEntity_collection
 }
 */
 
@@ -293,7 +293,7 @@ return {
     "operationKind": "query",
     "name": "ArtistCollectionsRailQuery",
     "id": null,
-    "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    id\n  }\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n}\n",
+    "text": "query ArtistCollectionsRailQuery(\n  $isFeaturedArtistContent: Boolean\n  $size: Int\n  $artistID: String\n) {\n  collections: marketingCollections(isFeaturedArtistContent: $isFeaturedArtistContent, size: $size, artistID: $artistID) {\n    ...ArtistCollectionsRail_collections\n    id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistCollectionsRail_collections.graphql.ts
+++ b/src/__generated__/ArtistCollectionsRail_collections.graphql.ts
@@ -6,11 +6,6 @@ export type ArtistCollectionsRail_collections = ReadonlyArray<{
     readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionEntity_collection">;
     readonly " $refType": "ArtistCollectionsRail_collections";
 }>;
-export type ArtistCollectionsRail_collections$data = ArtistCollectionsRail_collections;
-export type ArtistCollectionsRail_collections$key = ReadonlyArray<{
-    readonly " $data"?: ArtistCollectionsRail_collections$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_collections">;
-}>;
 
 
 

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -24,11 +24,6 @@ export type ArtistHeader_artist = {
     readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
     readonly " $refType": "ArtistHeader_artist";
 };
-export type ArtistHeader_artist$data = ArtistHeader_artist;
-export type ArtistHeader_artist$key = {
-    readonly " $data"?: ArtistHeader_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistHeader_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistInfoQuery.graphql.ts
+++ b/src/__generated__/ArtistInfoQuery.graphql.ts
@@ -27,12 +27,6 @@ query ArtistInfoQuery(
   }
 }
 
-fragment ArtistBio_bio on Artist {
-  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
-    text
-  }
-}
-
 fragment ArtistInfo_artist on Artist {
   internalID
   slug
@@ -79,6 +73,36 @@ fragment ArtistInfo_artist on Artist {
   }
 }
 
+fragment SelectedExhibitions_exhibitions on Show {
+  partner {
+    __typename
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+  }
+  name
+  start_at: startAt(format: "YYYY")
+  cover_image: coverImage {
+    cropped(width: 800, height: 600) {
+      url
+    }
+  }
+  city
+}
+
+fragment ArtistBio_bio on Artist {
+  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
+    text
+  }
+}
+
 fragment ArtistMarketInsights_artist on Artist {
   collections
   highlights {
@@ -117,30 +141,6 @@ fragment FollowArtistButton_artist on Artist {
   counts {
     follows
   }
-}
-
-fragment SelectedExhibitions_exhibitions on Show {
-  partner {
-    __typename
-    ... on ExternalPartner {
-      name
-      id
-    }
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-  }
-  name
-  start_at: startAt(format: "YYYY")
-  cover_image: coverImage {
-    cropped(width: 800, height: 600) {
-      url
-    }
-  }
-  city
 }
 */
 
@@ -642,7 +642,7 @@ return {
     "operationKind": "query",
     "name": "ArtistInfoQuery",
     "id": null,
-    "text": "query ArtistInfoQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n",
+    "text": "query ArtistInfoQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistInfo_artist.graphql.ts
+++ b/src/__generated__/ArtistInfo_artist.graphql.ts
@@ -42,11 +42,6 @@ export type ArtistInfo_artist = {
     readonly " $fragmentRefs": FragmentRefs<"ArtistBio_bio" | "ArtistMarketInsights_artist" | "FollowArtistButton_artist">;
     readonly " $refType": "ArtistInfo_artist";
 };
-export type ArtistInfo_artist$data = ArtistInfo_artist;
-export type ArtistInfo_artist$key = {
-    readonly " $data"?: ArtistInfo_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistInfo_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistMarketInsights_artist.graphql.ts
+++ b/src/__generated__/ArtistMarketInsights_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistMarketInsights_artist = {
     readonly collections: ReadonlyArray<string | null> | null;
     readonly highlights: {
@@ -27,11 +26,6 @@ export type ArtistMarketInsights_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtistMarketInsights_artist";
-};
-export type ArtistMarketInsights_artist$data = ArtistMarketInsights_artist;
-export type ArtistMarketInsights_artist$key = {
-    readonly " $data"?: ArtistMarketInsights_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistMarketInsights_artist">;
 };
 
 

--- a/src/__generated__/ArtistMeta_artist.graphql.ts
+++ b/src/__generated__/ArtistMeta_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistMeta_artist = {
     readonly slug: string;
     readonly name: string | null;
@@ -70,11 +69,6 @@ export type ArtistMeta_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtistMeta_artist";
-};
-export type ArtistMeta_artist$data = ArtistMeta_artist;
-export type ArtistMeta_artist$key = {
-    readonly " $data"?: ArtistMeta_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistMeta_artist">;
 };
 
 

--- a/src/__generated__/ArtistRecommendationsPaginationQuery.graphql.ts
+++ b/src/__generated__/ArtistRecommendationsPaginationQuery.graphql.ts
@@ -52,6 +52,66 @@ fragment ArtistRecommendations_artist_1G22uz on Artist {
   }
 }
 
+fragment RecommendedArtist_artist on Artist {
+  slug
+  internalID
+  name
+  formatted_nationality_and_birthday: formattedNationalityAndBirthday
+  href
+  image {
+    cropped(width: 100, height: 100) {
+      url
+    }
+  }
+  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
+    edges {
+      node {
+        id
+        image {
+          aspect_ratio: aspectRatio
+        }
+        ...FillwidthItem_artwork
+      }
+    }
+  }
+  ...FollowArtistButton_artist
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -60,34 +120,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -128,64 +160,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
+  partner(shallow: true) {
+    type
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment RecommendedArtist_artist on Artist {
-  slug
-  internalID
-  name
-  formatted_nationality_and_birthday: formattedNationalityAndBirthday
-  href
-  image {
-    cropped(width: 100, height: 100) {
-      url
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-  }
-  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
-    edges {
-      node {
-        id
-        image {
-          aspect_ratio: aspectRatio
-        }
-        ...FillwidthItem_artwork
-      }
+    opening_bid: openingBid {
+      display
     }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-  ...FollowArtistButton_artist
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -812,7 +812,7 @@ return {
     "operationKind": "query",
     "name": "ArtistRecommendationsPaginationQuery",
     "id": null,
-    "text": "query ArtistRecommendationsPaginationQuery(\n  $count: Int!\n  $cursor: String\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist_1G22uz\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist_1G22uz on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: $count, after: $cursor, minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistRecommendationsPaginationQuery(\n  $count: Int!\n  $cursor: String\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist_1G22uz\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist_1G22uz on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: $count, after: $cursor, minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistRecommendationsRendererQuery.graphql.ts
+++ b/src/__generated__/ArtistRecommendationsRendererQuery.graphql.ts
@@ -48,6 +48,66 @@ fragment ArtistRecommendations_artist on Artist {
   }
 }
 
+fragment RecommendedArtist_artist on Artist {
+  slug
+  internalID
+  name
+  formatted_nationality_and_birthday: formattedNationalityAndBirthday
+  href
+  image {
+    cropped(width: 100, height: 100) {
+      url
+    }
+  }
+  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
+    edges {
+      node {
+        id
+        image {
+          aspect_ratio: aspectRatio
+        }
+        ...FillwidthItem_artwork
+      }
+    }
+  }
+  ...FollowArtistButton_artist
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -56,34 +116,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -124,64 +156,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
+  partner(shallow: true) {
+    type
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment RecommendedArtist_artist on Artist {
-  slug
-  internalID
-  name
-  formatted_nationality_and_birthday: formattedNationalityAndBirthday
-  href
-  image {
-    cropped(width: 100, height: 100) {
-      url
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-  }
-  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
-    edges {
-      node {
-        id
-        image {
-          aspect_ratio: aspectRatio
-        }
-        ...FillwidthItem_artwork
-      }
+    opening_bid: openingBid {
+      display
     }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-  ...FollowArtistButton_artist
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -785,7 +785,7 @@ return {
     "operationKind": "query",
     "name": "ArtistRecommendationsRendererQuery",
     "id": null,
-    "text": "query ArtistRecommendationsRendererQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: 3, after: \"\", minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistRecommendationsRendererQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistRecommendations_artist\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: 3, after: \"\", minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRecommendations_Test_Query.graphql.ts
@@ -137,6 +137,66 @@ fragment ArtistRecommendations_artist on Artist {
   }
 }
 
+fragment RecommendedArtist_artist on Artist {
+  slug
+  internalID
+  name
+  formatted_nationality_and_birthday: formattedNationalityAndBirthday
+  href
+  image {
+    cropped(width: 100, height: 100) {
+      url
+    }
+  }
+  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
+    edges {
+      node {
+        id
+        image {
+          aspect_ratio: aspectRatio
+        }
+        ...FillwidthItem_artwork
+      }
+    }
+  }
+  ...FollowArtistButton_artist
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -145,34 +205,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -213,64 +245,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
+  partner(shallow: true) {
+    type
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment RecommendedArtist_artist on Artist {
-  slug
-  internalID
-  name
-  formatted_nationality_and_birthday: formattedNationalityAndBirthday
-  href
-  image {
-    cropped(width: 100, height: 100) {
-      url
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-  }
-  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {
-    edges {
-      node {
-        id
-        image {
-          aspect_ratio: aspectRatio
-        }
-        ...FillwidthItem_artwork
-      }
+    opening_bid: openingBid {
+      display
     }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-  ...FollowArtistButton_artist
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -866,7 +866,7 @@ return {
     "operationKind": "query",
     "name": "ArtistRecommendations_Test_Query",
     "id": null,
-    "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: 3, after: \"\", minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistRecommendations_Test_Query {\n  artist(id: \"andy-warhol\") {\n    ...ArtistRecommendations_artist\n    id\n  }\n}\n\nfragment ArtistRecommendations_artist on Artist {\n  slug\n  name\n  related {\n    artistsConnection(first: 3, after: \"\", minForsaleArtworks: 7) {\n      edges {\n        node {\n          id\n          ...RecommendedArtist_artist\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment RecommendedArtist_artist on Artist {\n  slug\n  internalID\n  name\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  artworks_connection: artworksConnection(first: 20, sort: PUBLISHED_AT_DESC, filter: IS_FOR_SALE) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistRecommendations_artist.graphql.ts
+++ b/src/__generated__/ArtistRecommendations_artist.graphql.ts
@@ -17,11 +17,6 @@ export type ArtistRecommendations_artist = {
     } | null;
     readonly " $refType": "ArtistRecommendations_artist";
 };
-export type ArtistRecommendations_artist$data = ArtistRecommendations_artist;
-export type ArtistRecommendations_artist$key = {
-    readonly " $data"?: ArtistRecommendations_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistRecommendations_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistRow_artist.graphql.ts
+++ b/src/__generated__/ArtistRow_artist.graphql.ts
@@ -11,11 +11,6 @@ export type ArtistRow_artist = {
     readonly " $fragmentRefs": FragmentRefs<"Follow_artist">;
     readonly " $refType": "ArtistRow_artist";
 };
-export type ArtistRow_artist$data = ArtistRow_artist;
-export type ArtistRow_artist$key = {
-    readonly " $data"?: ArtistRow_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistRow_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistSearchResults_viewer.graphql.ts
+++ b/src/__generated__/ArtistSearchResults_viewer.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistSearchResults_viewer = {
     readonly searchConnection: {
         readonly edges: ReadonlyArray<{
@@ -15,11 +14,6 @@ export type ArtistSearchResults_viewer = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtistSearchResults_viewer";
-};
-export type ArtistSearchResults_viewer$data = ArtistSearchResults_viewer;
-export type ArtistSearchResults_viewer$key = {
-    readonly " $data"?: ArtistSearchResults_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistSearchResults_viewer">;
 };
 
 

--- a/src/__generated__/ArtistSeriesEntity_member.graphql.ts
+++ b/src/__generated__/ArtistSeriesEntity_member.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistSeriesEntity_member = {
     readonly slug: string;
     readonly headerImage: string | null;
@@ -22,11 +21,6 @@ export type ArtistSeriesEntity_member = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtistSeriesEntity_member";
-};
-export type ArtistSeriesEntity_member$data = ArtistSeriesEntity_member;
-export type ArtistSeriesEntity_member$key = {
-    readonly " $data"?: ArtistSeriesEntity_member$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesEntity_member">;
 };
 
 

--- a/src/__generated__/ArtistSeriesRail_collectionGroup.graphql.ts
+++ b/src/__generated__/ArtistSeriesRail_collectionGroup.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 export type ArtistSeriesRail_collectionGroup = {
     readonly groupType: MarketingGroupTypes;
     readonly name: string;
@@ -10,11 +10,6 @@ export type ArtistSeriesRail_collectionGroup = {
         readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesEntity_member">;
     }>;
     readonly " $refType": "ArtistSeriesRail_collectionGroup";
-};
-export type ArtistSeriesRail_collectionGroup$data = ArtistSeriesRail_collectionGroup;
-export type ArtistSeriesRail_collectionGroup$key = {
-    readonly " $data"?: ArtistSeriesRail_collectionGroup$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesRail_collectionGroup">;
 };
 
 

--- a/src/__generated__/ArtistShows_artist.graphql.ts
+++ b/src/__generated__/ArtistShows_artist.graphql.ts
@@ -31,11 +31,6 @@ export type ArtistShows_artist = {
     } | null;
     readonly " $refType": "ArtistShows_artist";
 };
-export type ArtistShows_artist$data = ArtistShows_artist;
-export type ArtistShows_artist$key = {
-    readonly " $data"?: ArtistShows_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistShows_artist">;
-};
 
 
 

--- a/src/__generated__/ArtistToolTip_artist.graphql.ts
+++ b/src/__generated__/ArtistToolTip_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtistToolTip_artist = {
     readonly name: string | null;
     readonly slug: string;
@@ -22,11 +21,6 @@ export type ArtistToolTip_artist = {
         readonly name: string | null;
     } | null> | null;
     readonly " $refType": "ArtistToolTip_artist";
-};
-export type ArtistToolTip_artist$data = ArtistToolTip_artist;
-export type ArtistToolTip_artist$key = {
-    readonly " $data"?: ArtistToolTip_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistToolTip_artist">;
 };
 
 

--- a/src/__generated__/ArtistsQuery.graphql.ts
+++ b/src/__generated__/ArtistsQuery.graphql.ts
@@ -35,15 +35,6 @@ query ArtistsQuery(
   }
 }
 
-fragment ArtistRow_artist on Artist {
-  name
-  href
-  ...Follow_artist
-  artworks: artworksConnection(first: 6) {
-    ...Fillwidth_artworks
-  }
-}
-
 fragment Artists_gene_18MJUj on Gene {
   id
   artists: artistsConnection(first: $count, after: $cursor) {
@@ -70,6 +61,73 @@ fragment Artists_gene_18MJUj on Gene {
   }
 }
 
+fragment ArtistRow_artist on Artist {
+  name
+  href
+  ...Follow_artist
+  artworks: artworksConnection(first: 6) {
+    ...Fillwidth_artworks
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
+fragment Follow_artist on Artist {
+  id
+  internalID
+  is_followed: isFollowed
+}
+
+fragment Fillwidth_artworks on ArtworkConnection {
+  edges {
+    node {
+      id
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...FillwidthItem_artwork
+    }
+  }
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -78,34 +136,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -146,61 +176,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
-  }
-}
-
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Fillwidth_artworks on ArtworkConnection {
-  edges {
-    node {
-      id
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...FillwidthItem_artwork
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-  }
-}
-
-fragment Follow_artist on Artist {
-  id
-  internalID
-  is_followed: isFollowed
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
 }
 */
@@ -837,7 +837,7 @@ return {
     "operationKind": "query",
     "name": "ArtistsQuery",
     "id": null,
-    "text": "query ArtistsQuery(\n  $geneNodeID: ID!\n  $count: Int!\n  $cursor: String\n  $aggregations: [ArtworkAggregation]\n) {\n  node(id: $geneNodeID) {\n    __typename\n    ...Artists_gene_18MJUj\n    id\n  }\n}\n\nfragment ArtistRow_artist on Artist {\n  name\n  href\n  ...Follow_artist\n  artworks: artworksConnection(first: 6) {\n    ...Fillwidth_artworks\n  }\n}\n\nfragment Artists_gene_18MJUj on Gene {\n  id\n  artists: artistsConnection(first: $count, after: $cursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ArtistRow_artist\n        __typename\n      }\n      cursor\n    }\n  }\n  filter_aggregations: filterArtworksConnection(aggregations: $aggregations, size: 0, includeMediumFilterInAggregation: true) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      ...Dropdown_aggregation\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment Follow_artist on Artist {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query ArtistsQuery(\n  $geneNodeID: ID!\n  $count: Int!\n  $cursor: String\n  $aggregations: [ArtworkAggregation]\n) {\n  node(id: $geneNodeID) {\n    __typename\n    ...Artists_gene_18MJUj\n    id\n  }\n}\n\nfragment Artists_gene_18MJUj on Gene {\n  id\n  artists: artistsConnection(first: $count, after: $cursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ArtistRow_artist\n        __typename\n      }\n      cursor\n    }\n  }\n  filter_aggregations: filterArtworksConnection(aggregations: $aggregations, size: 0, includeMediumFilterInAggregation: true) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      ...Dropdown_aggregation\n    }\n    id\n  }\n}\n\nfragment ArtistRow_artist on Artist {\n  name\n  href\n  ...Follow_artist\n  artworks: artworksConnection(first: 6) {\n    ...Fillwidth_artworks\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment Follow_artist on Artist {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Artists_gene.graphql.ts
+++ b/src/__generated__/Artists_gene.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Artists_gene = {
     readonly id: string;
     readonly artists: {
@@ -24,11 +24,6 @@ export type Artists_gene = {
         readonly " $fragmentRefs": FragmentRefs<"TotalCount_filter_artworks">;
     } | null;
     readonly " $refType": "Artists_gene";
-};
-export type Artists_gene$data = Artists_gene;
-export type Artists_gene$key = {
-    readonly " $data"?: Artists_gene$data;
-    readonly " $fragmentRefs": FragmentRefs<"Artists_gene">;
 };
 
 

--- a/src/__generated__/ArtworkActionsStoryQuery.graphql.ts
+++ b/src/__generated__/ArtworkActionsStoryQuery.graphql.ts
@@ -56,6 +56,14 @@ fragment ArtworkActions_artwork on Artwork {
   }
 }
 
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment ArtworkSharePanel_artwork on Artwork {
   href
   images {
@@ -64,14 +72,6 @@ fragment ArtworkSharePanel_artwork on Artwork {
   artworkMeta: meta {
     share
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -349,7 +349,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkActionsStoryQuery",
     "id": null,
-    "text": "query ArtworkActionsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkActions_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkActionsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkActions_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkActions_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkActions_Test_Query.graphql.ts
@@ -102,6 +102,14 @@ fragment ArtworkActions_artwork on Artwork {
   }
 }
 
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment ArtworkSharePanel_artwork on Artwork {
   href
   images {
@@ -110,14 +118,6 @@ fragment ArtworkSharePanel_artwork on Artwork {
   artworkMeta: meta {
     share
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -403,7 +403,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkActions_Test_Query",
     "id": null,
-    "text": "query ArtworkActions_Test_Query(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkActions_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkActions_Test_Query(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkActions_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkActions_artwork.graphql.ts
+++ b/src/__generated__/ArtworkActions_artwork.graphql.ts
@@ -31,11 +31,6 @@ export type ArtworkActions_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Save_artwork" | "ArtworkSharePanel_artwork">;
     readonly " $refType": "ArtworkActions_artwork";
 };
-export type ArtworkActions_artwork$data = ArtworkActions_artwork;
-export type ArtworkActions_artwork$key = {
-    readonly " $data"?: ArtworkActions_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkActions_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkApp_artwork.graphql.ts
+++ b/src/__generated__/ArtworkApp_artwork.graphql.ts
@@ -23,11 +23,6 @@ export type ArtworkApp_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkRelatedArtists_artwork" | "ArtworkMeta_artwork" | "ArtworkBanner_artwork" | "ArtworkSidebar_artwork" | "ArtworkDetails_artwork" | "ArtworkImageBrowser_artwork" | "OtherWorks_artwork" | "PricingContext_artwork">;
     readonly " $refType": "ArtworkApp_artwork";
 };
-export type ArtworkApp_artwork$data = ArtworkApp_artwork;
-export type ArtworkApp_artwork$key = {
-    readonly " $data"?: ArtworkApp_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkApp_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkBanner_artwork.graphql.ts
+++ b/src/__generated__/ArtworkBanner_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkBanner_artwork = {
     readonly partner: {
         readonly name: string | null;
@@ -47,11 +46,6 @@ export type ArtworkBanner_artwork = {
         readonly __typename: "%other";
     }) | null;
     readonly " $refType": "ArtworkBanner_artwork";
-};
-export type ArtworkBanner_artwork$data = ArtworkBanner_artwork;
-export type ArtworkBanner_artwork$key = {
-    readonly " $data"?: ArtworkBanner_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkBanner_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql.ts
+++ b/src/__generated__/ArtworkDetailsAboutTheWorkFromArtsy_artwork.graphql.ts
@@ -1,15 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkDetailsAboutTheWorkFromArtsy_artwork = {
     readonly description: string | null;
     readonly " $refType": "ArtworkDetailsAboutTheWorkFromArtsy_artwork";
-};
-export type ArtworkDetailsAboutTheWorkFromArtsy_artwork$data = ArtworkDetailsAboutTheWorkFromArtsy_artwork;
-export type ArtworkDetailsAboutTheWorkFromArtsy_artwork$key = {
-    readonly " $data"?: ArtworkDetailsAboutTheWorkFromArtsy_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkDetailsAboutTheWorkFromArtsy_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkDetailsAboutTheWorkFromPartner_artwork.graphql.ts
+++ b/src/__generated__/ArtworkDetailsAboutTheWorkFromPartner_artwork.graphql.ts
@@ -29,11 +29,6 @@ export type ArtworkDetailsAboutTheWorkFromPartner_artwork = {
     } | null;
     readonly " $refType": "ArtworkDetailsAboutTheWorkFromPartner_artwork";
 };
-export type ArtworkDetailsAboutTheWorkFromPartner_artwork$data = ArtworkDetailsAboutTheWorkFromPartner_artwork;
-export type ArtworkDetailsAboutTheWorkFromPartner_artwork$key = {
-    readonly " $data"?: ArtworkDetailsAboutTheWorkFromPartner_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkDetailsAboutTheWorkFromPartner_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkDetailsAdditionalInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkDetailsAdditionalInfo_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkDetailsAdditionalInfo_artwork = {
     readonly series: string | null;
     readonly publisher: string | null;
@@ -24,11 +23,6 @@ export type ArtworkDetailsAdditionalInfo_artwork = {
         readonly details: string | null;
     } | null;
     readonly " $refType": "ArtworkDetailsAdditionalInfo_artwork";
-};
-export type ArtworkDetailsAdditionalInfo_artwork$data = ArtworkDetailsAdditionalInfo_artwork;
-export type ArtworkDetailsAdditionalInfo_artwork$key = {
-    readonly " $data"?: ArtworkDetailsAdditionalInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkDetailsAdditionalInfo_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkDetailsArticles_artwork.graphql.ts
+++ b/src/__generated__/ArtworkDetailsArticles_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkDetailsArticles_artwork = {
     readonly articles: ReadonlyArray<{
         readonly author: {
@@ -17,11 +16,6 @@ export type ArtworkDetailsArticles_artwork = {
         readonly thumbnail_title: string | null;
     } | null> | null;
     readonly " $refType": "ArtworkDetailsArticles_artwork";
-};
-export type ArtworkDetailsArticles_artwork$data = ArtworkDetailsArticles_artwork;
-export type ArtworkDetailsArticles_artwork$key = {
-    readonly " $data"?: ArtworkDetailsArticles_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkDetailsArticles_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkDetailsQuery.graphql.ts
+++ b/src/__generated__/ArtworkDetailsQuery.graphql.ts
@@ -27,6 +27,20 @@ query ArtworkDetailsQuery(
   }
 }
 
+fragment ArtworkDetails_artwork on Artwork {
+  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
+  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
+  ...ArtworkDetailsAdditionalInfo_artwork
+  ...ArtworkDetailsArticles_artwork
+  articles(size: 10) {
+    slug
+    id
+  }
+  literature(format: HTML)
+  exhibition_history: exhibitionHistory(format: HTML)
+  provenance(format: HTML)
+}
+
 fragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {
   description(format: HTML)
 }
@@ -101,20 +115,6 @@ fragment ArtworkDetailsArticles_artwork on Artwork {
     thumbnail_title: thumbnailTitle
     id
   }
-}
-
-fragment ArtworkDetails_artwork on Artwork {
-  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
-  ...ArtworkDetailsAdditionalInfo_artwork
-  ...ArtworkDetailsArticles_artwork
-  articles(size: 10) {
-    slug
-    id
-  }
-  literature(format: HTML)
-  exhibition_history: exhibitionHistory(format: HTML)
-  provenance(format: HTML)
 }
 
 fragment FollowProfileButton_profile on Profile {
@@ -566,7 +566,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkDetailsQuery",
     "id": null,
-    "text": "query ArtworkDetailsQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
+    "text": "query ArtworkDetailsQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkDetailsStoryQuery.graphql.ts
+++ b/src/__generated__/ArtworkDetailsStoryQuery.graphql.ts
@@ -23,6 +23,20 @@ query ArtworkDetailsStoryQuery {
   }
 }
 
+fragment ArtworkDetails_artwork on Artwork {
+  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
+  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
+  ...ArtworkDetailsAdditionalInfo_artwork
+  ...ArtworkDetailsArticles_artwork
+  articles(size: 10) {
+    slug
+    id
+  }
+  literature(format: HTML)
+  exhibition_history: exhibitionHistory(format: HTML)
+  provenance(format: HTML)
+}
+
 fragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {
   description(format: HTML)
 }
@@ -97,20 +111,6 @@ fragment ArtworkDetailsArticles_artwork on Artwork {
     thumbnail_title: thumbnailTitle
     id
   }
-}
-
-fragment ArtworkDetails_artwork on Artwork {
-  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
-  ...ArtworkDetailsAdditionalInfo_artwork
-  ...ArtworkDetailsArticles_artwork
-  articles(size: 10) {
-    slug
-    id
-  }
-  literature(format: HTML)
-  exhibition_history: exhibitionHistory(format: HTML)
-  provenance(format: HTML)
 }
 
 fragment FollowProfileButton_profile on Profile {
@@ -554,7 +554,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkDetailsStoryQuery",
     "id": null,
-    "text": "query ArtworkDetailsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
+    "text": "query ArtworkDetailsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkDetails_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkDetails_Test_Query.graphql.ts
@@ -98,6 +98,20 @@ query ArtworkDetails_Test_Query {
   }
 }
 
+fragment ArtworkDetails_artwork on Artwork {
+  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
+  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
+  ...ArtworkDetailsAdditionalInfo_artwork
+  ...ArtworkDetailsArticles_artwork
+  articles(size: 10) {
+    slug
+    id
+  }
+  literature(format: HTML)
+  exhibition_history: exhibitionHistory(format: HTML)
+  provenance(format: HTML)
+}
+
 fragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {
   description(format: HTML)
 }
@@ -172,20 +186,6 @@ fragment ArtworkDetailsArticles_artwork on Artwork {
     thumbnail_title: thumbnailTitle
     id
   }
-}
-
-fragment ArtworkDetails_artwork on Artwork {
-  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
-  ...ArtworkDetailsAdditionalInfo_artwork
-  ...ArtworkDetailsArticles_artwork
-  articles(size: 10) {
-    slug
-    id
-  }
-  literature(format: HTML)
-  exhibition_history: exhibitionHistory(format: HTML)
-  provenance(format: HTML)
 }
 
 fragment FollowProfileButton_profile on Profile {
@@ -629,7 +629,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkDetails_Test_Query",
     "id": null,
-    "text": "query ArtworkDetails_Test_Query {\n  artwork(id: \"richard-prince-untitled-fashion\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
+    "text": "query ArtworkDetails_Test_Query {\n  artwork(id: \"richard-prince-untitled-fashion\") {\n    ...ArtworkDetails_artwork\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkDetails_artwork.graphql.ts
+++ b/src/__generated__/ArtworkDetails_artwork.graphql.ts
@@ -12,11 +12,6 @@ export type ArtworkDetails_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkDetailsAboutTheWorkFromArtsy_artwork" | "ArtworkDetailsAboutTheWorkFromPartner_artwork" | "ArtworkDetailsAdditionalInfo_artwork" | "ArtworkDetailsArticles_artwork">;
     readonly " $refType": "ArtworkDetails_artwork";
 };
-export type ArtworkDetails_artwork$data = ArtworkDetails_artwork;
-export type ArtworkDetails_artwork$key = {
-    readonly " $data"?: ArtworkDetails_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkDetails_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkFilterArtworkGrid2_filtered_artworks.graphql.ts
+++ b/src/__generated__/ArtworkFilterArtworkGrid2_filtered_artworks.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type ArtworkFilterArtworkGrid2_filtered_artworks = {
     readonly id: string;
     readonly aggregations: ReadonlyArray<{
@@ -27,11 +27,6 @@ export type ArtworkFilterArtworkGrid2_filtered_artworks = {
     } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtworkGrid_artworks">;
     readonly " $refType": "ArtworkFilterArtworkGrid2_filtered_artworks";
-};
-export type ArtworkFilterArtworkGrid2_filtered_artworks$data = ArtworkFilterArtworkGrid2_filtered_artworks;
-export type ArtworkFilterArtworkGrid2_filtered_artworks$key = {
-    readonly " $data"?: ArtworkFilterArtworkGrid2_filtered_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkFilterArtworkGrid2_filtered_artworks">;
 };
 
 

--- a/src/__generated__/ArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/ArtworkFilterQuery.graphql.ts
@@ -159,6 +159,13 @@ query ArtworkFilterQuery(
   }
 }
 
+fragment ArtworkFilter_viewer_2c4z0P on Viewer {
+  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {
+    id
+    ...ArtworkFilterArtworkGrid2_filtered_artworks
+  }
+}
+
 fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
   id
   aggregations {
@@ -184,10 +191,25 @@ fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection
   ...ArtworkGrid_artworks
 }
 
-fragment ArtworkFilter_viewer_2c4z0P on Viewer {
-  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {
-    id
-    ...ArtworkFilterArtworkGrid2_filtered_artworks
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
   }
 }
 
@@ -209,6 +231,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -217,34 +268,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -285,55 +308,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  first {
-    cursor
-    page
-    isCurrent
+  partner(shallow: true) {
+    type
+    id
   }
-  last {
-    cursor
-    page
-    isCurrent
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-  previous {
-    cursor
-    page
-  }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -1122,7 +1122,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkFilterQuery",
     "id": null,
-    "text": "query ArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $artistID: String\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $keyword: String\n  $width: String\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2c4z0P\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2c4z0P on Viewer {\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $artistID: String\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $keyword: String\n  $width: String\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2c4z0P\n  }\n}\n\nfragment ArtworkFilter_viewer_2c4z0P on Viewer {\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkFilter_viewer.graphql.ts
+++ b/src/__generated__/ArtworkFilter_viewer.graphql.ts
@@ -9,11 +9,6 @@ export type ArtworkFilter_viewer = {
     } | null;
     readonly " $refType": "ArtworkFilter_viewer";
 };
-export type ArtworkFilter_viewer$data = ArtworkFilter_viewer;
-export type ArtworkFilter_viewer$key = {
-    readonly " $data"?: ArtworkFilter_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkFilter_viewer">;
-};
 
 
 

--- a/src/__generated__/ArtworkGridExampleQuery.graphql.ts
+++ b/src/__generated__/ArtworkGridExampleQuery.graphql.ts
@@ -49,6 +49,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -57,34 +86,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -125,33 +126,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -587,7 +587,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkGridExampleQuery",
     "id": null,
-    "text": "query ArtworkGridExampleQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 10) {\n      ...ArtworkGrid_artworks\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkGridExampleQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 10) {\n      ...ArtworkGrid_artworks\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkGridQuery.graphql.ts
+++ b/src/__generated__/ArtworkGridQuery.graphql.ts
@@ -49,6 +49,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -57,34 +86,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -125,33 +126,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -587,7 +587,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkGridQuery",
     "id": null,
-    "text": "query ArtworkGridQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 10) {\n      ...ArtworkGrid_artworks\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkGridQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 10) {\n      ...ArtworkGrid_artworks\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkGrid_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkGrid_Test_Query.graphql.ts
@@ -113,6 +113,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -121,34 +150,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -189,33 +190,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -631,7 +631,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkGrid_Test_Query",
     "id": null,
-    "text": "query ArtworkGrid_Test_Query {\n  artist(id: \"pablo-picasso\") {\n    ...ArtworkGrid_artist\n    id\n  }\n}\n\nfragment ArtworkGrid_artist on Artist {\n  artworks_connection: artworksConnection(first: 4) {\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkGrid_Test_Query {\n  artist(id: \"pablo-picasso\") {\n    ...ArtworkGrid_artist\n    id\n  }\n}\n\nfragment ArtworkGrid_artist on Artist {\n  artworks_connection: artworksConnection(first: 4) {\n    ...ArtworkGrid_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkGrid_artist.graphql.ts
+++ b/src/__generated__/ArtworkGrid_artist.graphql.ts
@@ -8,11 +8,6 @@ export type ArtworkGrid_artist = {
     } | null;
     readonly " $refType": "ArtworkGrid_artist";
 };
-export type ArtworkGrid_artist$data = ArtworkGrid_artist;
-export type ArtworkGrid_artist$key = {
-    readonly " $data"?: ArtworkGrid_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkGrid_artist">;
-};
 
 
 

--- a/src/__generated__/ArtworkGrid_artworks.graphql.ts
+++ b/src/__generated__/ArtworkGrid_artworks.graphql.ts
@@ -16,11 +16,6 @@ export type ArtworkGrid_artworks = {
     } | null> | null;
     readonly " $refType": "ArtworkGrid_artworks";
 };
-export type ArtworkGrid_artworks$data = ArtworkGrid_artworks;
-export type ArtworkGrid_artworks$key = {
-    readonly " $data"?: ArtworkGrid_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkGrid_artworks">;
-};
 
 
 

--- a/src/__generated__/ArtworkImageBrowserQuery.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowserQuery.graphql.ts
@@ -27,6 +27,37 @@ query ArtworkImageBrowserQuery(
   }
 }
 
+fragment ArtworkImageBrowser_artwork on Artwork {
+  image_alt: formattedMetadata
+  ...ArtworkActions_artwork
+  image {
+    internalID
+  }
+  images {
+    internalID
+    uri: url(version: ["large"])
+    placeholder: resized(width: 30, height: 30, version: "small") {
+      url
+    }
+    aspectRatio
+    is_zoomable: isZoomable
+    is_default: isDefault
+    deepZoom {
+      Image {
+        xmlns
+        Url
+        Format
+        TileSize
+        Overlap
+        Size {
+          Width
+          Height
+        }
+      }
+    }
+  }
+}
+
 fragment ArtworkActions_artwork on Artwork {
   ...Save_artwork
   ...ArtworkSharePanel_artwork
@@ -60,35 +91,12 @@ fragment ArtworkActions_artwork on Artwork {
   }
 }
 
-fragment ArtworkImageBrowser_artwork on Artwork {
-  image_alt: formattedMetadata
-  ...ArtworkActions_artwork
-  image {
-    internalID
-  }
-  images {
-    internalID
-    uri: url(version: ["large"])
-    placeholder: resized(width: 30, height: 30, version: "small") {
-      url
-    }
-    aspectRatio
-    is_zoomable: isZoomable
-    is_default: isDefault
-    deepZoom {
-      Image {
-        xmlns
-        Url
-        Format
-        TileSize
-        Overlap
-        Size {
-          Width
-          Height
-        }
-      }
-    }
-  }
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
 }
 
 fragment ArtworkSharePanel_artwork on Artwork {
@@ -99,14 +107,6 @@ fragment ArtworkSharePanel_artwork on Artwork {
   artworkMeta: meta {
     share
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -547,7 +547,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkImageBrowserQuery",
     "id": null,
-    "text": "query ArtworkImageBrowserQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkImageBrowserQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkImageBrowser_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowser_Test_Query.graphql.ts
@@ -91,6 +91,37 @@ query ArtworkImageBrowser_Test_Query(
   }
 }
 
+fragment ArtworkImageBrowser_artwork on Artwork {
+  image_alt: formattedMetadata
+  ...ArtworkActions_artwork
+  image {
+    internalID
+  }
+  images {
+    internalID
+    uri: url(version: ["large"])
+    placeholder: resized(width: 30, height: 30, version: "small") {
+      url
+    }
+    aspectRatio
+    is_zoomable: isZoomable
+    is_default: isDefault
+    deepZoom {
+      Image {
+        xmlns
+        Url
+        Format
+        TileSize
+        Overlap
+        Size {
+          Width
+          Height
+        }
+      }
+    }
+  }
+}
+
 fragment ArtworkActions_artwork on Artwork {
   ...Save_artwork
   ...ArtworkSharePanel_artwork
@@ -124,35 +155,12 @@ fragment ArtworkActions_artwork on Artwork {
   }
 }
 
-fragment ArtworkImageBrowser_artwork on Artwork {
-  image_alt: formattedMetadata
-  ...ArtworkActions_artwork
-  image {
-    internalID
-  }
-  images {
-    internalID
-    uri: url(version: ["large"])
-    placeholder: resized(width: 30, height: 30, version: "small") {
-      url
-    }
-    aspectRatio
-    is_zoomable: isZoomable
-    is_default: isDefault
-    deepZoom {
-      Image {
-        xmlns
-        Url
-        Format
-        TileSize
-        Overlap
-        Size {
-          Width
-          Height
-        }
-      }
-    }
-  }
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
 }
 
 fragment ArtworkSharePanel_artwork on Artwork {
@@ -163,14 +171,6 @@ fragment ArtworkSharePanel_artwork on Artwork {
   artworkMeta: meta {
     share
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -611,7 +611,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkImageBrowser_Test_Query",
     "id": null,
-    "text": "query ArtworkImageBrowser_Test_Query(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtworkImageBrowser_Test_Query(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkImageBrowser_artwork.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowser_artwork.graphql.ts
@@ -33,11 +33,6 @@ export type ArtworkImageBrowser_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkActions_artwork">;
     readonly " $refType": "ArtworkImageBrowser_artwork";
 };
-export type ArtworkImageBrowser_artwork$data = ArtworkImageBrowser_artwork;
-export type ArtworkImageBrowser_artwork$key = {
-    readonly " $data"?: ArtworkImageBrowser_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkImageBrowser_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/ArtworkMeta_artwork.graphql.ts
@@ -39,11 +39,6 @@ export type ArtworkMeta_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"SeoDataForArtwork_artwork">;
     readonly " $refType": "ArtworkMeta_artwork";
 };
-export type ArtworkMeta_artwork$data = ArtworkMeta_artwork;
-export type ArtworkMeta_artwork$key = {
-    readonly " $data"?: ArtworkMeta_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkMeta_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkMetadataQuery.graphql.ts
+++ b/src/__generated__/ArtworkMetadataQuery.graphql.ts
@@ -27,32 +27,10 @@ query ArtworkMetadataQuery(
   }
 }
 
-fragment Contact_artwork on Artwork {
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
   href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
 }
 
 fragment Details_artwork on Artwork {
@@ -91,10 +69,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
+fragment Contact_artwork on Artwork {
   href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -369,7 +369,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkMetadataQuery",
     "id": null,
-    "text": "query ArtworkMetadataQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...Metadata_artwork\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
+    "text": "query ArtworkMetadataQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...Metadata_artwork\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkQuery.graphql.ts
+++ b/src/__generated__/ArtworkQuery.graphql.ts
@@ -36,32 +36,10 @@ fragment Artwork_artwork on Artwork {
   ...Metadata_artwork
 }
 
-fragment Contact_artwork on Artwork {
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
   href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
 }
 
 fragment Details_artwork on Artwork {
@@ -100,10 +78,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
+fragment Contact_artwork on Artwork {
   href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -416,7 +416,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkQuery",
     "id": null,
-    "text": "query ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...Artwork_artwork\n    id\n  }\n}\n\nfragment Artwork_artwork on Artwork {\n  slug\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  ...Metadata_artwork\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
+    "text": "query ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...Artwork_artwork\n    id\n  }\n}\n\nfragment Artwork_artwork on Artwork {\n  slug\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  ...Metadata_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkRelatedArtistsPaginationQuery.graphql.ts
+++ b/src/__generated__/ArtworkRelatedArtistsPaginationQuery.graphql.ts
@@ -31,19 +31,6 @@ query ArtworkRelatedArtistsPaginationQuery(
   }
 }
 
-fragment ArtistCard_artist on Artist {
-  name
-  slug
-  href
-  image {
-    cropped(width: 400, height: 300) {
-      url
-    }
-  }
-  formatted_nationality_and_birthday: formattedNationalityAndBirthday
-  ...FollowArtistButton_artist
-}
-
 fragment ArtworkRelatedArtists_artwork_1G22uz on Artwork {
   slug
   artist {
@@ -66,6 +53,19 @@ fragment ArtworkRelatedArtists_artwork_1G22uz on Artwork {
     }
     id
   }
+}
+
+fragment ArtistCard_artist on Artist {
+  name
+  slug
+  href
+  image {
+    cropped(width: 400, height: 300) {
+      url
+    }
+  }
+  formatted_nationality_and_birthday: formattedNationalityAndBirthday
+  ...FollowArtistButton_artist
 }
 
 fragment FollowArtistButton_artist on Artist {
@@ -403,7 +403,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkRelatedArtistsPaginationQuery",
     "id": null,
-    "text": "query ArtworkRelatedArtistsPaginationQuery(\n  $count: Int!\n  $cursor: String\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkRelatedArtists_artwork_1G22uz\n    id\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtworkRelatedArtists_artwork_1G22uz on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: $count, after: $cursor) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
+    "text": "query ArtworkRelatedArtistsPaginationQuery(\n  $count: Int!\n  $cursor: String\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkRelatedArtists_artwork_1G22uz\n    id\n  }\n}\n\nfragment ArtworkRelatedArtists_artwork_1G22uz on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: $count, after: $cursor) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkRelatedArtists_artwork.graphql.ts
+++ b/src/__generated__/ArtworkRelatedArtists_artwork.graphql.ts
@@ -21,11 +21,6 @@ export type ArtworkRelatedArtists_artwork = {
     } | null;
     readonly " $refType": "ArtworkRelatedArtists_artwork";
 };
-export type ArtworkRelatedArtists_artwork$data = ArtworkRelatedArtists_artwork;
-export type ArtworkRelatedArtists_artwork$key = {
-    readonly " $data"?: ArtworkRelatedArtists_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkRelatedArtists_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkSharePanel_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSharePanel_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSharePanel_artwork = {
     readonly href: string | null;
     readonly images: ReadonlyArray<{
@@ -11,11 +10,6 @@ export type ArtworkSharePanel_artwork = {
         readonly share: string | null;
     } | null;
     readonly " $refType": "ArtworkSharePanel_artwork";
-};
-export type ArtworkSharePanel_artwork$data = ArtworkSharePanel_artwork;
-export type ArtworkSharePanel_artwork$key = {
-    readonly " $data"?: ArtworkSharePanel_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSharePanel_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarArtistsStoryQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarArtistsStoryQuery.graphql.ts
@@ -46,16 +46,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
   ...FollowArtistPopover_artist
 }
 
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
-}
-
 fragment FollowArtistPopover_artist on Artist {
   related {
     suggestedConnection(first: 3, excludeFollowedArtists: true) {
@@ -66,6 +56,16 @@ fragment FollowArtistPopover_artist on Artist {
           ...FollowArtistPopoverRow_artist
         }
       }
+    }
+  }
+}
+
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
     }
   }
 }
@@ -308,7 +308,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarArtistsStoryQuery",
     "id": null,
-    "text": "query ArtworkSidebarArtistsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebarArtists_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query ArtworkSidebarArtistsStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebarArtists_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarArtists_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebarArtists_Test_Query.graphql.ts
@@ -80,16 +80,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
   ...FollowArtistPopover_artist
 }
 
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
-}
-
 fragment FollowArtistPopover_artist on Artist {
   related {
     suggestedConnection(first: 3, excludeFollowedArtists: true) {
@@ -100,6 +90,16 @@ fragment FollowArtistPopover_artist on Artist {
           ...FollowArtistPopoverRow_artist
         }
       }
+    }
+  }
+}
+
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
     }
   }
 }
@@ -342,7 +342,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarArtists_Test_Query",
     "id": null,
-    "text": "query ArtworkSidebarArtists_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebarArtists_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query ArtworkSidebarArtists_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebarArtists_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarArtists_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarArtists_artwork.graphql.ts
@@ -14,11 +14,6 @@ export type ArtworkSidebarArtists_artwork = {
     } | null> | null;
     readonly " $refType": "ArtworkSidebarArtists_artwork";
 };
-export type ArtworkSidebarArtists_artwork$data = ArtworkSidebarArtists_artwork;
-export type ArtworkSidebarArtists_artwork$key = {
-    readonly " $data"?: ArtworkSidebarArtists_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarArtists_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarAuctionPartnerInfo_artwork = {
     readonly partner: {
         readonly name: string | null;
@@ -14,11 +13,6 @@ export type ArtworkSidebarAuctionPartnerInfo_artwork = {
         readonly is_closed: boolean | null;
     } | null;
     readonly " $refType": "ArtworkSidebarAuctionPartnerInfo_artwork";
-};
-export type ArtworkSidebarAuctionPartnerInfo_artwork$data = ArtworkSidebarAuctionPartnerInfo_artwork;
-export type ArtworkSidebarAuctionPartnerInfo_artwork$key = {
-    readonly " $data"?: ArtworkSidebarAuctionPartnerInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarAuctionPartnerInfo_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarBidAction_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarBidAction_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarBidAction_artwork = {
     readonly myLotStanding: ReadonlyArray<{
         readonly most_recent_bid: {
@@ -30,11 +29,6 @@ export type ArtworkSidebarBidAction_artwork = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtworkSidebarBidAction_artwork";
-};
-export type ArtworkSidebarBidAction_artwork$data = ArtworkSidebarBidAction_artwork;
-export type ArtworkSidebarBidAction_artwork$key = {
-    readonly " $data"?: ArtworkSidebarBidAction_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarBidAction_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarClassification_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarClassification_artwork.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarClassification_artwork = {
     readonly attribution_class: {
         readonly short_description: string | null;
     } | null;
     readonly " $refType": "ArtworkSidebarClassification_artwork";
-};
-export type ArtworkSidebarClassification_artwork$data = ArtworkSidebarClassification_artwork;
-export type ArtworkSidebarClassification_artwork$key = {
-    readonly " $data"?: ArtworkSidebarClassification_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarClassification_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarCommercial_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarCommercial_artwork.graphql.ts
@@ -26,11 +26,6 @@ export type ArtworkSidebarCommercial_artwork = {
     } | null> | null;
     readonly " $refType": "ArtworkSidebarCommercial_artwork";
 };
-export type ArtworkSidebarCommercial_artwork$data = ArtworkSidebarCommercial_artwork;
-export type ArtworkSidebarCommercial_artwork$key = {
-    readonly " $data"?: ArtworkSidebarCommercial_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarCommercial_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkSidebarCurrentBidInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarCurrentBidInfo_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarCurrentBidInfo_artwork = {
     readonly sale: {
         readonly is_closed: boolean | null;
@@ -31,11 +30,6 @@ export type ArtworkSidebarCurrentBidInfo_artwork = {
         } | null;
     }> | null;
     readonly " $refType": "ArtworkSidebarCurrentBidInfo_artwork";
-};
-export type ArtworkSidebarCurrentBidInfo_artwork$data = ArtworkSidebarCurrentBidInfo_artwork;
-export type ArtworkSidebarCurrentBidInfo_artwork$key = {
-    readonly " $data"?: ArtworkSidebarCurrentBidInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarCurrentBidInfo_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarExtraLinks_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarExtraLinks_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarExtraLinks_artwork = {
     readonly internalID: string;
     readonly is_in_auction: boolean | null;
@@ -15,11 +14,6 @@ export type ArtworkSidebarExtraLinks_artwork = {
         readonly is_closed: boolean | null;
     } | null;
     readonly " $refType": "ArtworkSidebarExtraLinks_artwork";
-};
-export type ArtworkSidebarExtraLinks_artwork$data = ArtworkSidebarExtraLinks_artwork;
-export type ArtworkSidebarExtraLinks_artwork$key = {
-    readonly " $data"?: ArtworkSidebarExtraLinks_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarExtraLinks_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarMetadataStoryQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadataStoryQuery.graphql.ts
@@ -23,13 +23,6 @@ query ArtworkSidebarMetadataStoryQuery {
   }
 }
 
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
 fragment ArtworkSidebarMetadata_artwork on Artwork {
   is_biddable: isBiddable
   edition_sets: editionSets {
@@ -45,6 +38,12 @@ fragment ArtworkSidebarMetadata_artwork on Artwork {
   ...ArtworkSidebarClassification_artwork
 }
 
+fragment ArtworkSidebarTitleInfo_artwork on Artwork {
+  title
+  date
+  medium
+}
+
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
   dimensions {
     in
@@ -53,10 +52,11 @@ fragment ArtworkSidebarSizeInfo_piece on Sellable {
   edition_of: editionOf
 }
 
-fragment ArtworkSidebarTitleInfo_artwork on Artwork {
-  title
-  date
-  medium
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
+    id
+  }
 }
 */
 
@@ -242,7 +242,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarMetadataStoryQuery",
     "id": null,
-    "text": "query ArtworkSidebarMetadataStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n",
+    "text": "query ArtworkSidebarMetadataStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadata_Test_Query.graphql.ts
@@ -50,13 +50,6 @@ query ArtworkSidebarMetadata_Test_Query {
   }
 }
 
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
 fragment ArtworkSidebarMetadata_artwork on Artwork {
   is_biddable: isBiddable
   edition_sets: editionSets {
@@ -72,6 +65,12 @@ fragment ArtworkSidebarMetadata_artwork on Artwork {
   ...ArtworkSidebarClassification_artwork
 }
 
+fragment ArtworkSidebarTitleInfo_artwork on Artwork {
+  title
+  date
+  medium
+}
+
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
   dimensions {
     in
@@ -80,10 +79,11 @@ fragment ArtworkSidebarSizeInfo_piece on Sellable {
   edition_of: editionOf
 }
 
-fragment ArtworkSidebarTitleInfo_artwork on Artwork {
-  title
-  date
-  medium
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
+    id
+  }
 }
 */
 
@@ -269,7 +269,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarMetadata_Test_Query",
     "id": null,
-    "text": "query ArtworkSidebarMetadata_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n",
+    "text": "query ArtworkSidebarMetadata_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebarMetadata_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarMetadata_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarMetadata_artwork.graphql.ts
@@ -13,11 +13,6 @@ export type ArtworkSidebarMetadata_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarTitleInfo_artwork" | "ArtworkSidebarSizeInfo_piece" | "ArtworkSidebarClassification_artwork">;
     readonly " $refType": "ArtworkSidebarMetadata_artwork";
 };
-export type ArtworkSidebarMetadata_artwork$data = ArtworkSidebarMetadata_artwork;
-export type ArtworkSidebarMetadata_artwork$key = {
-    readonly " $data"?: ArtworkSidebarMetadata_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarMetadata_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkSidebarPartnerInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarPartnerInfo_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarPartnerInfo_artwork = {
     readonly partner: {
         readonly name: string | null;
@@ -11,11 +10,6 @@ export type ArtworkSidebarPartnerInfo_artwork = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtworkSidebarPartnerInfo_artwork";
-};
-export type ArtworkSidebarPartnerInfo_artwork$data = ArtworkSidebarPartnerInfo_artwork;
-export type ArtworkSidebarPartnerInfo_artwork$key = {
-    readonly " $data"?: ArtworkSidebarPartnerInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarPartnerInfo_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarQuery.graphql.ts
@@ -27,6 +27,26 @@ query ArtworkSidebarQuery(
   }
 }
 
+fragment ArtworkSidebar_artwork on Artwork {
+  is_in_auction: isInAuction
+  ...ArtworkSidebarArtists_artwork
+  ...ArtworkSidebarMetadata_artwork
+  ...ArtworkSidebarAuctionPartnerInfo_artwork
+  ...ArtworkSidebarCurrentBidInfo_artwork
+  ...ArtworkSidebarBidAction_artwork
+  ...ArtworkSidebarCommercial_artwork
+  ...ArtworkSidebarPartnerInfo_artwork
+  ...ArtworkSidebarExtraLinks_artwork
+  ...SecurePayment_artwork
+  ...VerifiedSeller_artwork
+  ...AuthenticityCertificate_artwork
+  sale {
+    is_closed: isClosed
+    ...AuctionTimer_sale
+    id
+  }
+}
+
 fragment ArtworkSidebarArtists_artwork on Artwork {
   cultural_maker: culturalMaker
   artists {
@@ -37,6 +57,21 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
     href
     ...FollowArtistButton_artist_2eN9lh
   }
+}
+
+fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable: isBiddable
+  edition_sets: editionSets {
+    __typename
+    id
+  }
+  sale_artwork: saleArtwork {
+    lot_label: lotLabel
+    id
+  }
+  ...ArtworkSidebarTitleInfo_artwork
+  ...ArtworkSidebarSizeInfo_piece
+  ...ArtworkSidebarClassification_artwork
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
@@ -52,76 +87,6 @@ fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
     internalID
     is_closed: isClosed
     id
-  }
-}
-
-fragment ArtworkSidebarBidAction_artwork on Artwork {
-  myLotStanding(live: true) {
-    most_recent_bid: mostRecentBid {
-      max_bid: maxBid {
-        cents
-      }
-      id
-    }
-  }
-  slug
-  internalID
-  sale {
-    slug
-    registrationStatus {
-      qualified_for_bidding: qualifiedForBidding
-      id
-    }
-    is_preview: isPreview
-    is_open: isOpen
-    is_live_open: isLiveOpen
-    is_closed: isClosed
-    is_registration_closed: isRegistrationClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    increments {
-      cents
-      display
-    }
-    id
-  }
-}
-
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
-fragment ArtworkSidebarCommercial_artwork on Artwork {
-  slug
-  internalID
-  is_for_sale: isForSale
-  is_acquireable: isAcquireable
-  is_inquireable: isInquireable
-  is_offerable: isOfferable
-  listPrice {
-    __typename
-    ... on PriceRange {
-      display
-    }
-    ... on Money {
-      display
-    }
-  }
-  priceIncludesTaxDisplay
-  sale_message: saleMessage
-  shippingInfo
-  shippingOrigin
-  edition_sets: editionSets {
-    internalID
-    id
-    is_acquireable: isAcquireable
-    is_offerable: isOfferable
-    sale_message: saleMessage
-    ...ArtworkSidebarSizeInfo_piece
   }
 }
 
@@ -159,6 +124,81 @@ fragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {
   }
 }
 
+fragment ArtworkSidebarBidAction_artwork on Artwork {
+  myLotStanding(live: true) {
+    most_recent_bid: mostRecentBid {
+      max_bid: maxBid {
+        cents
+      }
+      id
+    }
+  }
+  slug
+  internalID
+  sale {
+    slug
+    registrationStatus {
+      qualified_for_bidding: qualifiedForBidding
+      id
+    }
+    is_preview: isPreview
+    is_open: isOpen
+    is_live_open: isLiveOpen
+    is_closed: isClosed
+    is_registration_closed: isRegistrationClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    increments {
+      cents
+      display
+    }
+    id
+  }
+}
+
+fragment ArtworkSidebarCommercial_artwork on Artwork {
+  slug
+  internalID
+  is_for_sale: isForSale
+  is_acquireable: isAcquireable
+  is_inquireable: isInquireable
+  is_offerable: isOfferable
+  listPrice {
+    __typename
+    ... on PriceRange {
+      display
+    }
+    ... on Money {
+      display
+    }
+  }
+  priceIncludesTaxDisplay
+  sale_message: saleMessage
+  shippingInfo
+  shippingOrigin
+  edition_sets: editionSets {
+    internalID
+    id
+    is_acquireable: isAcquireable
+    is_offerable: isOfferable
+    sale_message: saleMessage
+    ...ArtworkSidebarSizeInfo_piece
+  }
+}
+
+fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+  partner {
+    name
+    href
+    locations {
+      city
+      id
+    }
+    id
+  }
+}
+
 fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   internalID
   is_in_auction: isInAuction
@@ -175,31 +215,28 @@ fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   }
 }
 
-fragment ArtworkSidebarMetadata_artwork on Artwork {
-  is_biddable: isBiddable
-  edition_sets: editionSets {
-    __typename
-    id
-  }
-  sale_artwork: saleArtwork {
-    lot_label: lotLabel
-    id
-  }
-  ...ArtworkSidebarTitleInfo_artwork
-  ...ArtworkSidebarSizeInfo_piece
-  ...ArtworkSidebarClassification_artwork
+fragment SecurePayment_artwork on Artwork {
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
 }
 
-fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+fragment VerifiedSeller_artwork on Artwork {
+  is_biddable: isBiddable
   partner {
+    isVerifiedSeller
     name
-    href
-    locations {
-      city
-      id
-    }
     id
   }
+}
+
+fragment AuthenticityCertificate_artwork on Artwork {
+  hasCertificateOfAuthenticity
+  is_biddable: isBiddable
+}
+
+fragment AuctionTimer_sale on Sale {
+  live_start_at: liveStartAt
+  end_at: endAt
 }
 
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
@@ -216,34 +253,11 @@ fragment ArtworkSidebarTitleInfo_artwork on Artwork {
   medium
 }
 
-fragment ArtworkSidebar_artwork on Artwork {
-  is_in_auction: isInAuction
-  ...ArtworkSidebarArtists_artwork
-  ...ArtworkSidebarMetadata_artwork
-  ...ArtworkSidebarAuctionPartnerInfo_artwork
-  ...ArtworkSidebarCurrentBidInfo_artwork
-  ...ArtworkSidebarBidAction_artwork
-  ...ArtworkSidebarCommercial_artwork
-  ...ArtworkSidebarPartnerInfo_artwork
-  ...ArtworkSidebarExtraLinks_artwork
-  ...SecurePayment_artwork
-  ...VerifiedSeller_artwork
-  ...AuthenticityCertificate_artwork
-  sale {
-    is_closed: isClosed
-    ...AuctionTimer_sale
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
     id
   }
-}
-
-fragment AuctionTimer_sale on Sale {
-  live_start_at: liveStartAt
-  end_at: endAt
-}
-
-fragment AuthenticityCertificate_artwork on Artwork {
-  hasCertificateOfAuthenticity
-  is_biddable: isBiddable
 }
 
 fragment FollowArtistButton_artist_2eN9lh on Artist {
@@ -255,16 +269,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
     follows
   }
   ...FollowArtistPopover_artist
-}
-
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
 }
 
 fragment FollowArtistPopover_artist on Artist {
@@ -281,17 +285,13 @@ fragment FollowArtistPopover_artist on Artist {
   }
 }
 
-fragment SecurePayment_artwork on Artwork {
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-}
-
-fragment VerifiedSeller_artwork on Artwork {
-  is_biddable: isBiddable
-  partner {
-    isVerifiedSeller
-    name
-    id
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
+    }
   }
 }
 */
@@ -1049,7 +1049,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarQuery",
     "id": null,
-    "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
+    "text": "query ArtworkSidebarQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarSizeInfo_piece.graphql.ts
+++ b/src/__generated__/ArtworkSidebarSizeInfo_piece.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarSizeInfo_piece = {
     readonly dimensions: {
         readonly in: string | null;
@@ -9,11 +8,6 @@ export type ArtworkSidebarSizeInfo_piece = {
     } | null;
     readonly edition_of: string | null;
     readonly " $refType": "ArtworkSidebarSizeInfo_piece";
-};
-export type ArtworkSidebarSizeInfo_piece$data = ArtworkSidebarSizeInfo_piece;
-export type ArtworkSidebarSizeInfo_piece$key = {
-    readonly " $data"?: ArtworkSidebarSizeInfo_piece$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarSizeInfo_piece">;
 };
 
 

--- a/src/__generated__/ArtworkSidebarStoryQuery.graphql.ts
+++ b/src/__generated__/ArtworkSidebarStoryQuery.graphql.ts
@@ -23,6 +23,26 @@ query ArtworkSidebarStoryQuery {
   }
 }
 
+fragment ArtworkSidebar_artwork on Artwork {
+  is_in_auction: isInAuction
+  ...ArtworkSidebarArtists_artwork
+  ...ArtworkSidebarMetadata_artwork
+  ...ArtworkSidebarAuctionPartnerInfo_artwork
+  ...ArtworkSidebarCurrentBidInfo_artwork
+  ...ArtworkSidebarBidAction_artwork
+  ...ArtworkSidebarCommercial_artwork
+  ...ArtworkSidebarPartnerInfo_artwork
+  ...ArtworkSidebarExtraLinks_artwork
+  ...SecurePayment_artwork
+  ...VerifiedSeller_artwork
+  ...AuthenticityCertificate_artwork
+  sale {
+    is_closed: isClosed
+    ...AuctionTimer_sale
+    id
+  }
+}
+
 fragment ArtworkSidebarArtists_artwork on Artwork {
   cultural_maker: culturalMaker
   artists {
@@ -33,6 +53,21 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
     href
     ...FollowArtistButton_artist_2eN9lh
   }
+}
+
+fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable: isBiddable
+  edition_sets: editionSets {
+    __typename
+    id
+  }
+  sale_artwork: saleArtwork {
+    lot_label: lotLabel
+    id
+  }
+  ...ArtworkSidebarTitleInfo_artwork
+  ...ArtworkSidebarSizeInfo_piece
+  ...ArtworkSidebarClassification_artwork
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
@@ -48,76 +83,6 @@ fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
     internalID
     is_closed: isClosed
     id
-  }
-}
-
-fragment ArtworkSidebarBidAction_artwork on Artwork {
-  myLotStanding(live: true) {
-    most_recent_bid: mostRecentBid {
-      max_bid: maxBid {
-        cents
-      }
-      id
-    }
-  }
-  slug
-  internalID
-  sale {
-    slug
-    registrationStatus {
-      qualified_for_bidding: qualifiedForBidding
-      id
-    }
-    is_preview: isPreview
-    is_open: isOpen
-    is_live_open: isLiveOpen
-    is_closed: isClosed
-    is_registration_closed: isRegistrationClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    increments {
-      cents
-      display
-    }
-    id
-  }
-}
-
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
-fragment ArtworkSidebarCommercial_artwork on Artwork {
-  slug
-  internalID
-  is_for_sale: isForSale
-  is_acquireable: isAcquireable
-  is_inquireable: isInquireable
-  is_offerable: isOfferable
-  listPrice {
-    __typename
-    ... on PriceRange {
-      display
-    }
-    ... on Money {
-      display
-    }
-  }
-  priceIncludesTaxDisplay
-  sale_message: saleMessage
-  shippingInfo
-  shippingOrigin
-  edition_sets: editionSets {
-    internalID
-    id
-    is_acquireable: isAcquireable
-    is_offerable: isOfferable
-    sale_message: saleMessage
-    ...ArtworkSidebarSizeInfo_piece
   }
 }
 
@@ -155,6 +120,81 @@ fragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {
   }
 }
 
+fragment ArtworkSidebarBidAction_artwork on Artwork {
+  myLotStanding(live: true) {
+    most_recent_bid: mostRecentBid {
+      max_bid: maxBid {
+        cents
+      }
+      id
+    }
+  }
+  slug
+  internalID
+  sale {
+    slug
+    registrationStatus {
+      qualified_for_bidding: qualifiedForBidding
+      id
+    }
+    is_preview: isPreview
+    is_open: isOpen
+    is_live_open: isLiveOpen
+    is_closed: isClosed
+    is_registration_closed: isRegistrationClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    increments {
+      cents
+      display
+    }
+    id
+  }
+}
+
+fragment ArtworkSidebarCommercial_artwork on Artwork {
+  slug
+  internalID
+  is_for_sale: isForSale
+  is_acquireable: isAcquireable
+  is_inquireable: isInquireable
+  is_offerable: isOfferable
+  listPrice {
+    __typename
+    ... on PriceRange {
+      display
+    }
+    ... on Money {
+      display
+    }
+  }
+  priceIncludesTaxDisplay
+  sale_message: saleMessage
+  shippingInfo
+  shippingOrigin
+  edition_sets: editionSets {
+    internalID
+    id
+    is_acquireable: isAcquireable
+    is_offerable: isOfferable
+    sale_message: saleMessage
+    ...ArtworkSidebarSizeInfo_piece
+  }
+}
+
+fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+  partner {
+    name
+    href
+    locations {
+      city
+      id
+    }
+    id
+  }
+}
+
 fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   internalID
   is_in_auction: isInAuction
@@ -171,31 +211,28 @@ fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   }
 }
 
-fragment ArtworkSidebarMetadata_artwork on Artwork {
-  is_biddable: isBiddable
-  edition_sets: editionSets {
-    __typename
-    id
-  }
-  sale_artwork: saleArtwork {
-    lot_label: lotLabel
-    id
-  }
-  ...ArtworkSidebarTitleInfo_artwork
-  ...ArtworkSidebarSizeInfo_piece
-  ...ArtworkSidebarClassification_artwork
+fragment SecurePayment_artwork on Artwork {
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
 }
 
-fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+fragment VerifiedSeller_artwork on Artwork {
+  is_biddable: isBiddable
   partner {
+    isVerifiedSeller
     name
-    href
-    locations {
-      city
-      id
-    }
     id
   }
+}
+
+fragment AuthenticityCertificate_artwork on Artwork {
+  hasCertificateOfAuthenticity
+  is_biddable: isBiddable
+}
+
+fragment AuctionTimer_sale on Sale {
+  live_start_at: liveStartAt
+  end_at: endAt
 }
 
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
@@ -212,34 +249,11 @@ fragment ArtworkSidebarTitleInfo_artwork on Artwork {
   medium
 }
 
-fragment ArtworkSidebar_artwork on Artwork {
-  is_in_auction: isInAuction
-  ...ArtworkSidebarArtists_artwork
-  ...ArtworkSidebarMetadata_artwork
-  ...ArtworkSidebarAuctionPartnerInfo_artwork
-  ...ArtworkSidebarCurrentBidInfo_artwork
-  ...ArtworkSidebarBidAction_artwork
-  ...ArtworkSidebarCommercial_artwork
-  ...ArtworkSidebarPartnerInfo_artwork
-  ...ArtworkSidebarExtraLinks_artwork
-  ...SecurePayment_artwork
-  ...VerifiedSeller_artwork
-  ...AuthenticityCertificate_artwork
-  sale {
-    is_closed: isClosed
-    ...AuctionTimer_sale
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
     id
   }
-}
-
-fragment AuctionTimer_sale on Sale {
-  live_start_at: liveStartAt
-  end_at: endAt
-}
-
-fragment AuthenticityCertificate_artwork on Artwork {
-  hasCertificateOfAuthenticity
-  is_biddable: isBiddable
 }
 
 fragment FollowArtistButton_artist_2eN9lh on Artist {
@@ -251,16 +265,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
     follows
   }
   ...FollowArtistPopover_artist
-}
-
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
 }
 
 fragment FollowArtistPopover_artist on Artist {
@@ -277,17 +281,13 @@ fragment FollowArtistPopover_artist on Artist {
   }
 }
 
-fragment SecurePayment_artwork on Artwork {
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-}
-
-fragment VerifiedSeller_artwork on Artwork {
-  is_biddable: isBiddable
-  partner {
-    isVerifiedSeller
-    name
-    id
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
+    }
   }
 }
 */
@@ -1037,7 +1037,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebarStoryQuery",
     "id": null,
-    "text": "query ArtworkSidebarStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
+    "text": "query ArtworkSidebarStoryQuery {\n  artwork(id: \"unused\") {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebarTitleInfo_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebarTitleInfo_artwork.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSidebarTitleInfo_artwork = {
     readonly title: string | null;
     readonly date: string | null;
     readonly medium: string | null;
     readonly " $refType": "ArtworkSidebarTitleInfo_artwork";
-};
-export type ArtworkSidebarTitleInfo_artwork$data = ArtworkSidebarTitleInfo_artwork;
-export type ArtworkSidebarTitleInfo_artwork$key = {
-    readonly " $data"?: ArtworkSidebarTitleInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarTitleInfo_artwork">;
 };
 
 

--- a/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_Test_Query.graphql.ts
@@ -163,6 +163,26 @@ query ArtworkSidebar_Test_Query {
   }
 }
 
+fragment ArtworkSidebar_artwork on Artwork {
+  is_in_auction: isInAuction
+  ...ArtworkSidebarArtists_artwork
+  ...ArtworkSidebarMetadata_artwork
+  ...ArtworkSidebarAuctionPartnerInfo_artwork
+  ...ArtworkSidebarCurrentBidInfo_artwork
+  ...ArtworkSidebarBidAction_artwork
+  ...ArtworkSidebarCommercial_artwork
+  ...ArtworkSidebarPartnerInfo_artwork
+  ...ArtworkSidebarExtraLinks_artwork
+  ...SecurePayment_artwork
+  ...VerifiedSeller_artwork
+  ...AuthenticityCertificate_artwork
+  sale {
+    is_closed: isClosed
+    ...AuctionTimer_sale
+    id
+  }
+}
+
 fragment ArtworkSidebarArtists_artwork on Artwork {
   cultural_maker: culturalMaker
   artists {
@@ -173,6 +193,21 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
     href
     ...FollowArtistButton_artist_2eN9lh
   }
+}
+
+fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable: isBiddable
+  edition_sets: editionSets {
+    __typename
+    id
+  }
+  sale_artwork: saleArtwork {
+    lot_label: lotLabel
+    id
+  }
+  ...ArtworkSidebarTitleInfo_artwork
+  ...ArtworkSidebarSizeInfo_piece
+  ...ArtworkSidebarClassification_artwork
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
@@ -188,76 +223,6 @@ fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
     internalID
     is_closed: isClosed
     id
-  }
-}
-
-fragment ArtworkSidebarBidAction_artwork on Artwork {
-  myLotStanding(live: true) {
-    most_recent_bid: mostRecentBid {
-      max_bid: maxBid {
-        cents
-      }
-      id
-    }
-  }
-  slug
-  internalID
-  sale {
-    slug
-    registrationStatus {
-      qualified_for_bidding: qualifiedForBidding
-      id
-    }
-    is_preview: isPreview
-    is_open: isOpen
-    is_live_open: isLiveOpen
-    is_closed: isClosed
-    is_registration_closed: isRegistrationClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    increments {
-      cents
-      display
-    }
-    id
-  }
-}
-
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
-fragment ArtworkSidebarCommercial_artwork on Artwork {
-  slug
-  internalID
-  is_for_sale: isForSale
-  is_acquireable: isAcquireable
-  is_inquireable: isInquireable
-  is_offerable: isOfferable
-  listPrice {
-    __typename
-    ... on PriceRange {
-      display
-    }
-    ... on Money {
-      display
-    }
-  }
-  priceIncludesTaxDisplay
-  sale_message: saleMessage
-  shippingInfo
-  shippingOrigin
-  edition_sets: editionSets {
-    internalID
-    id
-    is_acquireable: isAcquireable
-    is_offerable: isOfferable
-    sale_message: saleMessage
-    ...ArtworkSidebarSizeInfo_piece
   }
 }
 
@@ -295,6 +260,81 @@ fragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {
   }
 }
 
+fragment ArtworkSidebarBidAction_artwork on Artwork {
+  myLotStanding(live: true) {
+    most_recent_bid: mostRecentBid {
+      max_bid: maxBid {
+        cents
+      }
+      id
+    }
+  }
+  slug
+  internalID
+  sale {
+    slug
+    registrationStatus {
+      qualified_for_bidding: qualifiedForBidding
+      id
+    }
+    is_preview: isPreview
+    is_open: isOpen
+    is_live_open: isLiveOpen
+    is_closed: isClosed
+    is_registration_closed: isRegistrationClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    increments {
+      cents
+      display
+    }
+    id
+  }
+}
+
+fragment ArtworkSidebarCommercial_artwork on Artwork {
+  slug
+  internalID
+  is_for_sale: isForSale
+  is_acquireable: isAcquireable
+  is_inquireable: isInquireable
+  is_offerable: isOfferable
+  listPrice {
+    __typename
+    ... on PriceRange {
+      display
+    }
+    ... on Money {
+      display
+    }
+  }
+  priceIncludesTaxDisplay
+  sale_message: saleMessage
+  shippingInfo
+  shippingOrigin
+  edition_sets: editionSets {
+    internalID
+    id
+    is_acquireable: isAcquireable
+    is_offerable: isOfferable
+    sale_message: saleMessage
+    ...ArtworkSidebarSizeInfo_piece
+  }
+}
+
+fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+  partner {
+    name
+    href
+    locations {
+      city
+      id
+    }
+    id
+  }
+}
+
 fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   internalID
   is_in_auction: isInAuction
@@ -311,31 +351,28 @@ fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   }
 }
 
-fragment ArtworkSidebarMetadata_artwork on Artwork {
-  is_biddable: isBiddable
-  edition_sets: editionSets {
-    __typename
-    id
-  }
-  sale_artwork: saleArtwork {
-    lot_label: lotLabel
-    id
-  }
-  ...ArtworkSidebarTitleInfo_artwork
-  ...ArtworkSidebarSizeInfo_piece
-  ...ArtworkSidebarClassification_artwork
+fragment SecurePayment_artwork on Artwork {
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
 }
 
-fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+fragment VerifiedSeller_artwork on Artwork {
+  is_biddable: isBiddable
   partner {
+    isVerifiedSeller
     name
-    href
-    locations {
-      city
-      id
-    }
     id
   }
+}
+
+fragment AuthenticityCertificate_artwork on Artwork {
+  hasCertificateOfAuthenticity
+  is_biddable: isBiddable
+}
+
+fragment AuctionTimer_sale on Sale {
+  live_start_at: liveStartAt
+  end_at: endAt
 }
 
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
@@ -352,34 +389,11 @@ fragment ArtworkSidebarTitleInfo_artwork on Artwork {
   medium
 }
 
-fragment ArtworkSidebar_artwork on Artwork {
-  is_in_auction: isInAuction
-  ...ArtworkSidebarArtists_artwork
-  ...ArtworkSidebarMetadata_artwork
-  ...ArtworkSidebarAuctionPartnerInfo_artwork
-  ...ArtworkSidebarCurrentBidInfo_artwork
-  ...ArtworkSidebarBidAction_artwork
-  ...ArtworkSidebarCommercial_artwork
-  ...ArtworkSidebarPartnerInfo_artwork
-  ...ArtworkSidebarExtraLinks_artwork
-  ...SecurePayment_artwork
-  ...VerifiedSeller_artwork
-  ...AuthenticityCertificate_artwork
-  sale {
-    is_closed: isClosed
-    ...AuctionTimer_sale
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
     id
   }
-}
-
-fragment AuctionTimer_sale on Sale {
-  live_start_at: liveStartAt
-  end_at: endAt
-}
-
-fragment AuthenticityCertificate_artwork on Artwork {
-  hasCertificateOfAuthenticity
-  is_biddable: isBiddable
 }
 
 fragment FollowArtistButton_artist_2eN9lh on Artist {
@@ -391,16 +405,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
     follows
   }
   ...FollowArtistPopover_artist
-}
-
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
 }
 
 fragment FollowArtistPopover_artist on Artist {
@@ -417,17 +421,13 @@ fragment FollowArtistPopover_artist on Artist {
   }
 }
 
-fragment SecurePayment_artwork on Artwork {
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-}
-
-fragment VerifiedSeller_artwork on Artwork {
-  is_biddable: isBiddable
-  partner {
-    isVerifiedSeller
-    name
-    id
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
+    }
   }
 }
 */
@@ -1177,7 +1177,7 @@ return {
     "operationKind": "query",
     "name": "ArtworkSidebar_Test_Query",
     "id": null,
-    "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
+    "text": "query ArtworkSidebar_Test_Query {\n  artwork(id: \"josef-albers-homage-to-the-square-85\") {\n    ...ArtworkSidebar_artwork\n    id\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtworkSidebar_artwork.graphql.ts
+++ b/src/__generated__/ArtworkSidebar_artwork.graphql.ts
@@ -11,11 +11,6 @@ export type ArtworkSidebar_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebarArtists_artwork" | "ArtworkSidebarMetadata_artwork" | "ArtworkSidebarAuctionPartnerInfo_artwork" | "ArtworkSidebarCurrentBidInfo_artwork" | "ArtworkSidebarBidAction_artwork" | "ArtworkSidebarCommercial_artwork" | "ArtworkSidebarPartnerInfo_artwork" | "ArtworkSidebarExtraLinks_artwork" | "SecurePayment_artwork" | "VerifiedSeller_artwork" | "AuthenticityCertificate_artwork">;
     readonly " $refType": "ArtworkSidebar_artwork";
 };
-export type ArtworkSidebar_artwork$data = ArtworkSidebar_artwork;
-export type ArtworkSidebar_artwork$key = {
-    readonly " $data"?: ArtworkSidebar_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSidebar_artwork">;
-};
 
 
 

--- a/src/__generated__/ArtworkSummaryItem_order.graphql.ts
+++ b/src/__generated__/ArtworkSummaryItem_order.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ArtworkSummaryItem_order = {
     readonly sellerDetails: {
         readonly name?: string | null;
@@ -24,11 +23,6 @@ export type ArtworkSummaryItem_order = {
         } | null> | null;
     } | null;
     readonly " $refType": "ArtworkSummaryItem_order";
-};
-export type ArtworkSummaryItem_order$data = ArtworkSummaryItem_order;
-export type ArtworkSummaryItem_order$key = {
-    readonly " $data"?: ArtworkSummaryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order">;
 };
 
 

--- a/src/__generated__/Artwork_artwork.graphql.ts
+++ b/src/__generated__/Artwork_artwork.graphql.ts
@@ -11,11 +11,6 @@ export type Artwork_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork">;
     readonly " $refType": "Artwork_artwork";
 };
-export type Artwork_artwork$data = Artwork_artwork;
-export type Artwork_artwork$key = {
-    readonly " $data"?: Artwork_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Artwork_artwork">;
-};
 
 
 

--- a/src/__generated__/AuctionCard_sale.graphql.ts
+++ b/src/__generated__/AuctionCard_sale.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type AuctionCard_sale = {
     readonly cover_image: {
         readonly cropped: {
@@ -27,11 +26,6 @@ export type AuctionCard_sale = {
         readonly name: string | null;
     } | null;
     readonly " $refType": "AuctionCard_sale";
-};
-export type AuctionCard_sale$data = AuctionCard_sale;
-export type AuctionCard_sale$key = {
-    readonly " $data"?: AuctionCard_sale$data;
-    readonly " $fragmentRefs": FragmentRefs<"AuctionCard_sale">;
 };
 
 

--- a/src/__generated__/AuctionFAQ_viewer.graphql.ts
+++ b/src/__generated__/AuctionFAQ_viewer.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type AuctionFAQ_viewer = {
     readonly bidding: {
         readonly content: string | null;
@@ -19,11 +18,6 @@ export type AuctionFAQ_viewer = {
         readonly content: string | null;
     } | null;
     readonly " $refType": "AuctionFAQ_viewer";
-};
-export type AuctionFAQ_viewer$data = AuctionFAQ_viewer;
-export type AuctionFAQ_viewer$key = {
-    readonly " $data"?: AuctionFAQ_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"AuctionFAQ_viewer">;
 };
 
 

--- a/src/__generated__/AuctionResults_Test_Query.graphql.ts
+++ b/src/__generated__/AuctionResults_Test_Query.graphql.ts
@@ -85,25 +85,8 @@ query AuctionResults_Test_Query(
   }
 }
 
-fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
-  title
-  dimension_text: dimensionText
-  organization
-  images {
-    thumbnail {
-      url
-    }
-  }
-  description
-  date_text: dateText
-  sale_date_text: saleDateText
-  price_realized: priceRealized {
-    display
-    cents_usd: centsUSD
-  }
-  estimate {
-    display
-  }
+fragment AuctionResults_artist on Artist {
+  ...ArtistAuctionResults_artist
 }
 
 fragment ArtistAuctionResults_artist on Artist {
@@ -126,10 +109,6 @@ fragment ArtistAuctionResults_artist on Artist {
   }
 }
 
-fragment AuctionResults_artist on Artist {
-  ...ArtistAuctionResults_artist
-}
-
 fragment Pagination_pageCursors on PageCursors {
   around {
     cursor
@@ -149,6 +128,27 @@ fragment Pagination_pageCursors on PageCursors {
   previous {
     cursor
     page
+  }
+}
+
+fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
+  title
+  dimension_text: dimensionText
+  organization
+  images {
+    thumbnail {
+      url
+    }
+  }
+  description
+  date_text: dateText
+  sale_date_text: saleDateText
+  price_realized: priceRealized {
+    display
+    cents_usd: centsUSD
+  }
+  estimate {
+    display
   }
 }
 */
@@ -498,7 +498,7 @@ return {
     "operationKind": "query",
     "name": "AuctionResults_Test_Query",
     "id": null,
-    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/AuctionResults_artist.graphql.ts
+++ b/src/__generated__/AuctionResults_artist.graphql.ts
@@ -6,11 +6,6 @@ export type AuctionResults_artist = {
     readonly " $fragmentRefs": FragmentRefs<"ArtistAuctionResults_artist">;
     readonly " $refType": "AuctionResults_artist";
 };
-export type AuctionResults_artist$data = AuctionResults_artist;
-export type AuctionResults_artist$key = {
-    readonly " $data"?: AuctionResults_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"AuctionResults_artist">;
-};
 
 
 

--- a/src/__generated__/AuctionTimer_sale.graphql.ts
+++ b/src/__generated__/AuctionTimer_sale.graphql.ts
@@ -1,16 +1,10 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type AuctionTimer_sale = {
     readonly live_start_at: string | null;
     readonly end_at: string | null;
     readonly " $refType": "AuctionTimer_sale";
-};
-export type AuctionTimer_sale$data = AuctionTimer_sale;
-export type AuctionTimer_sale$key = {
-    readonly " $data"?: AuctionTimer_sale$data;
-    readonly " $fragmentRefs": FragmentRefs<"AuctionTimer_sale">;
 };
 
 

--- a/src/__generated__/AuthenticityCertificate_artwork.graphql.ts
+++ b/src/__generated__/AuthenticityCertificate_artwork.graphql.ts
@@ -1,16 +1,10 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type AuthenticityCertificate_artwork = {
     readonly hasCertificateOfAuthenticity: boolean | null;
     readonly is_biddable: boolean | null;
     readonly " $refType": "AuthenticityCertificate_artwork";
-};
-export type AuthenticityCertificate_artwork$data = AuthenticityCertificate_artwork;
-export type AuthenticityCertificate_artwork$key = {
-    readonly " $data"?: AuthenticityCertificate_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"AuthenticityCertificate_artwork">;
 };
 
 

--- a/src/__generated__/Badge_artwork.graphql.ts
+++ b/src/__generated__/Badge_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Badge_artwork = {
     readonly is_biddable: boolean | null;
     readonly is_acquireable: boolean | null;
@@ -12,11 +11,6 @@ export type Badge_artwork = {
         readonly display_timely_at: string | null;
     } | null;
     readonly " $refType": "Badge_artwork";
-};
-export type Badge_artwork$data = Badge_artwork;
-export type Badge_artwork$key = {
-    readonly " $data"?: Badge_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Badge_artwork">;
 };
 
 

--- a/src/__generated__/BidForm_saleArtwork.graphql.ts
+++ b/src/__generated__/BidForm_saleArtwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type BidForm_saleArtwork = {
     readonly minimumNextBid: {
         readonly cents: number | null;
@@ -11,11 +10,6 @@ export type BidForm_saleArtwork = {
         readonly display: string | null;
     } | null> | null;
     readonly " $refType": "BidForm_saleArtwork";
-};
-export type BidForm_saleArtwork$data = BidForm_saleArtwork;
-export type BidForm_saleArtwork$key = {
-    readonly " $data"?: BidForm_saleArtwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"BidForm_saleArtwork">;
 };
 
 

--- a/src/__generated__/CVItem_artist.graphql.ts
+++ b/src/__generated__/CVItem_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CVItem_artist = {
     readonly slug: string;
     readonly showsConnection: {
@@ -23,11 +22,6 @@ export type CVItem_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "CVItem_artist";
-};
-export type CVItem_artist$data = CVItem_artist;
-export type CVItem_artist$key = {
-    readonly " $data"?: CVItem_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"CVItem_artist">;
 };
 
 

--- a/src/__generated__/CV_Test_Query.graphql.ts
+++ b/src/__generated__/CV_Test_Query.graphql.ts
@@ -133,9 +133,24 @@ query CV_Test_Query(
   }
 }
 
-fragment CVItem_artist_47e96d on Artist {
+fragment CV_viewer on Viewer {
+  artist_soloShows: artist(id: $artistID) {
+    ...CVItem_artist_ieWPx
+    id
+  }
+  artist_groupShows: artist(id: $artistID) {
+    ...CVItem_artist_4DszuY
+    id
+  }
+  artist_fairBooths: artist(id: $artistID) {
+    ...CVItem_artist_47e96d
+    id
+  }
+}
+
+fragment CVItem_artist_ieWPx on Artist {
   slug
-  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {
+  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {
     pageInfo {
       hasNextPage
       endCursor
@@ -203,9 +218,9 @@ fragment CVItem_artist_4DszuY on Artist {
   }
 }
 
-fragment CVItem_artist_ieWPx on Artist {
+fragment CVItem_artist_47e96d on Artist {
   slug
-  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {
+  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {
     pageInfo {
       hasNextPage
       endCursor
@@ -235,21 +250,6 @@ fragment CVItem_artist_ieWPx on Artist {
       }
       cursor
     }
-  }
-}
-
-fragment CV_viewer on Viewer {
-  artist_soloShows: artist(id: $artistID) {
-    ...CVItem_artist_ieWPx
-    id
-  }
-  artist_groupShows: artist(id: $artistID) {
-    ...CVItem_artist_4DszuY
-    id
-  }
-  artist_fairBooths: artist(id: $artistID) {
-    ...CVItem_artist_47e96d
-    id
   }
 }
 */
@@ -627,7 +627,7 @@ return {
     "operationKind": "query",
     "name": "CV_Test_Query",
     "id": null,
-    "text": "query CV_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...CV_viewer\n  }\n}\n\nfragment CVItem_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CV_viewer on Viewer {\n  artist_soloShows: artist(id: $artistID) {\n    ...CVItem_artist_ieWPx\n    id\n  }\n  artist_groupShows: artist(id: $artistID) {\n    ...CVItem_artist_4DszuY\n    id\n  }\n  artist_fairBooths: artist(id: $artistID) {\n    ...CVItem_artist_47e96d\n    id\n  }\n}\n",
+    "text": "query CV_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...CV_viewer\n  }\n}\n\nfragment CV_viewer on Viewer {\n  artist_soloShows: artist(id: $artistID) {\n    ...CVItem_artist_ieWPx\n    id\n  }\n  artist_groupShows: artist(id: $artistID) {\n    ...CVItem_artist_4DszuY\n    id\n  }\n  artist_fairBooths: artist(id: $artistID) {\n    ...CVItem_artist_47e96d\n    id\n  }\n}\n\nfragment CVItem_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/CV_viewer.graphql.ts
+++ b/src/__generated__/CV_viewer.graphql.ts
@@ -14,11 +14,6 @@ export type CV_viewer = {
     } | null;
     readonly " $refType": "CV_viewer";
 };
-export type CV_viewer$data = CV_viewer;
-export type CV_viewer$key = {
-    readonly " $data"?: CV_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"CV_viewer">;
-};
 
 
 

--- a/src/__generated__/CarouselArtworkBrickStoryQuery.graphql.ts
+++ b/src/__generated__/CarouselArtworkBrickStoryQuery.graphql.ts
@@ -23,6 +23,31 @@ query CarouselArtworkBrickStoryQuery {
   }
 }
 
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -31,34 +56,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -99,29 +96,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -475,7 +475,7 @@ return {
     "operationKind": "query",
     "name": "CarouselArtworkBrickStoryQuery",
     "id": null,
-    "text": "query CarouselArtworkBrickStoryQuery {\n  artwork(id: \"unused\") {\n    ...FillwidthItem_artwork\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query CarouselArtworkBrickStoryQuery {\n  artwork(id: \"unused\") {\n    ...FillwidthItem_artwork\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Collect_marketingHubCollections.graphql.ts
+++ b/src/__generated__/Collect_marketingHubCollections.graphql.ts
@@ -6,11 +6,6 @@ export type Collect_marketingHubCollections = ReadonlyArray<{
     readonly " $fragmentRefs": FragmentRefs<"CollectionsHubsNav_marketingHubCollections">;
     readonly " $refType": "Collect_marketingHubCollections";
 }>;
-export type Collect_marketingHubCollections$data = Collect_marketingHubCollections;
-export type Collect_marketingHubCollections$key = ReadonlyArray<{
-    readonly " $data"?: Collect_marketingHubCollections$data;
-    readonly " $fragmentRefs": FragmentRefs<"Collect_marketingHubCollections">;
-}>;
 
 
 

--- a/src/__generated__/CollectionEntity_collection.graphql.ts
+++ b/src/__generated__/CollectionEntity_collection.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CollectionEntity_collection = {
     readonly slug: string;
     readonly headerImage: string | null;
@@ -9,11 +8,6 @@ export type CollectionEntity_collection = {
     readonly price_guidance: number | null;
     readonly show_on_editorial: boolean;
     readonly " $refType": "CollectionEntity_collection";
-};
-export type CollectionEntity_collection$data = CollectionEntity_collection;
-export type CollectionEntity_collection$key = {
-    readonly " $data"?: CollectionEntity_collection$data;
-    readonly " $fragmentRefs": FragmentRefs<"CollectionEntity_collection">;
 };
 
 

--- a/src/__generated__/CollectionRefetch2Query.graphql.ts
+++ b/src/__generated__/CollectionRefetch2Query.graphql.ts
@@ -56,94 +56,6 @@ query CollectionRefetch2Query(
   }
 }
 
-fragment ArtistSeriesEntity_member on MarketingCollection {
-  slug
-  headerImage
-  thumbnail
-  title
-  price_guidance: priceGuidance
-  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
-    edges {
-      node {
-        artist {
-          name
-          id
-        }
-        title
-        image {
-          url(version: "small")
-        }
-        id
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    ...ArtistSeriesEntity_member
-    id
-  }
-}
-
-fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
-  id
-  aggregations {
-    slice
-    counts {
-      value
-      name
-      count
-    }
-  }
-  pageInfo {
-    hasNextPage
-    endCursor
-  }
-  pageCursors {
-    ...Pagination_pageCursors
-  }
-  edges {
-    node {
-      id
-    }
-  }
-  ...ArtworkGrid_artworks
-}
-
-fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
-  edges {
-    __typename
-    node {
-      id
-      slug
-      href
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...GridItem_artwork
-    }
-    ... on Node {
-      id
-    }
-  }
-}
-
-fragment Badge_artwork on Artwork {
-  is_biddable: isBiddable
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-  href
-  sale {
-    is_preview: isPreview
-    display_timely_at: displayTimelyAt
-    id
-  }
-}
-
 fragment Collection_collection_2Pwt5i on MarketingCollection {
   ...Header_collection
   description
@@ -181,151 +93,6 @@ fragment Collection_collection_2Pwt5i on MarketingCollection {
   }
 }
 
-fragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {
-  groupType
-  ...FeaturedCollectionsRails_collectionGroup
-  ...OtherCollectionsRail_collectionGroup
-  ...ArtistSeriesRail_collectionGroup
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
-}
-
-fragment DefaultHeader_headerArtworks on FilterArtworksConnection {
-  edges {
-    node {
-      href
-      slug
-      image {
-        small: resized(height: 160) {
-          url
-          width
-          height
-        }
-        large: resized(height: 220) {
-          url
-          width
-          height
-        }
-      }
-      id
-    }
-  }
-}
-
-fragment Details_artwork on Artwork {
-  href
-  title
-  date
-  sale_message: saleMessage
-  cultural_maker: culturalMaker
-  artists(shallow: true) {
-    id
-    href
-    name
-  }
-  collecting_institution: collectingInstitution
-  partner(shallow: true) {
-    name
-    href
-    id
-  }
-  sale {
-    is_auction: isAuction
-    is_closed: isClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    counts {
-      bidder_positions: bidderPositions
-    }
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    id
-  }
-}
-
-fragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    slug
-    title
-    description
-    price_guidance: priceGuidance
-    thumbnail
-    id
-  }
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Header_artworks on FilterArtworksConnection {
-  ...DefaultHeader_headerArtworks
-  merchandisableArtists {
-    slug
-    internalID
-    name
-    imageUrl
-    birthday
-    nationality
-    ...FollowArtistButton_artist
-    id
-  }
-}
-
 fragment Header_collection on MarketingCollection {
   category
   credit
@@ -341,84 +108,29 @@ fragment Header_collection on MarketingCollection {
   title
 }
 
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment OtherCollectionEntity_member on MarketingCollection {
-  slug
-  thumbnail
-  title
-}
-
-fragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    ...OtherCollectionEntity_member
-    id
-  }
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
-fragment RelatedCollectionEntity_collection on MarketingCollection {
-  headerImage
-  slug
-  title
-  price_guidance: priceGuidance
-  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
-    edges {
-      node {
-        artist {
-          name
-          id
-        }
-        title
-        image {
-          resized(width: 262) {
-            url
-          }
-        }
-        id
-      }
-    }
-    id
-  }
-}
-
 fragment RelatedCollectionsRail_collections on MarketingCollection {
   ...RelatedCollectionEntity_collection
 }
 
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+fragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {
+  groupType
+  ...FeaturedCollectionsRails_collectionGroup
+  ...OtherCollectionsRail_collectionGroup
+  ...ArtistSeriesRail_collectionGroup
+}
+
+fragment Header_artworks on FilterArtworksConnection {
+  ...DefaultHeader_headerArtworks
+  merchandisableArtists {
+    slug
+    internalID
+    name
+    imageUrl
+    birthday
+    nationality
+    ...FollowArtistButton_artist
+    id
+  }
 }
 
 fragment SeoProductsForArtworks_artworks on FilterArtworksConnection {
@@ -474,6 +186,294 @@ fragment SeoProductsForArtworks_artworks on FilterArtworksConnection {
         id
       }
     }
+  }
+}
+
+fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
+  id
+  aggregations {
+    slice
+    counts {
+      value
+      name
+      count
+    }
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment DefaultHeader_headerArtworks on FilterArtworksConnection {
+  edges {
+    node {
+      href
+      slug
+      image {
+        small: resized(height: 160) {
+          url
+          width
+          height
+        }
+        large: resized(height: 220) {
+          url
+          width
+          height
+        }
+      }
+      id
+    }
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    slug
+    title
+    description
+    price_guidance: priceGuidance
+    thumbnail
+    id
+  }
+}
+
+fragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    ...OtherCollectionEntity_member
+    id
+  }
+}
+
+fragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    ...ArtistSeriesEntity_member
+    id
+  }
+}
+
+fragment ArtistSeriesEntity_member on MarketingCollection {
+  slug
+  headerImage
+  thumbnail
+  title
+  price_guidance: priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        artist {
+          name
+          id
+        }
+        title
+        image {
+          url(version: "small")
+        }
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment OtherCollectionEntity_member on MarketingCollection {
+  slug
+  thumbnail
+  title
+}
+
+fragment RelatedCollectionEntity_collection on MarketingCollection {
+  headerImage
+  slug
+  title
+  price_guidance: priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        artist {
+          name
+          id
+        }
+        title
+        image {
+          resized(width: 262) {
+            url
+          }
+        }
+        id
+      }
+    }
+    id
   }
 }
 */
@@ -1886,7 +1886,7 @@ return {
     "operationKind": "query",
     "name": "CollectionRefetch2Query",
     "id": null,
-    "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Collection_collection.graphql.ts
+++ b/src/__generated__/Collection_collection.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Collection_collection = {
     readonly description: string | null;
     readonly headerImage: string | null;
@@ -35,11 +35,6 @@ export type Collection_collection = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"Header_collection">;
     readonly " $refType": "Collection_collection";
-};
-export type Collection_collection$data = Collection_collection;
-export type Collection_collection$key = {
-    readonly " $data"?: Collection_collection$data;
-    readonly " $fragmentRefs": FragmentRefs<"Collection_collection">;
 };
 
 

--- a/src/__generated__/CollectionsHubRailsStoryQuery.graphql.ts
+++ b/src/__generated__/CollectionsHubRailsStoryQuery.graphql.ts
@@ -31,6 +31,44 @@ query CollectionsHubRailsStoryQuery(
   }
 }
 
+fragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {
+  groupType
+  ...FeaturedCollectionsRails_collectionGroup
+  ...OtherCollectionsRail_collectionGroup
+  ...ArtistSeriesRail_collectionGroup
+}
+
+fragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    slug
+    title
+    description
+    price_guidance: priceGuidance
+    thumbnail
+    id
+  }
+}
+
+fragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    ...OtherCollectionEntity_member
+    id
+  }
+}
+
+fragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {
+  groupType
+  name
+  members {
+    ...ArtistSeriesEntity_member
+    id
+  }
+}
+
 fragment ArtistSeriesEntity_member on MarketingCollection {
   slug
   headerImage
@@ -55,48 +93,10 @@ fragment ArtistSeriesEntity_member on MarketingCollection {
   }
 }
 
-fragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    ...ArtistSeriesEntity_member
-    id
-  }
-}
-
-fragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {
-  groupType
-  ...FeaturedCollectionsRails_collectionGroup
-  ...OtherCollectionsRail_collectionGroup
-  ...ArtistSeriesRail_collectionGroup
-}
-
-fragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    slug
-    title
-    description
-    price_guidance: priceGuidance
-    thumbnail
-    id
-  }
-}
-
 fragment OtherCollectionEntity_member on MarketingCollection {
   slug
   thumbnail
   title
-}
-
-fragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {
-  groupType
-  name
-  members {
-    ...OtherCollectionEntity_member
-    id
-  }
 }
 */
 
@@ -356,7 +356,7 @@ return {
     "operationKind": "query",
     "name": "CollectionsHubRailsStoryQuery",
     "id": null,
-    "text": "query CollectionsHubRailsStoryQuery(\n  $collectionID: String!\n) {\n  marketingCollection(slug: $collectionID) {\n    linkedCollections {\n      ...CollectionsHubRails_linkedCollections\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n",
+    "text": "query CollectionsHubRailsStoryQuery(\n  $collectionID: String!\n) {\n  marketingCollection(slug: $collectionID) {\n    linkedCollections {\n      ...CollectionsHubRails_linkedCollections\n    }\n    id\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/CollectionsHubRails_linkedCollections.graphql.ts
+++ b/src/__generated__/CollectionsHubRails_linkedCollections.graphql.ts
@@ -1,17 +1,12 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 export type CollectionsHubRails_linkedCollections = ReadonlyArray<{
     readonly groupType: MarketingGroupTypes;
     readonly " $fragmentRefs": FragmentRefs<"FeaturedCollectionsRails_collectionGroup" | "OtherCollectionsRail_collectionGroup" | "ArtistSeriesRail_collectionGroup">;
     readonly " $refType": "CollectionsHubRails_linkedCollections";
-}>;
-export type CollectionsHubRails_linkedCollections$data = CollectionsHubRails_linkedCollections;
-export type CollectionsHubRails_linkedCollections$key = ReadonlyArray<{
-    readonly " $data"?: CollectionsHubRails_linkedCollections$data;
-    readonly " $fragmentRefs": FragmentRefs<"CollectionsHubRails_linkedCollections">;
 }>;
 
 

--- a/src/__generated__/CollectionsHubsHomepageNav_marketingHubCollections.graphql.ts
+++ b/src/__generated__/CollectionsHubsHomepageNav_marketingHubCollections.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CollectionsHubsHomepageNav_marketingHubCollections = ReadonlyArray<{
     readonly slug: string;
     readonly title: string;
     readonly thumbnail: string | null;
     readonly " $refType": "CollectionsHubsHomepageNav_marketingHubCollections";
-}>;
-export type CollectionsHubsHomepageNav_marketingHubCollections$data = CollectionsHubsHomepageNav_marketingHubCollections;
-export type CollectionsHubsHomepageNav_marketingHubCollections$key = ReadonlyArray<{
-    readonly " $data"?: CollectionsHubsHomepageNav_marketingHubCollections$data;
-    readonly " $fragmentRefs": FragmentRefs<"CollectionsHubsHomepageNav_marketingHubCollections">;
 }>;
 
 

--- a/src/__generated__/CollectionsHubsNav_marketingHubCollections.graphql.ts
+++ b/src/__generated__/CollectionsHubsNav_marketingHubCollections.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CollectionsHubsNav_marketingHubCollections = ReadonlyArray<{
     readonly slug: string;
     readonly title: string;
     readonly thumbnail: string | null;
     readonly " $refType": "CollectionsHubsNav_marketingHubCollections";
-}>;
-export type CollectionsHubsNav_marketingHubCollections$data = CollectionsHubsNav_marketingHubCollections;
-export type CollectionsHubsNav_marketingHubCollections$key = ReadonlyArray<{
-    readonly " $data"?: CollectionsHubsNav_marketingHubCollections$data;
-    readonly " $fragmentRefs": FragmentRefs<"CollectionsHubsNav_marketingHubCollections">;
 }>;
 
 

--- a/src/__generated__/CollectionsRailQuery.graphql.ts
+++ b/src/__generated__/CollectionsRailQuery.graphql.ts
@@ -31,16 +31,16 @@ query CollectionsRailQuery(
   }
 }
 
+fragment CollectionsRail_collections on MarketingCollection {
+  ...CollectionEntity_collection
+}
+
 fragment CollectionEntity_collection on MarketingCollection {
   slug
   headerImage
   title
   price_guidance: priceGuidance
   show_on_editorial: showOnEditorial
-}
-
-fragment CollectionsRail_collections on MarketingCollection {
-  ...CollectionEntity_collection
 }
 */
 
@@ -173,7 +173,7 @@ return {
     "operationKind": "query",
     "name": "CollectionsRailQuery",
     "id": null,
-    "text": "query CollectionsRailQuery(\n  $showOnEditorial: Boolean\n  $size: Int\n  $randomizationSeed: String\n) {\n  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomizationSeed: $randomizationSeed) {\n    ...CollectionsRail_collections\n    id\n  }\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance: priceGuidance\n  show_on_editorial: showOnEditorial\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n}\n",
+    "text": "query CollectionsRailQuery(\n  $showOnEditorial: Boolean\n  $size: Int\n  $randomizationSeed: String\n) {\n  collections: marketingCollections(showOnEditorial: $showOnEditorial, size: $size, randomizationSeed: $randomizationSeed) {\n    ...CollectionsRail_collections\n    id\n  }\n}\n\nfragment CollectionsRail_collections on MarketingCollection {\n  ...CollectionEntity_collection\n}\n\nfragment CollectionEntity_collection on MarketingCollection {\n  slug\n  headerImage\n  title\n  price_guidance: priceGuidance\n  show_on_editorial: showOnEditorial\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/CollectionsRail_collections.graphql.ts
+++ b/src/__generated__/CollectionsRail_collections.graphql.ts
@@ -6,11 +6,6 @@ export type CollectionsRail_collections = ReadonlyArray<{
     readonly " $fragmentRefs": FragmentRefs<"CollectionEntity_collection">;
     readonly " $refType": "CollectionsRail_collections";
 }>;
-export type CollectionsRail_collections$data = CollectionsRail_collections;
-export type CollectionsRail_collections$key = ReadonlyArray<{
-    readonly " $data"?: CollectionsRail_collections$data;
-    readonly " $fragmentRefs": FragmentRefs<"CollectionsRail_collections">;
-}>;
 
 
 

--- a/src/__generated__/Collections_marketingCategories.graphql.ts
+++ b/src/__generated__/Collections_marketingCategories.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Collections_marketingCategories = ReadonlyArray<{
     readonly name: string;
     readonly collections: ReadonlyArray<{
@@ -10,11 +9,6 @@ export type Collections_marketingCategories = ReadonlyArray<{
         readonly title: string;
     }>;
     readonly " $refType": "Collections_marketingCategories";
-}>;
-export type Collections_marketingCategories$data = Collections_marketingCategories;
-export type Collections_marketingCategories$key = ReadonlyArray<{
-    readonly " $data"?: Collections_marketingCategories$data;
-    readonly " $fragmentRefs": FragmentRefs<"Collections_marketingCategories">;
 }>;
 
 

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -120,16 +120,6 @@ query ConfirmBidValidTestQuery {
   }
 }
 
-fragment BidForm_saleArtwork on SaleArtwork {
-  minimumNextBid {
-    cents
-  }
-  increments(useMyMaxBid: true) {
-    cents
-    display
-  }
-}
-
 fragment LotInfo_artwork on Artwork {
   internalID
   date
@@ -145,6 +135,16 @@ fragment LotInfo_saleArtwork on SaleArtwork {
   lotLabel
   minimumNextBid {
     amount
+    cents
+    display
+  }
+}
+
+fragment BidForm_saleArtwork on SaleArtwork {
+  minimumNextBid {
+    cents
+  }
+  increments(useMyMaxBid: true) {
     cents
     display
   }
@@ -506,7 +506,7 @@ return {
     "operationKind": "query",
     "name": "ConfirmBidValidTestQuery",
     "id": null,
-    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    id\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Contact_artwork.graphql.ts
+++ b/src/__generated__/Contact_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Contact_artwork = {
     readonly href: string | null;
     readonly is_inquireable: boolean | null;
@@ -26,11 +25,6 @@ export type Contact_artwork = {
         } | null;
     } | null;
     readonly " $refType": "Contact_artwork";
-};
-export type Contact_artwork$data = Contact_artwork;
-export type Contact_artwork$key = {
-    readonly " $data"?: Contact_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Contact_artwork">;
 };
 
 

--- a/src/__generated__/CounterTestQuery.graphql.ts
+++ b/src/__generated__/CounterTestQuery.graphql.ts
@@ -195,6 +195,83 @@ query CounterTestQuery {
   }
 }
 
+fragment Counter_order on CommerceOrder {
+  internalID
+  mode
+  state
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  stateExpiresAt
+  ... on CommerceOfferOrder {
+    lastOffer {
+      createdAt
+      id
+    }
+    myLastOffer {
+      internalID
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+}
+
+fragment TransactionDetailsSummaryItem_order on CommerceOrder {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+    myLastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+  }
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -229,39 +306,23 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
   }
 }
 
-fragment Counter_order on CommerceOrder {
-  internalID
-  mode
+fragment ShippingSummaryItem_order on CommerceOrder {
   state
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  stateExpiresAt
-  ... on CommerceOfferOrder {
-    lastOffer {
-      createdAt
-      id
-    }
-    myLastOffer {
-      internalID
-      id
-    }
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
   }
   lineItems {
     edges {
       node {
         artwork {
-          slug
+          shippingOrigin
           id
         }
         id
       }
     }
   }
-  ...TransactionDetailsSummaryItem_order
-  ...ArtworkSummaryItem_order
-  ...ShippingSummaryItem_order
-  ...CreditCardSummaryItem_order
-  ...OfferHistoryItem_order
 }
 
 fragment CreditCardSummaryItem_order on CommerceOrder {
@@ -309,67 +370,6 @@ fragment ShippingAddress_ship on CommerceShip {
   region
   country
   phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment TransactionDetailsSummaryItem_order on CommerceOrder {
-  __typename
-  mode
-  shippingTotal(precision: 2)
-  shippingTotalCents
-  taxTotal(precision: 2)
-  taxTotalCents
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  buyerTotal(precision: 2)
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-    myLastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-  }
 }
 */
 
@@ -931,7 +931,7 @@ return {
     "operationKind": "query",
     "name": "CounterTestQuery",
     "id": null,
-    "text": "query CounterTestQuery {\n  order: commerceOrder(id: \"\") {\n    __typename\n    ...Counter_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Counter_order on CommerceOrder {\n  internalID\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  stateExpiresAt\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      id\n    }\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query CounterTestQuery {\n  order: commerceOrder(id: \"\") {\n    __typename\n    ...Counter_order\n    id\n  }\n}\n\nfragment Counter_order on CommerceOrder {\n  internalID\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  stateExpiresAt\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      id\n    }\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Counter_order.graphql.ts
+++ b/src/__generated__/Counter_order.graphql.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Counter_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -28,11 +28,6 @@ export type Counter_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"TransactionDetailsSummaryItem_order" | "ArtworkSummaryItem_order" | "ShippingSummaryItem_order" | "CreditCardSummaryItem_order" | "OfferHistoryItem_order">;
     readonly " $refType": "Counter_order";
-};
-export type Counter_order$data = Counter_order;
-export type Counter_order$key = {
-    readonly " $data"?: Counter_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Counter_order">;
 };
 
 

--- a/src/__generated__/CreditCardSummaryItem_order.graphql.ts
+++ b/src/__generated__/CreditCardSummaryItem_order.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CreditCardSummaryItem_order = {
     readonly creditCard: {
         readonly brand: string;
@@ -10,11 +9,6 @@ export type CreditCardSummaryItem_order = {
         readonly expirationMonth: number;
     } | null;
     readonly " $refType": "CreditCardSummaryItem_order";
-};
-export type CreditCardSummaryItem_order$data = CreditCardSummaryItem_order;
-export type CreditCardSummaryItem_order$key = {
-    readonly " $data"?: CreditCardSummaryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"CreditCardSummaryItem_order">;
 };
 
 

--- a/src/__generated__/CurrentEvent_artist.graphql.ts
+++ b/src/__generated__/CurrentEvent_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type CurrentEvent_artist = {
     readonly currentEvent: {
         readonly event: {
@@ -19,11 +18,6 @@ export type CurrentEvent_artist = {
         readonly href: string | null;
     } | null;
     readonly " $refType": "CurrentEvent_artist";
-};
-export type CurrentEvent_artist$data = CurrentEvent_artist;
-export type CurrentEvent_artist$key = {
-    readonly " $data"?: CurrentEvent_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"CurrentEvent_artist">;
 };
 
 

--- a/src/__generated__/DefaultHeader_headerArtworks.graphql.ts
+++ b/src/__generated__/DefaultHeader_headerArtworks.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type DefaultHeader_headerArtworks = {
     readonly edges: ReadonlyArray<{
         readonly node: {
@@ -22,11 +21,6 @@ export type DefaultHeader_headerArtworks = {
         } | null;
     } | null> | null;
     readonly " $refType": "DefaultHeader_headerArtworks";
-};
-export type DefaultHeader_headerArtworks$data = DefaultHeader_headerArtworks;
-export type DefaultHeader_headerArtworks$key = {
-    readonly " $data"?: DefaultHeader_headerArtworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"DefaultHeader_headerArtworks">;
 };
 
 

--- a/src/__generated__/Details_artwork.graphql.ts
+++ b/src/__generated__/Details_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Details_artwork = {
     readonly href: string | null;
     readonly title: string | null;
@@ -34,11 +33,6 @@ export type Details_artwork = {
         } | null;
     } | null;
     readonly " $refType": "Details_artwork";
-};
-export type Details_artwork$data = Details_artwork;
-export type Details_artwork$key = {
-    readonly " $data"?: Details_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Details_artwork">;
 };
 
 

--- a/src/__generated__/Dropdown_aggregation.graphql.ts
+++ b/src/__generated__/Dropdown_aggregation.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Dropdown_aggregation = {
     readonly slice: ArtworkAggregation | null;
     readonly counts: ReadonlyArray<{
@@ -11,11 +10,6 @@ export type Dropdown_aggregation = {
         readonly count: number;
     } | null> | null;
     readonly " $refType": "Dropdown_aggregation";
-};
-export type Dropdown_aggregation$data = Dropdown_aggregation;
-export type Dropdown_aggregation$key = {
-    readonly " $data"?: Dropdown_aggregation$data;
-    readonly " $fragmentRefs": FragmentRefs<"Dropdown_aggregation">;
 };
 
 

--- a/src/__generated__/FeaturedCollectionsRails_collectionGroup.graphql.ts
+++ b/src/__generated__/FeaturedCollectionsRails_collectionGroup.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type FeaturedCollectionsRails_collectionGroup = {
     readonly groupType: MarketingGroupTypes;
     readonly name: string;
@@ -14,11 +13,6 @@ export type FeaturedCollectionsRails_collectionGroup = {
         readonly thumbnail: string | null;
     }>;
     readonly " $refType": "FeaturedCollectionsRails_collectionGroup";
-};
-export type FeaturedCollectionsRails_collectionGroup$data = FeaturedCollectionsRails_collectionGroup;
-export type FeaturedCollectionsRails_collectionGroup$key = {
-    readonly " $data"?: FeaturedCollectionsRails_collectionGroup$data;
-    readonly " $fragmentRefs": FragmentRefs<"FeaturedCollectionsRails_collectionGroup">;
 };
 
 

--- a/src/__generated__/FillwidthItem_artwork.graphql.ts
+++ b/src/__generated__/FillwidthItem_artwork.graphql.ts
@@ -11,11 +11,6 @@ export type FillwidthItem_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork" | "Save_artwork" | "Badge_artwork">;
     readonly " $refType": "FillwidthItem_artwork";
 };
-export type FillwidthItem_artwork$data = FillwidthItem_artwork;
-export type FillwidthItem_artwork$key = {
-    readonly " $data"?: FillwidthItem_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
-};
 
 
 

--- a/src/__generated__/FillwidthQuery.graphql.ts
+++ b/src/__generated__/FillwidthQuery.graphql.ts
@@ -31,6 +31,43 @@ query FillwidthQuery(
   }
 }
 
+fragment Fillwidth_artworks on ArtworkConnection {
+  edges {
+    node {
+      id
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...FillwidthItem_artwork
+    }
+  }
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -39,34 +76,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -107,41 +116,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Fillwidth_artworks on ArtworkConnection {
-  edges {
-    node {
-      id
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...FillwidthItem_artwork
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -555,7 +555,7 @@ return {
     "operationKind": "query",
     "name": "FillwidthQuery",
     "id": null,
-    "text": "query FillwidthQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 6) {\n      ...Fillwidth_artworks\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query FillwidthQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    artworks: artworksConnection(first: 6) {\n      ...Fillwidth_artworks\n    }\n    id\n  }\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Fillwidth_artworks.graphql.ts
+++ b/src/__generated__/Fillwidth_artworks.graphql.ts
@@ -14,11 +14,6 @@ export type Fillwidth_artworks = {
     } | null> | null;
     readonly " $refType": "Fillwidth_artworks";
 };
-export type Fillwidth_artworks$data = Fillwidth_artworks;
-export type Fillwidth_artworks$key = {
-    readonly " $data"?: Fillwidth_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"Fillwidth_artworks">;
-};
 
 
 

--- a/src/__generated__/FollowArtistButton_artist.graphql.ts
+++ b/src/__generated__/FollowArtistButton_artist.graphql.ts
@@ -13,11 +13,6 @@ export type FollowArtistButton_artist = {
     readonly " $fragmentRefs": FragmentRefs<"FollowArtistPopover_artist">;
     readonly " $refType": "FollowArtistButton_artist";
 };
-export type FollowArtistButton_artist$data = FollowArtistButton_artist;
-export type FollowArtistButton_artist$key = {
-    readonly " $data"?: FollowArtistButton_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
-};
 
 
 

--- a/src/__generated__/FollowArtistPopoverQuery.graphql.ts
+++ b/src/__generated__/FollowArtistPopoverQuery.graphql.ts
@@ -27,16 +27,6 @@ query FollowArtistPopoverQuery(
   }
 }
 
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
-}
-
 fragment FollowArtistPopover_artist on Artist {
   related {
     suggestedConnection(first: 3, excludeFollowedArtists: true) {
@@ -47,6 +37,16 @@ fragment FollowArtistPopover_artist on Artist {
           ...FollowArtistPopoverRow_artist
         }
       }
+    }
+  }
+}
+
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
     }
   }
 }
@@ -235,7 +235,7 @@ return {
     "operationKind": "query",
     "name": "FollowArtistPopoverQuery",
     "id": null,
-    "text": "query FollowArtistPopoverQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...FollowArtistPopover_artist\n    id\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query FollowArtistPopoverQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...FollowArtistPopover_artist\n    id\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/FollowArtistPopoverRow_artist.graphql.ts
+++ b/src/__generated__/FollowArtistPopoverRow_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type FollowArtistPopoverRow_artist = {
     readonly internalID: string;
     readonly name: string | null;
@@ -11,11 +10,6 @@ export type FollowArtistPopoverRow_artist = {
         } | null;
     } | null;
     readonly " $refType": "FollowArtistPopoverRow_artist";
-};
-export type FollowArtistPopoverRow_artist$data = FollowArtistPopoverRow_artist;
-export type FollowArtistPopoverRow_artist$key = {
-    readonly " $data"?: FollowArtistPopoverRow_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"FollowArtistPopoverRow_artist">;
 };
 
 

--- a/src/__generated__/FollowArtistPopover_Test_Query.graphql.ts
+++ b/src/__generated__/FollowArtistPopover_Test_Query.graphql.ts
@@ -49,16 +49,6 @@ query FollowArtistPopover_Test_Query(
   }
 }
 
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
-}
-
 fragment FollowArtistPopover_artist on Artist {
   related {
     suggestedConnection(first: 3, excludeFollowedArtists: true) {
@@ -69,6 +59,16 @@ fragment FollowArtistPopover_artist on Artist {
           ...FollowArtistPopoverRow_artist
         }
       }
+    }
+  }
+}
+
+fragment FollowArtistPopoverRow_artist on Artist {
+  internalID
+  name
+  image {
+    cropped(width: 45, height: 45) {
+      url
     }
   }
 }
@@ -257,7 +257,7 @@ return {
     "operationKind": "query",
     "name": "FollowArtistPopover_Test_Query",
     "id": null,
-    "text": "query FollowArtistPopover_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...FollowArtistPopover_artist\n    id\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query FollowArtistPopover_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...FollowArtistPopover_artist\n    id\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/FollowArtistPopover_artist.graphql.ts
+++ b/src/__generated__/FollowArtistPopover_artist.graphql.ts
@@ -16,11 +16,6 @@ export type FollowArtistPopover_artist = {
     } | null;
     readonly " $refType": "FollowArtistPopover_artist";
 };
-export type FollowArtistPopover_artist$data = FollowArtistPopover_artist;
-export type FollowArtistPopover_artist$key = {
-    readonly " $data"?: FollowArtistPopover_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"FollowArtistPopover_artist">;
-};
 
 
 

--- a/src/__generated__/FollowGeneButton_gene.graphql.ts
+++ b/src/__generated__/FollowGeneButton_gene.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type FollowGeneButton_gene = {
     readonly id: string;
     readonly internalID: string;
     readonly is_followed: boolean | null;
     readonly " $refType": "FollowGeneButton_gene";
-};
-export type FollowGeneButton_gene$data = FollowGeneButton_gene;
-export type FollowGeneButton_gene$key = {
-    readonly " $data"?: FollowGeneButton_gene$data;
-    readonly " $fragmentRefs": FragmentRefs<"FollowGeneButton_gene">;
 };
 
 

--- a/src/__generated__/FollowProfileButton_profile.graphql.ts
+++ b/src/__generated__/FollowProfileButton_profile.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type FollowProfileButton_profile = {
     readonly id: string;
     readonly internalID: string;
     readonly is_followed: boolean | null;
     readonly " $refType": "FollowProfileButton_profile";
-};
-export type FollowProfileButton_profile$data = FollowProfileButton_profile;
-export type FollowProfileButton_profile$key = {
-    readonly " $data"?: FollowProfileButton_profile$data;
-    readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
 };
 
 

--- a/src/__generated__/Follow_artist.graphql.ts
+++ b/src/__generated__/Follow_artist.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Follow_artist = {
     readonly id: string;
     readonly internalID: string;
     readonly is_followed: boolean | null;
     readonly " $refType": "Follow_artist";
-};
-export type Follow_artist$data = Follow_artist;
-export type Follow_artist$key = {
-    readonly " $data"?: Follow_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"Follow_artist">;
 };
 
 

--- a/src/__generated__/GeneArtworksPaginationQuery.graphql.ts
+++ b/src/__generated__/GeneArtworksPaginationQuery.graphql.ts
@@ -41,6 +41,56 @@ query GeneArtworksPaginationQuery(
   }
 }
 
+fragment GeneArtworks_gene_1QTmdc on Gene {
+  slug
+  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: $count, after: $cursor, sort: $sort) {
+    ...TotalCount_filter_artworks
+    aggregations {
+      slice
+      counts {
+        name
+        value
+      }
+      ...Dropdown_aggregation
+    }
+    id
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    facet {
+      __typename
+      ...Headline_facet
+      ... on Node {
+        id
+      }
+    }
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -59,6 +109,44 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment Headline_facet on ArtworkFilterFacet {
+  ... on Tag {
+    name
+  }
+  ... on Gene {
+    name
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -67,34 +155,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -135,91 +195,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-}
-
-fragment GeneArtworks_gene_1QTmdc on Gene {
-  slug
-  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: $count, after: $cursor, sort: $sort) {
-    ...TotalCount_filter_artworks
-    aggregations {
-      slice
-      counts {
-        name
-        value
-      }
-      ...Dropdown_aggregation
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    ...ArtworkGrid_artworks
-    edges {
-      node {
-        id
-        __typename
-      }
-      cursor
-    }
-    facet {
-      __typename
-      ...Headline_facet
-      ... on Node {
-        id
-      }
-    }
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Headline_facet on ArtworkFilterFacet {
-  ... on Tag {
-    name
-  }
-  ... on Gene {
-    name
-  }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
   }
 }
 */
@@ -895,7 +895,7 @@ return {
     "operationKind": "query",
     "name": "GeneArtworksPaginationQuery",
     "id": null,
-    "text": "query GeneArtworksPaginationQuery(\n  $geneID: String!\n  $count: Int!\n  $cursor: String\n  $sort: String\n  $priceRange: String\n  $dimensionRange: String\n  $medium: String\n  $forSale: Boolean\n) {\n  gene(id: $geneID) {\n    ...GeneArtworks_gene_1QTmdc\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment GeneArtworks_gene_1QTmdc on Gene {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: $count, after: $cursor, sort: $sort) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query GeneArtworksPaginationQuery(\n  $geneID: String!\n  $count: Int!\n  $cursor: String\n  $sort: String\n  $priceRange: String\n  $dimensionRange: String\n  $medium: String\n  $forSale: Boolean\n) {\n  gene(id: $geneID) {\n    ...GeneArtworks_gene_1QTmdc\n    id\n  }\n}\n\nfragment GeneArtworks_gene_1QTmdc on Gene {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: $count, after: $cursor, sort: $sort) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/GeneArtworks_gene.graphql.ts
+++ b/src/__generated__/GeneArtworks_gene.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type GeneArtworks_gene = {
     readonly slug: string;
     readonly filtered_artworks: {
@@ -30,11 +30,6 @@ export type GeneArtworks_gene = {
         readonly " $fragmentRefs": FragmentRefs<"TotalCount_filter_artworks" | "ArtworkGrid_artworks">;
     } | null;
     readonly " $refType": "GeneArtworks_gene";
-};
-export type GeneArtworks_gene$data = GeneArtworks_gene;
-export type GeneArtworks_gene$key = {
-    readonly " $data"?: GeneArtworks_gene$data;
-    readonly " $fragmentRefs": FragmentRefs<"GeneArtworks_gene">;
 };
 
 

--- a/src/__generated__/GeneContentsArtistsQuery.graphql.ts
+++ b/src/__generated__/GeneContentsArtistsQuery.graphql.ts
@@ -27,15 +27,6 @@ query GeneContentsArtistsQuery(
   }
 }
 
-fragment ArtistRow_artist on Artist {
-  name
-  href
-  ...Follow_artist
-  artworks: artworksConnection(first: 6) {
-    ...Fillwidth_artworks
-  }
-}
-
 fragment Artists_gene on Gene {
   id
   artists: artistsConnection(first: 10, after: "") {
@@ -62,6 +53,73 @@ fragment Artists_gene on Gene {
   }
 }
 
+fragment ArtistRow_artist on Artist {
+  name
+  href
+  ...Follow_artist
+  artworks: artworksConnection(first: 6) {
+    ...Fillwidth_artworks
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
+fragment Follow_artist on Artist {
+  id
+  internalID
+  is_followed: isFollowed
+}
+
+fragment Fillwidth_artworks on ArtworkConnection {
+  edges {
+    node {
+      id
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...FillwidthItem_artwork
+    }
+  }
+}
+
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -70,34 +128,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -138,61 +168,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
-  }
-}
-
-fragment FillwidthItem_artwork on Artwork {
-  image {
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Fillwidth_artworks on ArtworkConnection {
-  edges {
-    node {
-      id
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...FillwidthItem_artwork
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-  }
-}
-
-fragment Follow_artist on Artist {
-  id
-  internalID
-  is_followed: isFollowed
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
 }
 */
@@ -795,7 +795,7 @@ return {
     "operationKind": "query",
     "name": "GeneContentsArtistsQuery",
     "id": null,
-    "text": "query GeneContentsArtistsQuery(\n  $geneID: String!\n) {\n  gene(id: $geneID) {\n    ...Artists_gene\n    id\n  }\n}\n\nfragment ArtistRow_artist on Artist {\n  name\n  href\n  ...Follow_artist\n  artworks: artworksConnection(first: 6) {\n    ...Fillwidth_artworks\n  }\n}\n\nfragment Artists_gene on Gene {\n  id\n  artists: artistsConnection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ArtistRow_artist\n        __typename\n      }\n      cursor\n    }\n  }\n  filter_aggregations: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], size: 0, includeMediumFilterInAggregation: true) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      ...Dropdown_aggregation\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment Follow_artist on Artist {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query GeneContentsArtistsQuery(\n  $geneID: String!\n) {\n  gene(id: $geneID) {\n    ...Artists_gene\n    id\n  }\n}\n\nfragment Artists_gene on Gene {\n  id\n  artists: artistsConnection(first: 10, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ArtistRow_artist\n        __typename\n      }\n      cursor\n    }\n  }\n  filter_aggregations: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], size: 0, includeMediumFilterInAggregation: true) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      ...Dropdown_aggregation\n    }\n    id\n  }\n}\n\nfragment ArtistRow_artist on Artist {\n  name\n  href\n  ...Follow_artist\n  artworks: artworksConnection(first: 6) {\n    ...Fillwidth_artworks\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment Follow_artist on Artist {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment Fillwidth_artworks on ArtworkConnection {\n  edges {\n    node {\n      id\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...FillwidthItem_artwork\n    }\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/GeneContentsArtworksQuery.graphql.ts
+++ b/src/__generated__/GeneContentsArtworksQuery.graphql.ts
@@ -37,6 +37,56 @@ query GeneContentsArtworksQuery(
   }
 }
 
+fragment GeneArtworks_gene_4q9qzB on Gene {
+  slug
+  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: 10, after: "", sort: $sort) {
+    ...TotalCount_filter_artworks
+    aggregations {
+      slice
+      counts {
+        name
+        value
+      }
+      ...Dropdown_aggregation
+    }
+    id
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    facet {
+      __typename
+      ...Headline_facet
+      ... on Node {
+        id
+      }
+    }
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -55,6 +105,44 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment Headline_facet on ArtworkFilterFacet {
+  ... on Tag {
+    name
+  }
+  ... on Gene {
+    name
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -63,34 +151,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -131,91 +191,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-}
-
-fragment GeneArtworks_gene_4q9qzB on Gene {
-  slug
-  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: 10, after: "", sort: $sort) {
-    ...TotalCount_filter_artworks
-    aggregations {
-      slice
-      counts {
-        name
-        value
-      }
-      ...Dropdown_aggregation
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    ...ArtworkGrid_artworks
-    edges {
-      node {
-        id
-        __typename
-      }
-      cursor
-    }
-    facet {
-      __typename
-      ...Headline_facet
-      ... on Node {
-        id
-      }
-    }
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Headline_facet on ArtworkFilterFacet {
-  ... on Tag {
-    name
-  }
-  ... on Gene {
-    name
-  }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
   }
 }
 */
@@ -869,7 +869,7 @@ return {
     "operationKind": "query",
     "name": "GeneContentsArtworksQuery",
     "id": null,
-    "text": "query GeneContentsArtworksQuery(\n  $geneID: String!\n  $medium: String\n  $priceRange: String\n  $forSale: Boolean\n  $dimensionRange: String\n  $sort: String\n) {\n  gene(id: $geneID) {\n    ...GeneArtworks_gene_4q9qzB\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment GeneArtworks_gene_4q9qzB on Gene {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: 10, after: \"\", sort: $sort) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query GeneContentsArtworksQuery(\n  $geneID: String!\n  $medium: String\n  $priceRange: String\n  $forSale: Boolean\n  $dimensionRange: String\n  $sort: String\n) {\n  gene(id: $geneID) {\n    ...GeneArtworks_gene_4q9qzB\n    id\n  }\n}\n\nfragment GeneArtworks_gene_4q9qzB on Gene {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, includeMediumFilterInAggregation: true, first: 10, after: \"\", sort: $sort) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/GeneSearchResults_viewer.graphql.ts
+++ b/src/__generated__/GeneSearchResults_viewer.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type GeneSearchResults_viewer = {
     readonly match_gene: {
         readonly edges: ReadonlyArray<{
@@ -19,11 +18,6 @@ export type GeneSearchResults_viewer = {
         } | null> | null;
     } | null;
     readonly " $refType": "GeneSearchResults_viewer";
-};
-export type GeneSearchResults_viewer$data = GeneSearchResults_viewer;
-export type GeneSearchResults_viewer$key = {
-    readonly " $data"?: GeneSearchResults_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"GeneSearchResults_viewer">;
 };
 
 

--- a/src/__generated__/GeneToolTip_gene.graphql.ts
+++ b/src/__generated__/GeneToolTip_gene.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type GeneToolTip_gene = {
     readonly description: string | null;
     readonly href: string | null;
@@ -12,11 +11,6 @@ export type GeneToolTip_gene = {
     } | null;
     readonly name: string | null;
     readonly " $refType": "GeneToolTip_gene";
-};
-export type GeneToolTip_gene$data = GeneToolTip_gene;
-export type GeneToolTip_gene$key = {
-    readonly " $data"?: GeneToolTip_gene$data;
-    readonly " $fragmentRefs": FragmentRefs<"GeneToolTip_gene">;
 };
 
 

--- a/src/__generated__/Genes_artist.graphql.ts
+++ b/src/__generated__/Genes_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Genes_artist = {
     readonly related: {
         readonly genes: {
@@ -14,11 +13,6 @@ export type Genes_artist = {
         } | null;
     } | null;
     readonly " $refType": "Genes_artist";
-};
-export type Genes_artist$data = Genes_artist;
-export type Genes_artist$key = {
-    readonly " $data"?: Genes_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"Genes_artist">;
 };
 
 

--- a/src/__generated__/GridItem_artwork.graphql.ts
+++ b/src/__generated__/GridItem_artwork.graphql.ts
@@ -15,11 +15,6 @@ export type GridItem_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork" | "Save_artwork" | "Badge_artwork">;
     readonly " $refType": "GridItem_artwork";
 };
-export type GridItem_artwork$data = GridItem_artwork;
-export type GridItem_artwork$key = {
-    readonly " $data"?: GridItem_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
-};
 
 
 

--- a/src/__generated__/Header_artworks.graphql.ts
+++ b/src/__generated__/Header_artworks.graphql.ts
@@ -15,11 +15,6 @@ export type Header_artworks = {
     readonly " $fragmentRefs": FragmentRefs<"DefaultHeader_headerArtworks">;
     readonly " $refType": "Header_artworks";
 };
-export type Header_artworks$data = Header_artworks;
-export type Header_artworks$key = {
-    readonly " $data"?: Header_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"Header_artworks">;
-};
 
 
 

--- a/src/__generated__/Header_collection.graphql.ts
+++ b/src/__generated__/Header_collection.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Header_collection = {
     readonly category: string;
     readonly credit: string | null;
@@ -15,11 +14,6 @@ export type Header_collection = {
     readonly slug: string;
     readonly title: string;
     readonly " $refType": "Header_collection";
-};
-export type Header_collection$data = Header_collection;
-export type Header_collection$key = {
-    readonly " $data"?: Header_collection$data;
-    readonly " $fragmentRefs": FragmentRefs<"Header_collection">;
 };
 
 

--- a/src/__generated__/Headline_facet.graphql.ts
+++ b/src/__generated__/Headline_facet.graphql.ts
@@ -1,15 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Headline_facet = {
     readonly name?: string | null;
     readonly " $refType": "Headline_facet";
-};
-export type Headline_facet$data = Headline_facet;
-export type Headline_facet$key = {
-    readonly " $data"?: Headline_facet$data;
-    readonly " $fragmentRefs": FragmentRefs<"Headline_facet">;
 };
 
 

--- a/src/__generated__/InquiryArtworkQuery.graphql.ts
+++ b/src/__generated__/InquiryArtworkQuery.graphql.ts
@@ -27,6 +27,10 @@ query InquiryArtworkQuery(
   }
 }
 
+fragment InquiryArtwork_artwork on Artwork {
+  ...Artwork_artwork
+}
+
 fragment Artwork_artwork on Artwork {
   slug
   image {
@@ -36,32 +40,10 @@ fragment Artwork_artwork on Artwork {
   ...Metadata_artwork
 }
 
-fragment Contact_artwork on Artwork {
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
   href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
 }
 
 fragment Details_artwork on Artwork {
@@ -100,14 +82,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment InquiryArtwork_artwork on Artwork {
-  ...Artwork_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
+fragment Contact_artwork on Artwork {
   href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -420,7 +420,7 @@ return {
     "operationKind": "query",
     "name": "InquiryArtworkQuery",
     "id": null,
-    "text": "query InquiryArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...InquiryArtwork_artwork\n    id\n  }\n}\n\nfragment Artwork_artwork on Artwork {\n  slug\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  ...Metadata_artwork\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment InquiryArtwork_artwork on Artwork {\n  ...Artwork_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
+    "text": "query InquiryArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...InquiryArtwork_artwork\n    id\n  }\n}\n\nfragment InquiryArtwork_artwork on Artwork {\n  ...Artwork_artwork\n}\n\nfragment Artwork_artwork on Artwork {\n  slug\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  ...Metadata_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/InquiryArtwork_artwork.graphql.ts
+++ b/src/__generated__/InquiryArtwork_artwork.graphql.ts
@@ -6,11 +6,6 @@ export type InquiryArtwork_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Artwork_artwork">;
     readonly " $refType": "InquiryArtwork_artwork";
 };
-export type InquiryArtwork_artwork$data = InquiryArtwork_artwork;
-export type InquiryArtwork_artwork$key = {
-    readonly " $data"?: InquiryArtwork_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"InquiryArtwork_artwork">;
-};
 
 
 

--- a/src/__generated__/ItemReview_lineItem.graphql.ts
+++ b/src/__generated__/ItemReview_lineItem.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ItemReview_lineItem = {
     readonly artwork: {
         readonly artist_names: string | null;
@@ -30,11 +29,6 @@ export type ItemReview_lineItem = {
     } | null;
     readonly editionSetId: string | null;
     readonly " $refType": "ItemReview_lineItem";
-};
-export type ItemReview_lineItem$data = ItemReview_lineItem;
-export type ItemReview_lineItem$key = {
-    readonly " $data"?: ItemReview_lineItem$data;
-    readonly " $fragmentRefs": FragmentRefs<"ItemReview_lineItem">;
 };
 
 

--- a/src/__generated__/LotInfo_artwork.graphql.ts
+++ b/src/__generated__/LotInfo_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type LotInfo_artwork = {
     readonly internalID: string;
     readonly date: string | null;
@@ -9,11 +8,6 @@ export type LotInfo_artwork = {
     readonly imageUrl: string | null;
     readonly artistNames: string | null;
     readonly " $refType": "LotInfo_artwork";
-};
-export type LotInfo_artwork$data = LotInfo_artwork;
-export type LotInfo_artwork$key = {
-    readonly " $data"?: LotInfo_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"LotInfo_artwork">;
 };
 
 

--- a/src/__generated__/LotInfo_saleArtwork.graphql.ts
+++ b/src/__generated__/LotInfo_saleArtwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type LotInfo_saleArtwork = {
     readonly counts: {
         readonly bidderPositions: number | null;
@@ -13,11 +12,6 @@ export type LotInfo_saleArtwork = {
         readonly display: string | null;
     } | null;
     readonly " $refType": "LotInfo_saleArtwork";
-};
-export type LotInfo_saleArtwork$data = LotInfo_saleArtwork;
-export type LotInfo_saleArtwork$key = {
-    readonly " $data"?: LotInfo_saleArtwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"LotInfo_saleArtwork">;
 };
 
 

--- a/src/__generated__/MarketDataSummary_artist.graphql.ts
+++ b/src/__generated__/MarketDataSummary_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type MarketDataSummary_artist = {
     readonly internalID: string;
     readonly collections: ReadonlyArray<string | null> | null;
@@ -26,11 +25,6 @@ export type MarketDataSummary_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "MarketDataSummary_artist";
-};
-export type MarketDataSummary_artist$data = MarketDataSummary_artist;
-export type MarketDataSummary_artist$key = {
-    readonly " $data"?: MarketDataSummary_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"MarketDataSummary_artist">;
 };
 
 

--- a/src/__generated__/MarketInsights_artist.graphql.ts
+++ b/src/__generated__/MarketInsights_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type MarketInsights_artist = {
     readonly internalID: string;
     readonly collections: ReadonlyArray<string | null> | null;
@@ -26,11 +25,6 @@ export type MarketInsights_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "MarketInsights_artist";
-};
-export type MarketInsights_artist$data = MarketInsights_artist;
-export type MarketInsights_artist$key = {
-    readonly " $data"?: MarketInsights_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"MarketInsights_artist">;
 };
 
 

--- a/src/__generated__/Metadata_artwork.graphql.ts
+++ b/src/__generated__/Metadata_artwork.graphql.ts
@@ -7,11 +7,6 @@ export type Metadata_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"Details_artwork" | "Contact_artwork">;
     readonly " $refType": "Metadata_artwork";
 };
-export type Metadata_artwork$data = Metadata_artwork;
-export type Metadata_artwork$key = {
-    readonly " $data"?: Metadata_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork">;
-};
 
 
 

--- a/src/__generated__/MockRelayRendererFixtures_artist.graphql.ts
+++ b/src/__generated__/MockRelayRendererFixtures_artist.graphql.ts
@@ -1,15 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type MockRelayRendererFixtures_artist = {
     readonly name: string | null;
     readonly " $refType": "MockRelayRendererFixtures_artist";
-};
-export type MockRelayRendererFixtures_artist$data = MockRelayRendererFixtures_artist;
-export type MockRelayRendererFixtures_artist$key = {
-    readonly " $data"?: MockRelayRendererFixtures_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"MockRelayRendererFixtures_artist">;
 };
 
 

--- a/src/__generated__/MockRelayRendererFixtures_artwork.graphql.ts
+++ b/src/__generated__/MockRelayRendererFixtures_artwork.graphql.ts
@@ -12,11 +12,6 @@ export type MockRelayRendererFixtures_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"MockRelayRendererFixtures_artworkMetadata">;
     readonly " $refType": "MockRelayRendererFixtures_artwork";
 };
-export type MockRelayRendererFixtures_artwork$data = MockRelayRendererFixtures_artwork;
-export type MockRelayRendererFixtures_artwork$key = {
-    readonly " $data"?: MockRelayRendererFixtures_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"MockRelayRendererFixtures_artwork">;
-};
 
 
 

--- a/src/__generated__/MockRelayRendererFixtures_artworkMetadata.graphql.ts
+++ b/src/__generated__/MockRelayRendererFixtures_artworkMetadata.graphql.ts
@@ -1,15 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type MockRelayRendererFixtures_artworkMetadata = {
     readonly title: string | null;
     readonly " $refType": "MockRelayRendererFixtures_artworkMetadata";
-};
-export type MockRelayRendererFixtures_artworkMetadata$data = MockRelayRendererFixtures_artworkMetadata;
-export type MockRelayRendererFixtures_artworkMetadata$key = {
-    readonly " $data"?: MockRelayRendererFixtures_artworkMetadata$data;
-    readonly " $fragmentRefs": FragmentRefs<"MockRelayRendererFixtures_artworkMetadata">;
 };
 
 

--- a/src/__generated__/NavigationTabs_artist.graphql.ts
+++ b/src/__generated__/NavigationTabs_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type NavigationTabs_artist = {
     readonly slug: string;
     readonly statuses: {
@@ -11,11 +10,6 @@ export type NavigationTabs_artist = {
         readonly auction_lots: boolean | null;
     } | null;
     readonly " $refType": "NavigationTabs_artist";
-};
-export type NavigationTabs_artist$data = NavigationTabs_artist;
-export type NavigationTabs_artist$key = {
-    readonly " $data"?: NavigationTabs_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_artist">;
 };
 
 

--- a/src/__generated__/NavigationTabs_searchableConnection.graphql.ts
+++ b/src/__generated__/NavigationTabs_searchableConnection.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type SearchAggregation = "TYPE" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type NavigationTabs_searchableConnection = {
     readonly aggregations: ReadonlyArray<{
         readonly slice: SearchAggregation | null;
@@ -12,11 +11,6 @@ export type NavigationTabs_searchableConnection = {
         } | null> | null;
     } | null> | null;
     readonly " $refType": "NavigationTabs_searchableConnection";
-};
-export type NavigationTabs_searchableConnection$data = NavigationTabs_searchableConnection;
-export type NavigationTabs_searchableConnection$key = {
-    readonly " $data"?: NavigationTabs_searchableConnection$data;
-    readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_searchableConnection">;
 };
 
 

--- a/src/__generated__/NewPaymentTestQuery.graphql.ts
+++ b/src/__generated__/NewPaymentTestQuery.graphql.ts
@@ -234,40 +234,6 @@ query NewPaymentTestQuery {
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment NewPayment_me on Me {
   ...PaymentPicker_me
 }
@@ -302,21 +268,6 @@ fragment NewPayment_order on CommerceOrder {
   ...PaymentPicker_order
   ...ArtworkSummaryItem_order
   ...TransactionDetailsSummaryItem_order
-}
-
-fragment PaymentPicker_me on Me {
-  creditCards(first: 100) {
-    edges {
-      node {
-        internalID
-        brand
-        lastDigits
-        expirationMonth
-        expirationYear
-        id
-      }
-    }
-  }
 }
 
 fragment PaymentPicker_order on CommerceOrder {
@@ -366,6 +317,40 @@ fragment PaymentPicker_order on CommerceOrder {
   }
 }
 
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -404,6 +389,21 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       fromParticipant
       note
       id
+    }
+  }
+}
+
+fragment PaymentPicker_me on Me {
+  creditCards(first: 100) {
+    edges {
+      node {
+        internalID
+        brand
+        lastDigits
+        expirationMonth
+        expirationYear
+        id
+      }
     }
   }
 }
@@ -1038,7 +1038,7 @@ return {
     "operationKind": "query",
     "name": "NewPaymentTestQuery",
     "id": null,
-    "text": "query NewPaymentTestQuery {\n  me {\n    ...NewPayment_me\n    id\n  }\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...NewPayment_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NewPayment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment NewPayment_order on CommerceOrder {\n  internalID\n  mode\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query NewPaymentTestQuery {\n  me {\n    ...NewPayment_me\n    id\n  }\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...NewPayment_order\n    id\n  }\n}\n\nfragment NewPayment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment NewPayment_order on CommerceOrder {\n  internalID\n  mode\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/NewPayment_me.graphql.ts
+++ b/src/__generated__/NewPayment_me.graphql.ts
@@ -6,11 +6,6 @@ export type NewPayment_me = {
     readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_me">;
     readonly " $refType": "NewPayment_me";
 };
-export type NewPayment_me$data = NewPayment_me;
-export type NewPayment_me$key = {
-    readonly " $data"?: NewPayment_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"NewPayment_me">;
-};
 
 
 

--- a/src/__generated__/NewPayment_order.graphql.ts
+++ b/src/__generated__/NewPayment_order.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type NewPayment_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -26,11 +26,6 @@ export type NewPayment_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_order" | "ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order">;
     readonly " $refType": "NewPayment_order";
-};
-export type NewPayment_order$data = NewPayment_order;
-export type NewPayment_order$key = {
-    readonly " $data"?: NewPayment_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"NewPayment_order">;
 };
 
 

--- a/src/__generated__/OfferHistoryItem_order.graphql.ts
+++ b/src/__generated__/OfferHistoryItem_order.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type OfferHistoryItem_order = {
     readonly totalListPrice: string | null;
     readonly offers?: {
@@ -24,11 +23,6 @@ export type OfferHistoryItem_order = {
         readonly note: string | null;
     } | null;
     readonly " $refType": "OfferHistoryItem_order";
-};
-export type OfferHistoryItem_order$data = OfferHistoryItem_order;
-export type OfferHistoryItem_order$key = {
-    readonly " $data"?: OfferHistoryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"OfferHistoryItem_order">;
 };
 
 

--- a/src/__generated__/OfferSummaryItem_order.graphql.ts
+++ b/src/__generated__/OfferSummaryItem_order.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type OfferSummaryItem_order = {
     readonly totalListPrice: string | null;
     readonly myLastOffer?: {
@@ -9,11 +8,6 @@ export type OfferSummaryItem_order = {
         readonly note: string | null;
     } | null;
     readonly " $refType": "OfferSummaryItem_order";
-};
-export type OfferSummaryItem_order$data = OfferSummaryItem_order;
-export type OfferSummaryItem_order$key = {
-    readonly " $data"?: OfferSummaryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"OfferSummaryItem_order">;
 };
 
 

--- a/src/__generated__/OfferTestQuery.graphql.ts
+++ b/src/__generated__/OfferTestQuery.graphql.ts
@@ -145,6 +145,28 @@ query OfferTestQuery {
   }
 }
 
+fragment Offer_order on CommerceOrder {
+  internalID
+  mode
+  state
+  totalListPrice(precision: 2)
+  totalListPriceCents
+  currencyCode
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ...ArtworkSummaryItem_order
+  ...TransactionDetailsSummaryItem_order
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -177,28 +199,6 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
       }
     }
   }
-}
-
-fragment Offer_order on CommerceOrder {
-  internalID
-  mode
-  state
-  totalListPrice(precision: 2)
-  totalListPriceCents
-  currencyCode
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ...ArtworkSummaryItem_order
-  ...TransactionDetailsSummaryItem_order
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -626,7 +626,7 @@ return {
     "operationKind": "query",
     "name": "OfferTestQuery",
     "id": null,
-    "text": "query OfferTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  internalID\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query OfferTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  internalID\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Offer_order.graphql.ts
+++ b/src/__generated__/Offer_order.graphql.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Offer_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -22,11 +22,6 @@ export type Offer_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order">;
     readonly " $refType": "Offer_order";
-};
-export type Offer_order$data = Offer_order;
-export type Offer_order$key = {
-    readonly " $data"?: Offer_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Offer_order">;
 };
 
 

--- a/src/__generated__/OrderApp_order.graphql.ts
+++ b/src/__generated__/OrderApp_order.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type OrderApp_order = {
     readonly mode: CommerceOrderModeEnum | null;
     readonly lineItems: {
@@ -17,11 +16,6 @@ export type OrderApp_order = {
         } | null> | null;
     } | null;
     readonly " $refType": "OrderApp_order";
-};
-export type OrderApp_order$data = OrderApp_order;
-export type OrderApp_order$key = {
-    readonly " $data"?: OrderApp_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"OrderApp_order">;
 };
 
 

--- a/src/__generated__/OtherAuctionsQuery.graphql.ts
+++ b/src/__generated__/OtherAuctionsQuery.graphql.ts
@@ -29,6 +29,15 @@ query OtherAuctionsQuery(
   }
 }
 
+fragment OtherAuctions_salesConnection on SaleConnection {
+  edges {
+    node {
+      ...AuctionCard_sale
+      id
+    }
+  }
+}
+
 fragment AuctionCard_sale on Sale {
   cover_image: coverImage {
     cropped(width: 200, height: 180) {
@@ -54,15 +63,6 @@ fragment AuctionCard_sale on Sale {
   partner {
     name
     id
-  }
-}
-
-fragment OtherAuctions_salesConnection on SaleConnection {
-  edges {
-    node {
-      ...AuctionCard_sale
-      id
-    }
   }
 }
 */
@@ -330,7 +330,7 @@ return {
     "operationKind": "query",
     "name": "OtherAuctionsQuery",
     "id": null,
-    "text": "query OtherAuctionsQuery(\n  $first: Int\n  $sort: SaleSorts\n) {\n  salesConnection(first: $first, sort: $sort) {\n    ...OtherAuctions_salesConnection\n  }\n}\n\nfragment AuctionCard_sale on Sale {\n  cover_image: coverImage {\n    cropped(width: 200, height: 180) {\n      url\n    }\n  }\n  isBenefit\n  isGalleryAuction\n  end_at: endAt\n  href\n  slug\n  is_live_open: isLiveOpen\n  is_preview: isPreview\n  live_start_at: liveStartAt\n  registrationStatus {\n    internalID\n    id\n  }\n  is_registration_closed: isRegistrationClosed\n  name\n  start_at: startAt\n  is_closed: isClosed\n  partner {\n    name\n    id\n  }\n}\n\nfragment OtherAuctions_salesConnection on SaleConnection {\n  edges {\n    node {\n      ...AuctionCard_sale\n      id\n    }\n  }\n}\n",
+    "text": "query OtherAuctionsQuery(\n  $first: Int\n  $sort: SaleSorts\n) {\n  salesConnection(first: $first, sort: $sort) {\n    ...OtherAuctions_salesConnection\n  }\n}\n\nfragment OtherAuctions_salesConnection on SaleConnection {\n  edges {\n    node {\n      ...AuctionCard_sale\n      id\n    }\n  }\n}\n\nfragment AuctionCard_sale on Sale {\n  cover_image: coverImage {\n    cropped(width: 200, height: 180) {\n      url\n    }\n  }\n  isBenefit\n  isGalleryAuction\n  end_at: endAt\n  href\n  slug\n  is_live_open: isLiveOpen\n  is_preview: isPreview\n  live_start_at: liveStartAt\n  registrationStatus {\n    internalID\n    id\n  }\n  is_registration_closed: isRegistrationClosed\n  name\n  start_at: startAt\n  is_closed: isClosed\n  partner {\n    name\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/OtherAuctionsStoryQuery.graphql.ts
+++ b/src/__generated__/OtherAuctionsStoryQuery.graphql.ts
@@ -26,6 +26,15 @@ query OtherAuctionsStoryQuery(
   }
 }
 
+fragment OtherAuctions_salesConnection on SaleConnection {
+  edges {
+    node {
+      ...AuctionCard_sale
+      id
+    }
+  }
+}
+
 fragment AuctionCard_sale on Sale {
   cover_image: coverImage {
     cropped(width: 200, height: 180) {
@@ -51,15 +60,6 @@ fragment AuctionCard_sale on Sale {
   partner {
     name
     id
-  }
-}
-
-fragment OtherAuctions_salesConnection on SaleConnection {
-  edges {
-    node {
-      ...AuctionCard_sale
-      id
-    }
   }
 }
 */
@@ -321,7 +321,7 @@ return {
     "operationKind": "query",
     "name": "OtherAuctionsStoryQuery",
     "id": null,
-    "text": "query OtherAuctionsStoryQuery(\n  $size: Int!\n) {\n  salesConnection(first: $size, sort: TIMELY_AT_NAME_ASC) {\n    ...OtherAuctions_salesConnection\n  }\n}\n\nfragment AuctionCard_sale on Sale {\n  cover_image: coverImage {\n    cropped(width: 200, height: 180) {\n      url\n    }\n  }\n  isBenefit\n  isGalleryAuction\n  end_at: endAt\n  href\n  slug\n  is_live_open: isLiveOpen\n  is_preview: isPreview\n  live_start_at: liveStartAt\n  registrationStatus {\n    internalID\n    id\n  }\n  is_registration_closed: isRegistrationClosed\n  name\n  start_at: startAt\n  is_closed: isClosed\n  partner {\n    name\n    id\n  }\n}\n\nfragment OtherAuctions_salesConnection on SaleConnection {\n  edges {\n    node {\n      ...AuctionCard_sale\n      id\n    }\n  }\n}\n",
+    "text": "query OtherAuctionsStoryQuery(\n  $size: Int!\n) {\n  salesConnection(first: $size, sort: TIMELY_AT_NAME_ASC) {\n    ...OtherAuctions_salesConnection\n  }\n}\n\nfragment OtherAuctions_salesConnection on SaleConnection {\n  edges {\n    node {\n      ...AuctionCard_sale\n      id\n    }\n  }\n}\n\nfragment AuctionCard_sale on Sale {\n  cover_image: coverImage {\n    cropped(width: 200, height: 180) {\n      url\n    }\n  }\n  isBenefit\n  isGalleryAuction\n  end_at: endAt\n  href\n  slug\n  is_live_open: isLiveOpen\n  is_preview: isPreview\n  live_start_at: liveStartAt\n  registrationStatus {\n    internalID\n    id\n  }\n  is_registration_closed: isRegistrationClosed\n  name\n  start_at: startAt\n  is_closed: isClosed\n  partner {\n    name\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/OtherAuctions_salesConnection.graphql.ts
+++ b/src/__generated__/OtherAuctions_salesConnection.graphql.ts
@@ -10,11 +10,6 @@ export type OtherAuctions_salesConnection = {
     } | null> | null;
     readonly " $refType": "OtherAuctions_salesConnection";
 };
-export type OtherAuctions_salesConnection$data = OtherAuctions_salesConnection;
-export type OtherAuctions_salesConnection$key = {
-    readonly " $data"?: OtherAuctions_salesConnection$data;
-    readonly " $fragmentRefs": FragmentRefs<"OtherAuctions_salesConnection">;
-};
 
 
 

--- a/src/__generated__/OtherCollectionEntity_member.graphql.ts
+++ b/src/__generated__/OtherCollectionEntity_member.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type OtherCollectionEntity_member = {
     readonly slug: string;
     readonly thumbnail: string | null;
     readonly title: string;
     readonly " $refType": "OtherCollectionEntity_member";
-};
-export type OtherCollectionEntity_member$data = OtherCollectionEntity_member;
-export type OtherCollectionEntity_member$key = {
-    readonly " $data"?: OtherCollectionEntity_member$data;
-    readonly " $fragmentRefs": FragmentRefs<"OtherCollectionEntity_member">;
 };
 
 

--- a/src/__generated__/OtherCollectionsRail_collectionGroup.graphql.ts
+++ b/src/__generated__/OtherCollectionsRail_collectionGroup.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type MarketingGroupTypes = "ArtistSeries" | "FeaturedCollections" | "OtherCollections" | "%future added value";
 export type OtherCollectionsRail_collectionGroup = {
     readonly groupType: MarketingGroupTypes;
     readonly name: string;
@@ -10,11 +10,6 @@ export type OtherCollectionsRail_collectionGroup = {
         readonly " $fragmentRefs": FragmentRefs<"OtherCollectionEntity_member">;
     }>;
     readonly " $refType": "OtherCollectionsRail_collectionGroup";
-};
-export type OtherCollectionsRail_collectionGroup$data = OtherCollectionsRail_collectionGroup;
-export type OtherCollectionsRail_collectionGroup$key = {
-    readonly " $data"?: OtherCollectionsRail_collectionGroup$data;
-    readonly " $fragmentRefs": FragmentRefs<"OtherCollectionsRail_collectionGroup">;
 };
 
 

--- a/src/__generated__/OtherWorksQuery.graphql.ts
+++ b/src/__generated__/OtherWorksQuery.graphql.ts
@@ -27,6 +27,40 @@ query OtherWorksQuery(
   }
 }
 
+fragment OtherWorks_artwork on Artwork {
+  contextGrids {
+    __typename
+    title
+    ctaTitle
+    ctaHref
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+  }
+  ...RelatedWorksArtworkGrid_artwork
+  slug
+  internalID
+  sale {
+    is_closed: isClosed
+    id
+  }
+  context {
+    __typename
+    ... on Node {
+      id
+    }
+    ... on Fair {
+      id
+    }
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -45,6 +79,57 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment RelatedWorksArtworkGrid_artwork on Artwork {
+  layers {
+    name
+    internalID
+    id
+  }
+  slug
+  layer {
+    name
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+    id
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -53,34 +138,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -121,89 +178,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment OtherWorks_artwork on Artwork {
-  contextGrids {
-    __typename
-    title
-    ctaTitle
-    ctaHref
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
-    }
-  }
-  ...RelatedWorksArtworkGrid_artwork
-  slug
-  internalID
+  is_inquireable: isInquireable
   sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
     is_closed: isClosed
     id
   }
-  context {
-    __typename
-    ... on Node {
-      id
-    }
-    ... on Fair {
-      id
-    }
-  }
-}
-
-fragment RelatedWorksArtworkGrid_artwork on Artwork {
-  layers {
-    name
-    internalID
+  partner(shallow: true) {
+    type
     id
   }
-  slug
-  layer {
-    name
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -716,7 +716,7 @@ return {
     "operationKind": "query",
     "name": "OtherWorksQuery",
     "id": null,
-    "text": "query OtherWorksQuery(\n  $artworkSlug: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...OtherWorks_artwork\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n    ... on Fair {\n      id\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query OtherWorksQuery(\n  $artworkSlug: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...OtherWorks_artwork\n    id\n  }\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n    ... on Fair {\n      id\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/OtherWorks_artwork.graphql.ts
+++ b/src/__generated__/OtherWorks_artwork.graphql.ts
@@ -28,11 +28,6 @@ export type OtherWorks_artwork = {
     readonly " $fragmentRefs": FragmentRefs<"RelatedWorksArtworkGrid_artwork">;
     readonly " $refType": "OtherWorks_artwork";
 };
-export type OtherWorks_artwork$data = OtherWorks_artwork;
-export type OtherWorks_artwork$key = {
-    readonly " $data"?: OtherWorks_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"OtherWorks_artwork">;
-};
 
 
 

--- a/src/__generated__/OverviewQuery.graphql.ts
+++ b/src/__generated__/OverviewQuery.graphql.ts
@@ -258,242 +258,6 @@ query OverviewQuery(
   }
 }
 
-fragment ArtistArtworkFilter_artist_3V5iLs on Artist {
-  is_followed: isFollowed
-  counts {
-    partner_shows: partnerShows
-    for_sale_artworks: forSaleArtworks
-    ecommerce_artworks: ecommerceArtworks
-    auction_artworks: auctionArtworks
-    artworks
-    has_make_offer_artworks: hasMakeOfferArtworks
-  }
-  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: "", sort: $sort, width: $width) {
-    id
-    ...ArtworkFilterArtworkGrid2_filtered_artworks
-  }
-}
-
-fragment ArtistBio_bio on Artist {
-  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
-    text
-  }
-}
-
-fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
-  id
-  aggregations {
-    slice
-    counts {
-      value
-      name
-      count
-    }
-  }
-  pageInfo {
-    hasNextPage
-    endCursor
-  }
-  pageCursors {
-    ...Pagination_pageCursors
-  }
-  edges {
-    node {
-      id
-    }
-  }
-  ...ArtworkGrid_artworks
-}
-
-fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
-  edges {
-    __typename
-    node {
-      id
-      slug
-      href
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...GridItem_artwork
-    }
-    ... on Node {
-      id
-    }
-  }
-}
-
-fragment Badge_artwork on Artwork {
-  is_biddable: isBiddable
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-  href
-  sale {
-    is_preview: isPreview
-    display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
-}
-
-fragment CurrentEvent_artist on Artist {
-  currentEvent {
-    event {
-      __typename
-      ... on Node {
-        id
-      }
-    }
-    image {
-      resized(width: 300) {
-        url
-      }
-    }
-    name
-    status
-    details
-    partner
-    href
-  }
-}
-
-fragment Details_artwork on Artwork {
-  href
-  title
-  date
-  sale_message: saleMessage
-  cultural_maker: culturalMaker
-  artists(shallow: true) {
-    id
-    href
-    name
-  }
-  collecting_institution: collectingInstitution
-  partner(shallow: true) {
-    name
-    href
-    id
-  }
-  sale {
-    is_auction: isAuction
-    is_closed: isClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    counts {
-      bidder_positions: bidderPositions
-    }
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    id
-  }
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
-  }
-}
-
-fragment Genes_artist on Artist {
-  related {
-    genes {
-      edges {
-        node {
-          href
-          name
-          id
-        }
-      }
-    }
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment MarketInsights_artist on Artist {
-  internalID
-  collections
-  highlights {
-    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
-      edges {
-        node {
-          categories {
-            slug
-            id
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
-    edges {
-      node {
-        price_realized: priceRealized {
-          display(format: "0a")
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
 fragment Overview_artist_3V5iLs on Artist {
   ...ArtistBio_bio
   ...CurrentEvent_artist
@@ -569,34 +333,60 @@ fragment Overview_artist_3V5iLs on Artist {
   ...ArtistArtworkFilter_artist_3V5iLs
 }
 
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
+fragment ArtistBio_bio on Artist {
+  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
+    text
   }
 }
 
-fragment Save_artwork on Artwork {
-  id
+fragment CurrentEvent_artist on Artist {
+  currentEvent {
+    event {
+      __typename
+      ... on Node {
+        id
+      }
+    }
+    image {
+      resized(width: 300) {
+        url
+      }
+    }
+    name
+    status
+    details
+    partner
+    href
+  }
+}
+
+fragment MarketInsights_artist on Artist {
   internalID
-  slug
-  is_saved: isSaved
-  title
+  collections
+  highlights {
+    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            slug
+            id
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
+    edges {
+      node {
+        price_realized: priceRealized {
+          display(format: "0a")
+        }
+        id
+      }
+    }
+  }
 }
 
 fragment SelectedCareerAchievements_artist on Artist {
@@ -630,6 +420,216 @@ fragment SelectedCareerAchievements_artist on Artist {
         id
       }
     }
+  }
+}
+
+fragment Genes_artist on Artist {
+  related {
+    genes {
+      edges {
+        node {
+          href
+          name
+          id
+        }
+      }
+    }
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment ArtistArtworkFilter_artist_3V5iLs on Artist {
+  is_followed: isFollowed
+  counts {
+    partner_shows: partnerShows
+    for_sale_artworks: forSaleArtworks
+    ecommerce_artworks: ecommerceArtworks
+    auction_artworks: auctionArtworks
+    artworks
+    has_make_offer_artworks: hasMakeOfferArtworks
+  }
+  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: "", sort: $sort, width: $width) {
+    id
+    ...ArtworkFilterArtworkGrid2_filtered_artworks
+  }
+}
+
+fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
+  id
+  aggregations {
+    slice
+    counts {
+      value
+      name
+      count
+    }
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
   }
 }
 */
@@ -1995,7 +1995,7 @@ return {
     "operationKind": "query",
     "name": "OverviewQuery",
     "id": null,
-    "text": "query OverviewQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3V5iLs\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_3V5iLs on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment MarketInsights_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Overview_artist_3V5iLs on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsights_artist\n  ...SelectedCareerAchievements_artist\n  ...Genes_artist\n  ...FollowArtistButton_artist\n  slug\n  id\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  href\n  is_consignable: isConsignable\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  sidebarAggregations: filterArtworksConnection(sort: $sort, page: $page, aggregations: $aggregations, first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_3V5iLs\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query OverviewQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...Overview_artist_3V5iLs\n    id\n  }\n}\n\nfragment Overview_artist_3V5iLs on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsights_artist\n  ...SelectedCareerAchievements_artist\n  ...Genes_artist\n  ...FollowArtistButton_artist\n  slug\n  id\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  href\n  is_consignable: isConsignable\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n    credit\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  sidebarAggregations: filterArtworksConnection(sort: $sort, page: $page, aggregations: $aggregations, first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_3V5iLs\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n}\n\nfragment MarketInsights_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment ArtistArtworkFilter_artist_3V5iLs on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Overview_artist = {
     readonly slug: string;
     readonly id: string;
@@ -66,11 +66,6 @@ export type Overview_artist = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtistBio_bio" | "CurrentEvent_artist" | "MarketInsights_artist" | "SelectedCareerAchievements_artist" | "Genes_artist" | "FollowArtistButton_artist" | "ArtistArtworkFilter_artist">;
     readonly " $refType": "Overview_artist";
-};
-export type Overview_artist$data = Overview_artist;
-export type Overview_artist$key = {
-    readonly " $data"?: Overview_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"Overview_artist">;
 };
 
 

--- a/src/__generated__/Pagination_pageCursors.graphql.ts
+++ b/src/__generated__/Pagination_pageCursors.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Pagination_pageCursors = {
     readonly around: ReadonlyArray<{
         readonly cursor: string;
@@ -23,11 +22,6 @@ export type Pagination_pageCursors = {
         readonly page: number;
     } | null;
     readonly " $refType": "Pagination_pageCursors";
-};
-export type Pagination_pageCursors$data = Pagination_pageCursors;
-export type Pagination_pageCursors$key = {
-    readonly " $data"?: Pagination_pageCursors$data;
-    readonly " $fragmentRefs": FragmentRefs<"Pagination_pageCursors">;
 };
 
 

--- a/src/__generated__/PaymentPicker_me.graphql.ts
+++ b/src/__generated__/PaymentPicker_me.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type PaymentPicker_me = {
     readonly creditCards: {
         readonly edges: ReadonlyArray<{
@@ -15,11 +14,6 @@ export type PaymentPicker_me = {
         } | null> | null;
     } | null;
     readonly " $refType": "PaymentPicker_me";
-};
-export type PaymentPicker_me$data = PaymentPicker_me;
-export type PaymentPicker_me$key = {
-    readonly " $data"?: PaymentPicker_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_me">;
 };
 
 

--- a/src/__generated__/PaymentPicker_order.graphql.ts
+++ b/src/__generated__/PaymentPicker_order.graphql.ts
@@ -3,7 +3,6 @@
 import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type PaymentPicker_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -49,11 +48,6 @@ export type PaymentPicker_order = {
         } | null> | null;
     } | null;
     readonly " $refType": "PaymentPicker_order";
-};
-export type PaymentPicker_order$data = PaymentPicker_order;
-export type PaymentPicker_order$key = {
-    readonly " $data"?: PaymentPicker_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_order">;
 };
 
 

--- a/src/__generated__/PaymentTestQuery.graphql.ts
+++ b/src/__generated__/PaymentTestQuery.graphql.ts
@@ -223,53 +223,27 @@ query PaymentTestQuery {
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
+fragment Payment_me on Me {
+  ...PaymentPicker_me
+}
+
+fragment Payment_order on CommerceOrder {
+  internalID
+  mode
   lineItems {
     edges {
       node {
         artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
+          slug
           id
         }
         id
       }
     }
   }
-}
-
-fragment PaymentPicker_me on Me {
-  creditCards(first: 100) {
-    edges {
-      node {
-        internalID
-        brand
-        lastDigits
-        expirationMonth
-        expirationYear
-        id
-      }
-    }
-  }
+  ...PaymentPicker_order
+  ...ArtworkSummaryItem_order
+  ...TransactionDetailsSummaryItem_order
 }
 
 fragment PaymentPicker_order on CommerceOrder {
@@ -319,27 +293,38 @@ fragment PaymentPicker_order on CommerceOrder {
   }
 }
 
-fragment Payment_me on Me {
-  ...PaymentPicker_me
-}
-
-fragment Payment_order on CommerceOrder {
-  internalID
-  mode
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
   lineItems {
     edges {
       node {
         artwork {
-          slug
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
           id
         }
         id
       }
     }
   }
-  ...PaymentPicker_order
-  ...ArtworkSummaryItem_order
-  ...TransactionDetailsSummaryItem_order
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -380,6 +365,21 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       fromParticipant
       note
       id
+    }
+  }
+}
+
+fragment PaymentPicker_me on Me {
+  creditCards(first: 100) {
+    edges {
+      node {
+        internalID
+        brand
+        lastDigits
+        expirationMonth
+        expirationYear
+        id
+      }
     }
   }
 }
@@ -969,7 +969,7 @@ return {
     "operationKind": "query",
     "name": "PaymentTestQuery",
     "id": null,
-    "text": "query PaymentTestQuery {\n  me {\n    ...Payment_me\n    id\n  }\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Payment_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Payment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment Payment_order on CommerceOrder {\n  internalID\n  mode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query PaymentTestQuery {\n  me {\n    ...Payment_me\n    id\n  }\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Payment_order\n    id\n  }\n}\n\nfragment Payment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment Payment_order on CommerceOrder {\n  internalID\n  mode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Payment_me.graphql.ts
+++ b/src/__generated__/Payment_me.graphql.ts
@@ -6,11 +6,6 @@ export type Payment_me = {
     readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_me">;
     readonly " $refType": "Payment_me";
 };
-export type Payment_me$data = Payment_me;
-export type Payment_me$key = {
-    readonly " $data"?: Payment_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"Payment_me">;
-};
 
 
 

--- a/src/__generated__/Payment_order.graphql.ts
+++ b/src/__generated__/Payment_order.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type Payment_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -17,11 +17,6 @@ export type Payment_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_order" | "ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order">;
     readonly " $refType": "Payment_order";
-};
-export type Payment_order$data = Payment_order;
-export type Payment_order$key = {
-    readonly " $data"?: Payment_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Payment_order">;
 };
 
 

--- a/src/__generated__/PopularArtists_popular_artists.graphql.ts
+++ b/src/__generated__/PopularArtists_popular_artists.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type PopularArtists_popular_artists = ReadonlyArray<{
     readonly slug: string;
     readonly internalID: string;
@@ -13,11 +12,6 @@ export type PopularArtists_popular_artists = ReadonlyArray<{
         } | null;
     } | null;
     readonly " $refType": "PopularArtists_popular_artists";
-}>;
-export type PopularArtists_popular_artists$data = PopularArtists_popular_artists;
-export type PopularArtists_popular_artists$key = ReadonlyArray<{
-    readonly " $data"?: PopularArtists_popular_artists$data;
-    readonly " $fragmentRefs": FragmentRefs<"PopularArtists_popular_artists">;
 }>;
 
 

--- a/src/__generated__/PricingContext_artwork.graphql.ts
+++ b/src/__generated__/PricingContext_artwork.graphql.ts
@@ -3,7 +3,6 @@
 import { ReaderFragment } from "relay-runtime";
 export type AnalyticsPricingContextCategoryEnum = "ARCHITECTURE" | "BOOKS_AND_PORTFOLIOS" | "DESIGN_DECORATIVE_ART" | "DRAWING_COLLAGE_OTHER_WORK_ON_PAPER" | "FASHION" | "INSTALLATION" | "JEWELRY" | "MIXED_MEDIA" | "OTHER" | "PAINTING" | "PERFORMANCE" | "PHOTOGRAPHY" | "POSTERS" | "PRINT" | "SCULPTURE" | "SOUND" | "TEXTILE" | "VIDEO_FILM_ANIMATION" | "WORK_ON_PAPER" | "%future added value";
 export type AnalyticsPricingContextDimensionEnum = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type PricingContext_artwork = {
     readonly listPrice: ({
         readonly __typename: "PriceRange";
@@ -40,11 +39,6 @@ export type PricingContext_artwork = {
         }>;
     } | null;
     readonly " $refType": "PricingContext_artwork";
-};
-export type PricingContext_artwork$data = PricingContext_artwork;
-export type PricingContext_artwork$key = {
-    readonly " $data"?: PricingContext_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"PricingContext_artwork">;
 };
 
 

--- a/src/__generated__/RecentlyViewedQuery.graphql.ts
+++ b/src/__generated__/RecentlyViewedQuery.graphql.ts
@@ -23,6 +23,38 @@ query RecentlyViewedQuery {
   }
 }
 
+fragment RecentlyViewed_me on Me {
+  recentlyViewedArtworksConnection(first: 20) {
+    edges {
+      node {
+        id
+        image {
+          aspect_ratio: aspectRatio
+          url(version: "large")
+        }
+        href
+        ...Metadata_artwork
+        ...Save_artwork
+        ...Badge_artwork
+      }
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -31,34 +63,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -99,36 +103,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
+fragment Contact_artwork on Artwork {
   href
-}
-
-fragment RecentlyViewed_me on Me {
-  recentlyViewedArtworksConnection(first: 20) {
-    edges {
-      node {
-        id
-        image {
-          aspect_ratio: aspectRatio
-          url(version: "large")
-        }
-        href
-        ...Metadata_artwork
-        ...Save_artwork
-        ...Badge_artwork
-      }
-    }
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -515,7 +515,7 @@ return {
     "operationKind": "query",
     "name": "RecentlyViewedQuery",
     "id": null,
-    "text": "query RecentlyViewedQuery {\n  me {\n    ...RecentlyViewed_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecentlyViewed_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n          url(version: \"large\")\n        }\n        href\n        ...Metadata_artwork\n        ...Save_artwork\n        ...Badge_artwork\n      }\n    }\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query RecentlyViewedQuery {\n  me {\n    ...RecentlyViewed_me\n    id\n  }\n}\n\nfragment RecentlyViewed_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n          url(version: \"large\")\n        }\n        href\n        ...Metadata_artwork\n        ...Save_artwork\n        ...Badge_artwork\n      }\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/RecentlyViewed_me.graphql.ts
+++ b/src/__generated__/RecentlyViewed_me.graphql.ts
@@ -18,11 +18,6 @@ export type RecentlyViewed_me = {
     } | null;
     readonly " $refType": "RecentlyViewed_me";
 };
-export type RecentlyViewed_me$data = RecentlyViewed_me;
-export type RecentlyViewed_me$key = {
-    readonly " $data"?: RecentlyViewed_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"RecentlyViewed_me">;
-};
 
 
 

--- a/src/__generated__/RecommendedArtist_artist.graphql.ts
+++ b/src/__generated__/RecommendedArtist_artist.graphql.ts
@@ -27,11 +27,6 @@ export type RecommendedArtist_artist = {
     readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
     readonly " $refType": "RecommendedArtist_artist";
 };
-export type RecommendedArtist_artist$data = RecommendedArtist_artist;
-export type RecommendedArtist_artist$key = {
-    readonly " $data"?: RecommendedArtist_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"RecommendedArtist_artist">;
-};
 
 
 

--- a/src/__generated__/RegisterValidTestQuery.graphql.ts
+++ b/src/__generated__/RegisterValidTestQuery.graphql.ts
@@ -43,14 +43,14 @@ query RegisterValidTestQuery {
   }
 }
 
-fragment Register_me on Me {
-  internalID
-}
-
 fragment Register_sale on Sale {
   slug
   internalID
   status
+}
+
+fragment Register_me on Me {
+  internalID
 }
 */
 
@@ -170,7 +170,7 @@ return {
     "operationKind": "query",
     "name": "RegisterValidTestQuery",
     "id": null,
-    "text": "query RegisterValidTestQuery {\n  sale(id: \"example-auction-id\") {\n    ...Register_sale\n    id\n  }\n  me {\n    ...Register_me\n    id\n  }\n}\n\nfragment Register_me on Me {\n  internalID\n}\n\nfragment Register_sale on Sale {\n  slug\n  internalID\n  status\n}\n",
+    "text": "query RegisterValidTestQuery {\n  sale(id: \"example-auction-id\") {\n    ...Register_sale\n    id\n  }\n  me {\n    ...Register_me\n    id\n  }\n}\n\nfragment Register_sale on Sale {\n  slug\n  internalID\n  status\n}\n\nfragment Register_me on Me {\n  internalID\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Register_me.graphql.ts
+++ b/src/__generated__/Register_me.graphql.ts
@@ -1,15 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Register_me = {
     readonly internalID: string;
     readonly " $refType": "Register_me";
-};
-export type Register_me$data = Register_me;
-export type Register_me$key = {
-    readonly " $data"?: Register_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"Register_me">;
 };
 
 

--- a/src/__generated__/Register_sale.graphql.ts
+++ b/src/__generated__/Register_sale.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Register_sale = {
     readonly slug: string;
     readonly internalID: string;
     readonly status: string | null;
     readonly " $refType": "Register_sale";
-};
-export type Register_sale$data = Register_sale;
-export type Register_sale$key = {
-    readonly " $data"?: Register_sale$data;
-    readonly " $fragmentRefs": FragmentRefs<"Register_sale">;
 };
 
 

--- a/src/__generated__/RejectTestQuery.graphql.ts
+++ b/src/__generated__/RejectTestQuery.graphql.ts
@@ -99,6 +99,30 @@ query RejectTestQuery {
   }
 }
 
+fragment Reject_order on CommerceOrder {
+  internalID
+  stateExpiresAt
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      createdAt
+      id
+    }
+  }
+  ...ArtworkSummaryItem_order
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -131,30 +155,6 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
       }
     }
   }
-}
-
-fragment Reject_order on CommerceOrder {
-  internalID
-  stateExpiresAt
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      createdAt
-      id
-    }
-  }
-  ...ArtworkSummaryItem_order
 }
 */
 
@@ -414,7 +414,7 @@ return {
     "operationKind": "query",
     "name": "RejectTestQuery",
     "id": null,
-    "text": "query RejectTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Reject_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Reject_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n}\n",
+    "text": "query RejectTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Reject_order\n    id\n  }\n}\n\nfragment Reject_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Reject_order.graphql.ts
+++ b/src/__generated__/Reject_order.graphql.ts
@@ -21,11 +21,6 @@ export type Reject_order = {
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order">;
     readonly " $refType": "Reject_order";
 };
-export type Reject_order$data = Reject_order;
-export type Reject_order$key = {
-    readonly " $data"?: Reject_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Reject_order">;
-};
 
 
 

--- a/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
+++ b/src/__generated__/RelatedCollectionEntity_collection.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type RelatedCollectionEntity_collection = {
     readonly headerImage: string | null;
     readonly slug: string;
@@ -23,11 +22,6 @@ export type RelatedCollectionEntity_collection = {
         } | null> | null;
     } | null;
     readonly " $refType": "RelatedCollectionEntity_collection";
-};
-export type RelatedCollectionEntity_collection$data = RelatedCollectionEntity_collection;
-export type RelatedCollectionEntity_collection$key = {
-    readonly " $data"?: RelatedCollectionEntity_collection$data;
-    readonly " $fragmentRefs": FragmentRefs<"RelatedCollectionEntity_collection">;
 };
 
 

--- a/src/__generated__/RelatedCollectionsRail_collections.graphql.ts
+++ b/src/__generated__/RelatedCollectionsRail_collections.graphql.ts
@@ -6,11 +6,6 @@ export type RelatedCollectionsRail_collections = ReadonlyArray<{
     readonly " $fragmentRefs": FragmentRefs<"RelatedCollectionEntity_collection">;
     readonly " $refType": "RelatedCollectionsRail_collections";
 }>;
-export type RelatedCollectionsRail_collections$data = RelatedCollectionsRail_collections;
-export type RelatedCollectionsRail_collections$key = ReadonlyArray<{
-    readonly " $data"?: RelatedCollectionsRail_collections$data;
-    readonly " $fragmentRefs": FragmentRefs<"RelatedCollectionsRail_collections">;
-}>;
 
 
 

--- a/src/__generated__/RelatedWorksArtworkGridQuery.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGridQuery.graphql.ts
@@ -27,6 +27,28 @@ query RelatedWorksArtworkGridQuery(
   }
 }
 
+fragment RelatedWorksArtworkGrid_artwork on Artwork {
+  layers {
+    name
+    internalID
+    id
+  }
+  slug
+  layer {
+    name
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+    id
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -45,6 +67,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -53,34 +104,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -121,55 +144,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment RelatedWorksArtworkGrid_artwork on Artwork {
-  layers {
-    name
-    internalID
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
     id
   }
-  slug
-  layer {
-    name
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -623,7 +623,7 @@ return {
     "operationKind": "query",
     "name": "RelatedWorksArtworkGridQuery",
     "id": null,
-    "text": "query RelatedWorksArtworkGridQuery(\n  $artworkSlug: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...RelatedWorksArtworkGrid_artwork\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query RelatedWorksArtworkGridQuery(\n  $artworkSlug: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...RelatedWorksArtworkGrid_artwork\n    id\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/RelatedWorksArtworkGridRefetchQuery.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGridRefetchQuery.graphql.ts
@@ -29,6 +29,28 @@ query RelatedWorksArtworkGridRefetchQuery(
   }
 }
 
+fragment RelatedWorksArtworkGrid_artwork_hOSfN on Artwork {
+  layers {
+    name
+    internalID
+    id
+  }
+  slug
+  layer(id: $layerId) {
+    name
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+    id
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -47,6 +69,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -55,34 +106,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -123,55 +146,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment RelatedWorksArtworkGrid_artwork_hOSfN on Artwork {
-  layers {
-    name
-    internalID
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
     id
   }
-  slug
-  layer(id: $layerId) {
-    name
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
   }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 */
 
@@ -643,7 +643,7 @@ return {
     "operationKind": "query",
     "name": "RelatedWorksArtworkGridRefetchQuery",
     "id": null,
-    "text": "query RelatedWorksArtworkGridRefetchQuery(\n  $artworkSlug: String!\n  $layerId: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...RelatedWorksArtworkGrid_artwork_hOSfN\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RelatedWorksArtworkGrid_artwork_hOSfN on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer(id: $layerId) {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query RelatedWorksArtworkGridRefetchQuery(\n  $artworkSlug: String!\n  $layerId: String!\n) {\n  artwork(id: $artworkSlug) {\n    ...RelatedWorksArtworkGrid_artwork_hOSfN\n    id\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork_hOSfN on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer(id: $layerId) {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/RelatedWorksArtworkGrid_artwork.graphql.ts
+++ b/src/__generated__/RelatedWorksArtworkGrid_artwork.graphql.ts
@@ -21,11 +21,6 @@ export type RelatedWorksArtworkGrid_artwork = {
     } | null;
     readonly " $refType": "RelatedWorksArtworkGrid_artwork";
 };
-export type RelatedWorksArtworkGrid_artwork$data = RelatedWorksArtworkGrid_artwork;
-export type RelatedWorksArtworkGrid_artwork$key = {
-    readonly " $data"?: RelatedWorksArtworkGrid_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"RelatedWorksArtworkGrid_artwork">;
-};
 
 
 

--- a/src/__generated__/RespondCounterOfferMutation.graphql.ts
+++ b/src/__generated__/RespondCounterOfferMutation.graphql.ts
@@ -57,6 +57,88 @@ mutation RespondCounterOfferMutation(
   }
 }
 
+fragment Respond_order on CommerceOrder {
+  internalID
+  mode
+  state
+  currencyCode
+  itemsTotal(precision: 2)
+  itemsTotalCents
+  totalListPrice(precision: 2)
+  totalListPriceCents
+  stateExpiresAt
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ... on CommerceOfferOrder {
+    lastOffer {
+      createdAt
+      internalID
+      note
+      id
+    }
+    myLastOffer {
+      createdAt
+      id
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+}
+
+fragment TransactionDetailsSummaryItem_order on CommerceOrder {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+    myLastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+  }
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -83,6 +165,25 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
               url
             }
           }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
           id
         }
         id
@@ -127,46 +228,6 @@ fragment OfferHistoryItem_order on CommerceOrder {
   totalListPrice(precision: 2)
 }
 
-fragment Respond_order on CommerceOrder {
-  internalID
-  mode
-  state
-  currencyCode
-  itemsTotal(precision: 2)
-  itemsTotalCents
-  totalListPrice(precision: 2)
-  totalListPriceCents
-  stateExpiresAt
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ... on CommerceOfferOrder {
-    lastOffer {
-      createdAt
-      internalID
-      note
-      id
-    }
-    myLastOffer {
-      createdAt
-      id
-    }
-  }
-  ...TransactionDetailsSummaryItem_order
-  ...ArtworkSummaryItem_order
-  ...ShippingSummaryItem_order
-  ...CreditCardSummaryItem_order
-  ...OfferHistoryItem_order
-}
-
 fragment ShippingAddress_ship on CommerceShip {
   name
   addressLine1
@@ -176,67 +237,6 @@ fragment ShippingAddress_ship on CommerceShip {
   region
   country
   phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment TransactionDetailsSummaryItem_order on CommerceOrder {
-  __typename
-  mode
-  shippingTotal(precision: 2)
-  shippingTotalCents
-  taxTotal(precision: 2)
-  taxTotalCents
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  buyerTotal(precision: 2)
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-    myLastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-  }
 }
 */
 
@@ -926,7 +926,7 @@ return {
     "operationKind": "mutation",
     "name": "RespondCounterOfferMutation",
     "id": null,
-    "text": "mutation RespondCounterOfferMutation(\n  $input: CommerceBuyerCounterOfferInput!\n) {\n  commerceBuyerCounterOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          ...Respond_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "mutation RespondCounterOfferMutation(\n  $input: CommerceBuyerCounterOfferInput!\n) {\n  commerceBuyerCounterOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          ...Respond_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/RespondTestQuery.graphql.ts
+++ b/src/__generated__/RespondTestQuery.graphql.ts
@@ -202,6 +202,88 @@ query RespondTestQuery {
   }
 }
 
+fragment Respond_order on CommerceOrder {
+  internalID
+  mode
+  state
+  currencyCode
+  itemsTotal(precision: 2)
+  itemsTotalCents
+  totalListPrice(precision: 2)
+  totalListPriceCents
+  stateExpiresAt
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ... on CommerceOfferOrder {
+    lastOffer {
+      createdAt
+      internalID
+      note
+      id
+    }
+    myLastOffer {
+      createdAt
+      id
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+}
+
+fragment TransactionDetailsSummaryItem_order on CommerceOrder {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+    myLastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+  }
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -228,6 +310,25 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
               url
             }
           }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
           id
         }
         id
@@ -272,46 +373,6 @@ fragment OfferHistoryItem_order on CommerceOrder {
   totalListPrice(precision: 2)
 }
 
-fragment Respond_order on CommerceOrder {
-  internalID
-  mode
-  state
-  currencyCode
-  itemsTotal(precision: 2)
-  itemsTotalCents
-  totalListPrice(precision: 2)
-  totalListPriceCents
-  stateExpiresAt
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ... on CommerceOfferOrder {
-    lastOffer {
-      createdAt
-      internalID
-      note
-      id
-    }
-    myLastOffer {
-      createdAt
-      id
-    }
-  }
-  ...TransactionDetailsSummaryItem_order
-  ...ArtworkSummaryItem_order
-  ...ShippingSummaryItem_order
-  ...CreditCardSummaryItem_order
-  ...OfferHistoryItem_order
-}
-
 fragment ShippingAddress_ship on CommerceShip {
   name
   addressLine1
@@ -321,67 +382,6 @@ fragment ShippingAddress_ship on CommerceShip {
   region
   country
   phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment TransactionDetailsSummaryItem_order on CommerceOrder {
-  __typename
-  mode
-  shippingTotal(precision: 2)
-  shippingTotalCents
-  taxTotal(precision: 2)
-  taxTotalCents
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  buyerTotal(precision: 2)
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-    myLastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-  }
 }
 */
 
@@ -966,7 +966,7 @@ return {
     "operationKind": "query",
     "name": "RespondTestQuery",
     "id": null,
-    "text": "query RespondTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Respond_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query RespondTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Respond_order\n    id\n  }\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Respond_order.graphql.ts
+++ b/src/__generated__/Respond_order.graphql.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Respond_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -33,11 +33,6 @@ export type Respond_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"TransactionDetailsSummaryItem_order" | "ArtworkSummaryItem_order" | "ShippingSummaryItem_order" | "CreditCardSummaryItem_order" | "OfferHistoryItem_order">;
     readonly " $refType": "Respond_order";
-};
-export type Respond_order$data = Respond_order;
-export type Respond_order$key = {
-    readonly " $data"?: Respond_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Respond_order">;
 };
 
 

--- a/src/__generated__/ReviewTestQuery.graphql.ts
+++ b/src/__generated__/ReviewTestQuery.graphql.ts
@@ -233,93 +233,6 @@ query ReviewTestQuery {
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ItemReview_lineItem on CommerceLineItem {
-  artwork {
-    artist_names: artistNames
-    title
-    date
-    medium
-    dimensions {
-      in
-      cm
-    }
-    attribution_class: attributionClass {
-      shortDescription
-      id
-    }
-    image {
-      resized(width: 185) {
-        url
-      }
-    }
-    edition_sets: editionSets {
-      internalID
-      dimensions {
-        in
-        cm
-      }
-      id
-    }
-    id
-  }
-  editionSetId
-}
-
-fragment OfferSummaryItem_order on CommerceOrder {
-  totalListPrice(precision: 2)
-  ... on CommerceOfferOrder {
-    myLastOffer {
-      amount(precision: 2)
-      note
-      id
-    }
-  }
-}
-
 fragment Review_order on CommerceOrder {
   internalID
   mode
@@ -354,28 +267,64 @@ fragment Review_order on CommerceOrder {
   ...OfferSummaryItem_order
 }
 
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
+fragment ItemReview_lineItem on CommerceLineItem {
+  artwork {
+    artist_names: artistNames
+    title
+    date
+    medium
+    dimensions {
+      in
+      cm
+    }
+    attribution_class: attributionClass {
+      shortDescription
+      id
+    }
+    image {
+      resized(width: 185) {
+        url
+      }
+    }
+    edition_sets: editionSets {
+      internalID
+      dimensions {
+        in
+        cm
+      }
+      id
+    }
+    id
+  }
+  editionSetId
 }
 
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
     __typename
-    ...ShippingAddress_ship
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
   }
   lineItems {
     edges {
       node {
         artwork {
+          artist_names: artistNames
+          title
+          date
           shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
           id
         }
         id
@@ -424,6 +373,57 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment OfferSummaryItem_order on CommerceOrder {
+  totalListPrice(precision: 2)
+  ... on CommerceOfferOrder {
+    myLastOffer {
+      amount(precision: 2)
+      note
+      id
+    }
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -1026,7 +1026,7 @@ return {
     "operationKind": "query",
     "name": "ReviewTestQuery",
     "id": null,
-    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names: artistNames\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class: attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    edition_sets: editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  totalListPrice(precision: 2)\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  internalID\n  mode\n  itemsTotal(precision: 2)\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferSummaryItem_order\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query ReviewTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  internalID\n  mode\n  itemsTotal(precision: 2)\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferSummaryItem_order\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names: artistNames\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class: attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    edition_sets: editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  totalListPrice(precision: 2)\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Review_order.graphql.ts
+++ b/src/__generated__/Review_order.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type Review_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -26,11 +26,6 @@ export type Review_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order" | "ShippingSummaryItem_order" | "CreditCardSummaryItem_order" | "OfferSummaryItem_order">;
     readonly " $refType": "Review_order";
-};
-export type Review_order$data = Review_order;
-export type Review_order$key = {
-    readonly " $data"?: Review_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Review_order">;
 };
 
 

--- a/src/__generated__/SaveArtworkQuery.graphql.ts
+++ b/src/__generated__/SaveArtworkQuery.graphql.ts
@@ -27,6 +27,35 @@ query SaveArtworkQuery(
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -35,34 +64,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -103,33 +104,32 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
 }
 */
 
@@ -505,7 +505,7 @@ return {
     "operationKind": "query",
     "name": "SaveArtworkQuery",
     "id": null,
-    "text": "query SaveArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...GridItem_artwork\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query SaveArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...GridItem_artwork\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Save_artwork.graphql.ts
+++ b/src/__generated__/Save_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type Save_artwork = {
     readonly id: string;
     readonly internalID: string;
@@ -9,11 +8,6 @@ export type Save_artwork = {
     readonly is_saved: boolean | null;
     readonly title: string | null;
     readonly " $refType": "Save_artwork";
-};
-export type Save_artwork$data = Save_artwork;
-export type Save_artwork$key = {
-    readonly " $data"?: Save_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"Save_artwork">;
 };
 
 

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type SearchAggregation = "TYPE" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type SearchAggregation = "TYPE" | "%future added value";
 export type SearchApp_viewer = {
     readonly searchConnection: {
         readonly aggregations: ReadonlyArray<{
@@ -27,11 +27,6 @@ export type SearchApp_viewer = {
         } | null;
     } | null;
     readonly " $refType": "SearchApp_viewer";
-};
-export type SearchApp_viewer$data = SearchApp_viewer;
-export type SearchApp_viewer$key = {
-    readonly " $data"?: SearchApp_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"SearchApp_viewer">;
 };
 
 

--- a/src/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/__generated__/SearchBar_viewer.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SearchBar_viewer = {
     readonly searchConnection?: {
         readonly edges: ReadonlyArray<{
@@ -14,11 +13,6 @@ export type SearchBar_viewer = {
         } | null> | null;
     } | null;
     readonly " $refType": "SearchBar_viewer";
-};
-export type SearchBar_viewer$data = SearchBar_viewer;
-export type SearchBar_viewer$key = {
-    readonly " $data"?: SearchBar_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"SearchBar_viewer">;
 };
 
 

--- a/src/__generated__/SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsQuery.graphql.ts
@@ -36,28 +36,6 @@ query SearchResultsArtistsQuery(
   }
 }
 
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
 fragment SearchResultsArtists_viewer_3D3mrw on Viewer {
   searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) @principalField {
     pageInfo {
@@ -82,6 +60,28 @@ fragment SearchResultsArtists_viewer_3D3mrw on Viewer {
         }
       }
     }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
   }
 }
 */
@@ -420,7 +420,7 @@ return {
     "operationKind": "query",
     "name": "SearchResultsArtistsQuery",
     "id": null,
-    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_3D3mrw\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_3D3mrw on Viewer {\n  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_3D3mrw\n  }\n}\n\nfragment SearchResultsArtists_viewer_3D3mrw on Viewer {\n  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/SearchResultsArtists_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtists_viewer.graphql.ts
@@ -23,11 +23,6 @@ export type SearchResultsArtists_viewer = {
     } | null;
     readonly " $refType": "SearchResultsArtists_viewer";
 };
-export type SearchResultsArtists_viewer$data = SearchResultsArtists_viewer;
-export type SearchResultsArtists_viewer$key = {
-    readonly " $data"?: SearchResultsArtists_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"SearchResultsArtists_viewer">;
-};
 
 
 

--- a/src/__generated__/SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/SearchResultsEntityQuery.graphql.ts
@@ -39,28 +39,6 @@ query SearchResultsEntityQuery(
   }
 }
 
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
 fragment SearchResultsEntity_viewer_4tOGvB on Viewer {
   searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: $entities) @principalField {
     pageInfo {
@@ -86,6 +64,28 @@ fragment SearchResultsEntity_viewer_4tOGvB on Viewer {
         }
       }
     }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
   }
 }
 */
@@ -437,7 +437,7 @@ return {
     "operationKind": "query",
     "name": "SearchResultsEntityQuery",
     "id": null,
-    "text": "query SearchResultsEntityQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_4tOGvB\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsEntity_viewer_4tOGvB on Viewer {\n  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query SearchResultsEntityQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_4tOGvB\n  }\n}\n\nfragment SearchResultsEntity_viewer_4tOGvB on Viewer {\n  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/SearchResultsEntity_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsEntity_viewer.graphql.ts
@@ -24,11 +24,6 @@ export type SearchResultsEntity_viewer = {
     } | null;
     readonly " $refType": "SearchResultsEntity_viewer";
 };
-export type SearchResultsEntity_viewer$data = SearchResultsEntity_viewer;
-export type SearchResultsEntity_viewer$key = {
-    readonly " $data"?: SearchResultsEntity_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"SearchResultsEntity_viewer">;
-};
 
 
 

--- a/src/__generated__/SecurePayment_artwork.graphql.ts
+++ b/src/__generated__/SecurePayment_artwork.graphql.ts
@@ -1,16 +1,10 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SecurePayment_artwork = {
     readonly is_acquireable: boolean | null;
     readonly is_offerable: boolean | null;
     readonly " $refType": "SecurePayment_artwork";
-};
-export type SecurePayment_artwork$data = SecurePayment_artwork;
-export type SecurePayment_artwork$key = {
-    readonly " $data"?: SecurePayment_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"SecurePayment_artwork">;
 };
 
 

--- a/src/__generated__/SelectedCareerAchievements_artist.graphql.ts
+++ b/src/__generated__/SelectedCareerAchievements_artist.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SelectedCareerAchievements_artist = {
     readonly highlights: {
         readonly partnersConnection: {
@@ -31,11 +30,6 @@ export type SelectedCareerAchievements_artist = {
         } | null> | null;
     } | null;
     readonly " $refType": "SelectedCareerAchievements_artist";
-};
-export type SelectedCareerAchievements_artist$data = SelectedCareerAchievements_artist;
-export type SelectedCareerAchievements_artist$key = {
-    readonly " $data"?: SelectedCareerAchievements_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"SelectedCareerAchievements_artist">;
 };
 
 

--- a/src/__generated__/SelectedExhibitions_exhibitions.graphql.ts
+++ b/src/__generated__/SelectedExhibitions_exhibitions.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SelectedExhibitions_exhibitions = ReadonlyArray<{
     readonly partner: {
         readonly name?: string | null;
@@ -15,11 +14,6 @@ export type SelectedExhibitions_exhibitions = ReadonlyArray<{
     } | null;
     readonly city: string | null;
     readonly " $refType": "SelectedExhibitions_exhibitions";
-}>;
-export type SelectedExhibitions_exhibitions$data = SelectedExhibitions_exhibitions;
-export type SelectedExhibitions_exhibitions$key = ReadonlyArray<{
-    readonly " $data"?: SelectedExhibitions_exhibitions$data;
-    readonly " $fragmentRefs": FragmentRefs<"SelectedExhibitions_exhibitions">;
 }>;
 
 

--- a/src/__generated__/SeoDataForArtwork_artwork.graphql.ts
+++ b/src/__generated__/SeoDataForArtwork_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SeoDataForArtwork_artwork = {
     readonly href: string | null;
     readonly date: string | null;
@@ -41,11 +40,6 @@ export type SeoDataForArtwork_artwork = {
         readonly in: string | null;
     } | null;
     readonly " $refType": "SeoDataForArtwork_artwork";
-};
-export type SeoDataForArtwork_artwork$data = SeoDataForArtwork_artwork;
-export type SeoDataForArtwork_artwork$key = {
-    readonly " $data"?: SeoDataForArtwork_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"SeoDataForArtwork_artwork">;
 };
 
 

--- a/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
+++ b/src/__generated__/SeoProductsForArtworks_artworks.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SeoProductsForArtworks_artworks = {
     readonly edges: ReadonlyArray<{
         readonly node: {
@@ -47,11 +46,6 @@ export type SeoProductsForArtworks_artworks = {
         } | null;
     } | null> | null;
     readonly " $refType": "SeoProductsForArtworks_artworks";
-};
-export type SeoProductsForArtworks_artworks$data = SeoProductsForArtworks_artworks;
-export type SeoProductsForArtworks_artworks$key = {
-    readonly " $data"?: SeoProductsForArtworks_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"SeoProductsForArtworks_artworks">;
 };
 
 

--- a/src/__generated__/ShippingAddress_ship.graphql.ts
+++ b/src/__generated__/ShippingAddress_ship.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type ShippingAddress_ship = {
     readonly name: string | null;
     readonly addressLine1: string | null;
@@ -12,11 +11,6 @@ export type ShippingAddress_ship = {
     readonly country: string | null;
     readonly phoneNumber: string | null;
     readonly " $refType": "ShippingAddress_ship";
-};
-export type ShippingAddress_ship$data = ShippingAddress_ship;
-export type ShippingAddress_ship$key = {
-    readonly " $data"?: ShippingAddress_ship$data;
-    readonly " $fragmentRefs": FragmentRefs<"ShippingAddress_ship">;
 };
 
 

--- a/src/__generated__/ShippingSummaryItemStoryQuery.graphql.ts
+++ b/src/__generated__/ShippingSummaryItemStoryQuery.graphql.ts
@@ -24,17 +24,6 @@ query ShippingSummaryItemStoryQuery {
   }
 }
 
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
-}
-
 fragment ShippingSummaryItem_order on CommerceOrder {
   state
   requestedFulfillment {
@@ -52,6 +41,17 @@ fragment ShippingSummaryItem_order on CommerceOrder {
       }
     }
   }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -262,7 +262,7 @@ return {
     "operationKind": "query",
     "name": "ShippingSummaryItemStoryQuery",
     "id": null,
-    "text": "query ShippingSummaryItemStoryQuery {\n  order: commerceOrder(id: \"foo\") {\n    __typename\n    ...ShippingSummaryItem_order\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query ShippingSummaryItemStoryQuery {\n  order: commerceOrder(id: \"foo\") {\n    __typename\n    ...ShippingSummaryItem_order\n    id\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ShippingSummaryItem_order.graphql.ts
+++ b/src/__generated__/ShippingSummaryItem_order.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
 export type ShippingSummaryItem_order = {
     readonly state: CommerceOrderStateEnum;
     readonly requestedFulfillment: {
@@ -19,11 +19,6 @@ export type ShippingSummaryItem_order = {
         } | null> | null;
     } | null;
     readonly " $refType": "ShippingSummaryItem_order";
-};
-export type ShippingSummaryItem_order$data = ShippingSummaryItem_order;
-export type ShippingSummaryItem_order$key = {
-    readonly " $data"?: ShippingSummaryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"ShippingSummaryItem_order">;
 };
 
 

--- a/src/__generated__/ShippingTestQuery.graphql.ts
+++ b/src/__generated__/ShippingTestQuery.graphql.ts
@@ -173,40 +173,6 @@ query ShippingTestQuery {
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment Shipping_order on CommerceOrder {
   internalID
   mode
@@ -240,6 +206,40 @@ fragment Shipping_order on CommerceOrder {
   }
   ...ArtworkSummaryItem_order
   ...TransactionDetailsSummaryItem_order
+}
+
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -743,7 +743,7 @@ return {
     "operationKind": "query",
     "name": "ShippingTestQuery",
     "id": null,
-    "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  internalID\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          pickup_available: pickupAvailable\n          onlyShipsDomestically\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  internalID\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          pickup_available: pickupAvailable\n          onlyShipsDomestically\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Shipping_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -37,11 +37,6 @@ export type Shipping_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order">;
     readonly " $refType": "Shipping_order";
-};
-export type Shipping_order$data = Shipping_order;
-export type Shipping_order$key = {
-    readonly " $data"?: Shipping_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Shipping_order">;
 };
 
 

--- a/src/__generated__/Shows_Test_Query.graphql.ts
+++ b/src/__generated__/Shows_Test_Query.graphql.ts
@@ -202,6 +202,61 @@ query Shows_Test_Query(
   }
 }
 
+fragment Shows_viewer on Viewer {
+  artist_currentShows: artist(id: $artistID) {
+    ...ArtistShows_artist_43oec1
+    id
+  }
+  artist_upcomingShows: artist(id: $artistID) {
+    ...ArtistShows_artist_12Fjro
+    id
+  }
+  artist_pastShows: artist(id: $artistID) {
+    ...ArtistShows_artist_3dp4w3
+    id
+  }
+}
+
+fragment ArtistShows_artist_43oec1 on Artist {
+  slug
+  showsConnection(first: 4, sort: END_AT_ASC, status: "running") {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        partner {
+          __typename
+          ... on ExternalPartner {
+            name
+            id
+          }
+          ... on Partner {
+            name
+          }
+          ... on Node {
+            id
+          }
+        }
+        name
+        href
+        exhibition_period: exhibitionPeriod
+        cover_image: coverImage {
+          cropped(width: 800, height: 600) {
+            url
+          }
+        }
+        city
+        id
+      }
+    }
+  }
+}
+
 fragment ArtistShows_artist_12Fjro on Artist {
   slug
   showsConnection(first: 4, sort: START_AT_ASC, status: "upcoming") {
@@ -282,46 +337,6 @@ fragment ArtistShows_artist_3dp4w3 on Artist {
   }
 }
 
-fragment ArtistShows_artist_43oec1 on Artist {
-  slug
-  showsConnection(first: 4, sort: END_AT_ASC, status: "running") {
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    pageCursors {
-      ...Pagination_pageCursors
-    }
-    edges {
-      node {
-        partner {
-          __typename
-          ... on ExternalPartner {
-            name
-            id
-          }
-          ... on Partner {
-            name
-          }
-          ... on Node {
-            id
-          }
-        }
-        name
-        href
-        exhibition_period: exhibitionPeriod
-        cover_image: coverImage {
-          cropped(width: 800, height: 600) {
-            url
-          }
-        }
-        city
-        id
-      }
-    }
-  }
-}
-
 fragment Pagination_pageCursors on PageCursors {
   around {
     cursor
@@ -341,21 +356,6 @@ fragment Pagination_pageCursors on PageCursors {
   previous {
     cursor
     page
-  }
-}
-
-fragment Shows_viewer on Viewer {
-  artist_currentShows: artist(id: $artistID) {
-    ...ArtistShows_artist_43oec1
-    id
-  }
-  artist_upcomingShows: artist(id: $artistID) {
-    ...ArtistShows_artist_12Fjro
-    id
-  }
-  artist_pastShows: artist(id: $artistID) {
-    ...ArtistShows_artist_3dp4w3
-    id
   }
 }
 */
@@ -779,7 +779,7 @@ return {
     "operationKind": "query",
     "name": "Shows_Test_Query",
     "id": null,
-    "text": "query Shows_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...Shows_viewer\n  }\n}\n\nfragment ArtistShows_artist_12Fjro on Artist {\n  slug\n  showsConnection(first: 4, sort: START_AT_ASC, status: \"upcoming\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_3dp4w3 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_DESC, status: \"closed\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_43oec1 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_ASC, status: \"running\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Shows_viewer on Viewer {\n  artist_currentShows: artist(id: $artistID) {\n    ...ArtistShows_artist_43oec1\n    id\n  }\n  artist_upcomingShows: artist(id: $artistID) {\n    ...ArtistShows_artist_12Fjro\n    id\n  }\n  artist_pastShows: artist(id: $artistID) {\n    ...ArtistShows_artist_3dp4w3\n    id\n  }\n}\n",
+    "text": "query Shows_Test_Query(\n  $artistID: String!\n) {\n  viewer {\n    ...Shows_viewer\n  }\n}\n\nfragment Shows_viewer on Viewer {\n  artist_currentShows: artist(id: $artistID) {\n    ...ArtistShows_artist_43oec1\n    id\n  }\n  artist_upcomingShows: artist(id: $artistID) {\n    ...ArtistShows_artist_12Fjro\n    id\n  }\n  artist_pastShows: artist(id: $artistID) {\n    ...ArtistShows_artist_3dp4w3\n    id\n  }\n}\n\nfragment ArtistShows_artist_43oec1 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_ASC, status: \"running\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_12Fjro on Artist {\n  slug\n  showsConnection(first: 4, sort: START_AT_ASC, status: \"upcoming\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_3dp4w3 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_DESC, status: \"closed\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Shows_viewer.graphql.ts
+++ b/src/__generated__/Shows_viewer.graphql.ts
@@ -14,11 +14,6 @@ export type Shows_viewer = {
     } | null;
     readonly " $refType": "Shows_viewer";
 };
-export type Shows_viewer$data = Shows_viewer;
-export type Shows_viewer$key = {
-    readonly " $data"?: Shows_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"Shows_viewer">;
-};
 
 
 

--- a/src/__generated__/StatusQuery.graphql.ts
+++ b/src/__generated__/StatusQuery.graphql.ts
@@ -205,80 +205,6 @@ query StatusQuery {
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment Status_order on CommerceOrder {
   __typename
   internalID
@@ -331,6 +257,40 @@ fragment Status_order on CommerceOrder {
   }
 }
 
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -371,6 +331,46 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -932,7 +932,7 @@ return {
     "operationKind": "query",
     "name": "StatusQuery",
     "id": null,
-    "text": "query StatusQuery {\n  order: commerceOrder(id: \"42\") {\n    __typename\n    ...Status_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  internalID\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      id\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query StatusQuery {\n  order: commerceOrder(id: \"42\") {\n    __typename\n    ...Status_order\n    id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  internalID\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Status_order.graphql.ts
+++ b/src/__generated__/Status_order.graphql.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type Status_order = {
     readonly __typename: string;
     readonly internalID: string;
@@ -47,11 +47,6 @@ export type Status_order = {
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtworkSummaryItem_order" | "TransactionDetailsSummaryItem_order" | "ShippingSummaryItem_order" | "CreditCardSummaryItem_order">;
     readonly " $refType": "Status_order";
-};
-export type Status_order$data = Status_order;
-export type Status_order$key = {
-    readonly " $data"?: Status_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"Status_order">;
 };
 
 

--- a/src/__generated__/SuggestedGenes_suggested_genes.graphql.ts
+++ b/src/__generated__/SuggestedGenes_suggested_genes.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type SuggestedGenes_suggested_genes = ReadonlyArray<{
     readonly id: string;
     readonly slug: string;
@@ -13,11 +12,6 @@ export type SuggestedGenes_suggested_genes = ReadonlyArray<{
         } | null;
     } | null;
     readonly " $refType": "SuggestedGenes_suggested_genes";
-}>;
-export type SuggestedGenes_suggested_genes$data = SuggestedGenes_suggested_genes;
-export type SuggestedGenes_suggested_genes$key = ReadonlyArray<{
-    readonly " $data"?: SuggestedGenes_suggested_genes$data;
-    readonly " $fragmentRefs": FragmentRefs<"SuggestedGenes_suggested_genes">;
 }>;
 
 

--- a/src/__generated__/TagArtworksPaginationQuery.graphql.ts
+++ b/src/__generated__/TagArtworksPaginationQuery.graphql.ts
@@ -41,6 +41,65 @@ query TagArtworksPaginationQuery(
   }
 }
 
+fragment TagArtworks_tag_1QTmdc on Tag {
+  slug
+  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: $count, after: $cursor) {
+    ...TotalCount_filter_artworks
+    aggregations {
+      slice
+      counts {
+        name
+        value
+      }
+      ...Dropdown_aggregation
+    }
+    facet {
+      __typename
+      ...Headline_facet
+      ... on Node {
+        id
+      }
+    }
+    id
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
+fragment Headline_facet on ArtworkFilterFacet {
+  ... on Tag {
+    name
+  }
+  ... on Gene {
+    name
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -59,6 +118,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -67,34 +155,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -135,91 +195,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Headline_facet on ArtworkFilterFacet {
-  ... on Tag {
-    name
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  ... on Gene {
-    name
+  partner(shallow: true) {
+    type
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TagArtworks_tag_1QTmdc on Tag {
-  slug
-  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: $count, after: $cursor) {
-    ...TotalCount_filter_artworks
-    aggregations {
-      slice
-      counts {
-        name
-        value
-      }
-      ...Dropdown_aggregation
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-    facet {
-      __typename
-      ...Headline_facet
-      ... on Node {
-        id
-      }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    ...ArtworkGrid_artworks
-    edges {
-      node {
-        id
-        __typename
-      }
-      cursor
-    }
-  }
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
   }
 }
 */
@@ -889,7 +889,7 @@ return {
     "operationKind": "query",
     "name": "TagArtworksPaginationQuery",
     "id": null,
-    "text": "query TagArtworksPaginationQuery(\n  $tagID: String!\n  $count: Int!\n  $cursor: String\n  $sort: String\n  $priceRange: String\n  $dimensionRange: String\n  $medium: String\n  $forSale: Boolean\n) {\n  tag(id: $tagID) {\n    ...TagArtworks_tag_1QTmdc\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TagArtworks_tag_1QTmdc on Tag {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: $count, after: $cursor) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query TagArtworksPaginationQuery(\n  $tagID: String!\n  $count: Int!\n  $cursor: String\n  $sort: String\n  $priceRange: String\n  $dimensionRange: String\n  $medium: String\n  $forSale: Boolean\n) {\n  tag(id: $tagID) {\n    ...TagArtworks_tag_1QTmdc\n    id\n  }\n}\n\nfragment TagArtworks_tag_1QTmdc on Tag {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: $count, after: $cursor) {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/TagArtworks_tag.graphql.ts
+++ b/src/__generated__/TagArtworks_tag.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type TagArtworks_tag = {
     readonly slug: string;
     readonly filtered_artworks: {
@@ -30,11 +30,6 @@ export type TagArtworks_tag = {
         readonly " $fragmentRefs": FragmentRefs<"TotalCount_filter_artworks" | "ArtworkGrid_artworks">;
     } | null;
     readonly " $refType": "TagArtworks_tag";
-};
-export type TagArtworks_tag$data = TagArtworks_tag;
-export type TagArtworks_tag$key = {
-    readonly " $data"?: TagArtworks_tag$data;
-    readonly " $fragmentRefs": FragmentRefs<"TagArtworks_tag">;
 };
 
 

--- a/src/__generated__/TagContentsArtworksQuery.graphql.ts
+++ b/src/__generated__/TagContentsArtworksQuery.graphql.ts
@@ -37,6 +37,65 @@ query TagContentsArtworksQuery(
   }
 }
 
+fragment TagArtworks_tag_4q9qzB on Tag {
+  slug
+  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: 10, after: "") {
+    ...TotalCount_filter_artworks
+    aggregations {
+      slice
+      counts {
+        name
+        value
+      }
+      ...Dropdown_aggregation
+    }
+    facet {
+      __typename
+      ...Headline_facet
+      ... on Node {
+        id
+      }
+    }
+    id
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    ...ArtworkGrid_artworks
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+
+fragment TotalCount_filter_artworks on FilterArtworksConnection {
+  counts {
+    total
+  }
+}
+
+fragment Dropdown_aggregation on ArtworksAggregationResults {
+  slice
+  counts {
+    name
+    value
+    count
+  }
+}
+
+fragment Headline_facet on ArtworkFilterFacet {
+  ... on Tag {
+    name
+  }
+  ... on Gene {
+    name
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -55,6 +114,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -63,34 +151,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -131,91 +191,31 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment Dropdown_aggregation on ArtworksAggregationResults {
-  slice
-  counts {
-    name
-    value
-    count
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Headline_facet on ArtworkFilterFacet {
-  ... on Tag {
-    name
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  ... on Gene {
-    name
+  partner(shallow: true) {
+    type
+    id
   }
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment TagArtworks_tag_4q9qzB on Tag {
-  slug
-  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: 10, after: "") {
-    ...TotalCount_filter_artworks
-    aggregations {
-      slice
-      counts {
-        name
-        value
-      }
-      ...Dropdown_aggregation
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
     }
-    facet {
-      __typename
-      ...Headline_facet
-      ... on Node {
-        id
-      }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    ...ArtworkGrid_artworks
-    edges {
-      node {
-        id
-        __typename
-      }
-      cursor
-    }
-  }
-}
-
-fragment TotalCount_filter_artworks on FilterArtworksConnection {
-  counts {
-    total
   }
 }
 */
@@ -863,7 +863,7 @@ return {
     "operationKind": "query",
     "name": "TagContentsArtworksQuery",
     "id": null,
-    "text": "query TagContentsArtworksQuery(\n  $tagID: String!\n  $medium: String\n  $priceRange: String\n  $sort: String\n  $forSale: Boolean\n  $dimensionRange: String\n) {\n  tag(id: $tagID) {\n    ...TagArtworks_tag_4q9qzB\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment TagArtworks_tag_4q9qzB on Tag {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: 10, after: \"\") {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n",
+    "text": "query TagContentsArtworksQuery(\n  $tagID: String!\n  $medium: String\n  $priceRange: String\n  $sort: String\n  $forSale: Boolean\n  $dimensionRange: String\n) {\n  tag(id: $tagID) {\n    ...TagArtworks_tag_4q9qzB\n    id\n  }\n}\n\nfragment TagArtworks_tag_4q9qzB on Tag {\n  slug\n  filtered_artworks: filterArtworksConnection(aggregations: [MEDIUM, TOTAL, PRICE_RANGE, DIMENSION_RANGE], forSale: $forSale, medium: $medium, priceRange: $priceRange, dimensionRange: $dimensionRange, sort: $sort, first: 10, after: \"\") {\n    ...TotalCount_filter_artworks\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n      ...Dropdown_aggregation\n    }\n    facet {\n      __typename\n      ...Headline_facet\n      ... on Node {\n        id\n      }\n    }\n    id\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment TotalCount_filter_artworks on FilterArtworksConnection {\n  counts {\n    total\n  }\n}\n\nfragment Dropdown_aggregation on ArtworksAggregationResults {\n  slice\n  counts {\n    name\n    value\n    count\n  }\n}\n\nfragment Headline_facet on ArtworkFilterFacet {\n  ... on Tag {\n    name\n  }\n  ... on Gene {\n    name\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/TooltipsDataLoaderQuery.graphql.ts
+++ b/src/__generated__/TooltipsDataLoaderQuery.graphql.ts
@@ -69,33 +69,6 @@ fragment ArtistToolTip_artist on Artist {
   }
 }
 
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
-  }
-}
-
-fragment FollowGeneButton_gene on Gene {
-  id
-  internalID
-  is_followed: isFollowed
-}
-
-fragment GeneToolTip_gene on Gene {
-  description
-  href
-  slug
-  internalID
-  image {
-    url(version: "tall")
-  }
-  name
-}
-
 fragment MarketDataSummary_artist on Artist {
   internalID
   collections
@@ -123,6 +96,33 @@ fragment MarketDataSummary_artist on Artist {
       }
     }
   }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment GeneToolTip_gene on Gene {
+  description
+  href
+  slug
+  internalID
+  image {
+    url(version: "tall")
+  }
+  name
+}
+
+fragment FollowGeneButton_gene on Gene {
+  id
+  internalID
+  is_followed: isFollowed
 }
 */
 
@@ -605,7 +605,7 @@ return {
     "operationKind": "query",
     "name": "TooltipsDataLoaderQuery",
     "id": null,
-    "text": "query TooltipsDataLoaderQuery(\n  $artistSlugs: [String!]\n  $geneSlugs: [String!]\n) {\n  artists(slugs: $artistSlugs) {\n    slug\n    internalID\n    ...ArtistToolTip_artist\n    ...MarketDataSummary_artist\n    ...FollowArtistButton_artist\n    id\n  }\n  genes(slugs: $geneSlugs) {\n    slug\n    internalID\n    ...GeneToolTip_gene\n    ...FollowGeneButton_gene\n    id\n  }\n}\n\nfragment ArtistToolTip_artist on Artist {\n  name\n  slug\n  internalID\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  blurb\n  carousel {\n    images {\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  genes {\n    name\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GeneToolTip_gene on Gene {\n  description\n  href\n  slug\n  internalID\n  image {\n    url(version: \"tall\")\n  }\n  name\n}\n\nfragment MarketDataSummary_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query TooltipsDataLoaderQuery(\n  $artistSlugs: [String!]\n  $geneSlugs: [String!]\n) {\n  artists(slugs: $artistSlugs) {\n    slug\n    internalID\n    ...ArtistToolTip_artist\n    ...MarketDataSummary_artist\n    ...FollowArtistButton_artist\n    id\n  }\n  genes(slugs: $geneSlugs) {\n    slug\n    internalID\n    ...GeneToolTip_gene\n    ...FollowGeneButton_gene\n    id\n  }\n}\n\nfragment ArtistToolTip_artist on Artist {\n  name\n  slug\n  internalID\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  href\n  blurb\n  carousel {\n    images {\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  genes {\n    name\n    id\n  }\n}\n\nfragment MarketDataSummary_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GeneToolTip_gene on Gene {\n  description\n  href\n  slug\n  internalID\n  image {\n    url(version: \"tall\")\n  }\n  name\n}\n\nfragment FollowGeneButton_gene on Gene {\n  id\n  internalID\n  is_followed: isFollowed\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/TotalCount_filter_artworks.graphql.ts
+++ b/src/__generated__/TotalCount_filter_artworks.graphql.ts
@@ -1,17 +1,11 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type TotalCount_filter_artworks = {
     readonly counts: {
         readonly total: number | null;
     } | null;
     readonly " $refType": "TotalCount_filter_artworks";
-};
-export type TotalCount_filter_artworks$data = TotalCount_filter_artworks;
-export type TotalCount_filter_artworks$key = {
-    readonly " $data"?: TotalCount_filter_artworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"TotalCount_filter_artworks">;
 };
 
 

--- a/src/__generated__/TransactionDetailsSummaryItemOfferProperties.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItemOfferProperties.graphql.ts
@@ -2,7 +2,6 @@
 
 import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type TransactionDetailsSummaryItemOfferProperties = {
     readonly internalID: string;
     readonly amount: string | null;
@@ -16,11 +15,6 @@ export type TransactionDetailsSummaryItemOfferProperties = {
     readonly fromParticipant: CommerceOrderParticipantEnum | null;
     readonly note: string | null;
     readonly " $refType": "TransactionDetailsSummaryItemOfferProperties";
-};
-export type TransactionDetailsSummaryItemOfferProperties$data = TransactionDetailsSummaryItemOfferProperties;
-export type TransactionDetailsSummaryItemOfferProperties$key = {
-    readonly " $data"?: TransactionDetailsSummaryItemOfferProperties$data;
-    readonly " $fragmentRefs": FragmentRefs<"TransactionDetailsSummaryItemOfferProperties">;
 };
 
 

--- a/src/__generated__/TransactionDetailsSummaryItem_order.graphql.ts
+++ b/src/__generated__/TransactionDetailsSummaryItem_order.graphql.ts
@@ -3,7 +3,6 @@
 import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type TransactionDetailsSummaryItem_order = {
     readonly __typename: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -41,11 +40,6 @@ export type TransactionDetailsSummaryItem_order = {
         readonly note: string | null;
     } | null;
     readonly " $refType": "TransactionDetailsSummaryItem_order";
-};
-export type TransactionDetailsSummaryItem_order$data = TransactionDetailsSummaryItem_order;
-export type TransactionDetailsSummaryItem_order$key = {
-    readonly " $data"?: TransactionDetailsSummaryItem_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"TransactionDetailsSummaryItem_order">;
 };
 
 

--- a/src/__generated__/UserSettingsPaymentsCreditCard.graphql.ts
+++ b/src/__generated__/UserSettingsPaymentsCreditCard.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type UserSettingsPaymentsCreditCard = {
     readonly id: string;
     readonly internalID: string;
@@ -11,11 +10,6 @@ export type UserSettingsPaymentsCreditCard = {
     readonly expirationMonth: number;
     readonly __typename: "CreditCard";
     readonly " $refType": "UserSettingsPaymentsCreditCard";
-};
-export type UserSettingsPaymentsCreditCard$data = UserSettingsPaymentsCreditCard;
-export type UserSettingsPaymentsCreditCard$key = {
-    readonly " $data"?: UserSettingsPaymentsCreditCard$data;
-    readonly " $fragmentRefs": FragmentRefs<"UserSettingsPaymentsCreditCard">;
 };
 
 

--- a/src/__generated__/UserSettingsPayments_me.graphql.ts
+++ b/src/__generated__/UserSettingsPayments_me.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type UserSettingsPayments_me = {
     readonly id: string;
     readonly internalID: string;
@@ -19,11 +18,6 @@ export type UserSettingsPayments_me = {
         } | null> | null;
     } | null;
     readonly " $refType": "UserSettingsPayments_me";
-};
-export type UserSettingsPayments_me$data = UserSettingsPayments_me;
-export type UserSettingsPayments_me$key = {
-    readonly " $data"?: UserSettingsPayments_me$data;
-    readonly " $fragmentRefs": FragmentRefs<"UserSettingsPayments_me">;
 };
 
 

--- a/src/__generated__/VerifiedSeller_artwork.graphql.ts
+++ b/src/__generated__/VerifiedSeller_artwork.graphql.ts
@@ -1,7 +1,6 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type VerifiedSeller_artwork = {
     readonly is_biddable: boolean | null;
     readonly partner: {
@@ -9,11 +8,6 @@ export type VerifiedSeller_artwork = {
         readonly name: string | null;
     } | null;
     readonly " $refType": "VerifiedSeller_artwork";
-};
-export type VerifiedSeller_artwork$data = VerifiedSeller_artwork;
-export type VerifiedSeller_artwork$key = {
-    readonly " $data"?: VerifiedSeller_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"VerifiedSeller_artwork">;
 };
 
 

--- a/src/__generated__/WorksForYouArtistFeedPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouArtistFeedPaginationQuery.graphql.ts
@@ -33,6 +33,37 @@ query WorksForYouArtistFeedPaginationQuery(
   }
 }
 
+fragment WorksForYouArtistFeed_viewer_VuLYe on Viewer {
+  artist(id: $artistID) {
+    name
+    href
+    counts {
+      artworks
+      for_sale_artworks: forSaleArtworks
+    }
+    image {
+      resized(height: 80, width: 80) {
+        url
+      }
+    }
+    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, filter: $filter) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          id
+          __typename
+        }
+        cursor
+      }
+    }
+    id
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -51,6 +82,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -59,34 +119,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -127,61 +159,29 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment WorksForYouArtistFeed_viewer_VuLYe on Viewer {
-  artist(id: $artistID) {
-    name
-    href
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
     counts {
-      artworks
-      for_sale_artworks: forSaleArtworks
-    }
-    image {
-      resized(height: 80, width: 80) {
-        url
-      }
-    }
-    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, filter: $filter) {
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          id
-          __typename
-        }
-        cursor
-      }
+      bidder_positions: bidderPositions
     }
     id
   }
@@ -783,7 +783,7 @@ return {
     "operationKind": "query",
     "name": "WorksForYouArtistFeedPaginationQuery",
     "id": null,
-    "text": "query WorksForYouArtistFeedPaginationQuery(\n  $artistID: String!\n  $count: Int!\n  $cursor: String\n  $filter: [ArtistArtworksFilters]\n) {\n  viewer {\n    ...WorksForYouArtistFeed_viewer_VuLYe\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment WorksForYouArtistFeed_viewer_VuLYe on Viewer {\n  artist(id: $artistID) {\n    name\n    href\n    counts {\n      artworks\n      for_sale_artworks: forSaleArtworks\n    }\n    image {\n      resized(height: 80, width: 80) {\n        url\n      }\n    }\n    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, filter: $filter) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          id\n          __typename\n        }\n        cursor\n      }\n    }\n    id\n  }\n}\n",
+    "text": "query WorksForYouArtistFeedPaginationQuery(\n  $artistID: String!\n  $count: Int!\n  $cursor: String\n  $filter: [ArtistArtworksFilters]\n) {\n  viewer {\n    ...WorksForYouArtistFeed_viewer_VuLYe\n  }\n}\n\nfragment WorksForYouArtistFeed_viewer_VuLYe on Viewer {\n  artist(id: $artistID) {\n    name\n    href\n    counts {\n      artworks\n      for_sale_artworks: forSaleArtworks\n    }\n    image {\n      resized(height: 80, width: 80) {\n        url\n      }\n    }\n    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, filter: $filter) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          id\n          __typename\n        }\n        cursor\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/WorksForYouArtistFeed_viewer.graphql.ts
+++ b/src/__generated__/WorksForYouArtistFeed_viewer.graphql.ts
@@ -30,11 +30,6 @@ export type WorksForYouArtistFeed_viewer = {
     } | null;
     readonly " $refType": "WorksForYouArtistFeed_viewer";
 };
-export type WorksForYouArtistFeed_viewer$data = WorksForYouArtistFeed_viewer;
-export type WorksForYouArtistFeed_viewer$key = {
-    readonly " $data"?: WorksForYouArtistFeed_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"WorksForYouArtistFeed_viewer">;
-};
 
 
 

--- a/src/__generated__/WorksForYouFeedPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouFeedPaginationQuery.graphql.ts
@@ -28,6 +28,39 @@ query WorksForYouFeedPaginationQuery(
   }
 }
 
+fragment WorksForYouFeed_viewer_1G22uz on Viewer {
+  me {
+    followsAndSaves {
+      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, forSale: true) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            id
+            href
+            summary
+            artists
+            published_at: publishedAt(format: "MMM DD")
+            artworksConnection {
+              ...ArtworkGrid_artworks
+            }
+            image {
+              resized(height: 80, width: 80) {
+                url
+              }
+            }
+            __typename
+          }
+          cursor
+        }
+      }
+    }
+    id
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -46,6 +79,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -54,34 +116,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -122,63 +156,29 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
   }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment WorksForYouFeed_viewer_1G22uz on Viewer {
-  me {
-    followsAndSaves {
-      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, forSale: true) {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            id
-            href
-            summary
-            artists
-            published_at: publishedAt(format: "MMM DD")
-            artworksConnection {
-              ...ArtworkGrid_artworks
-            }
-            image {
-              resized(height: 80, width: 80) {
-                url
-              }
-            }
-            __typename
-          }
-          cursor
-        }
-      }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
   }
@@ -801,7 +801,7 @@ return {
     "operationKind": "query",
     "name": "WorksForYouFeedPaginationQuery",
     "id": null,
-    "text": "query WorksForYouFeedPaginationQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    ...WorksForYouFeed_viewer_1G22uz\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment WorksForYouFeed_viewer_1G22uz on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, forSale: true) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            id\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            image {\n              resized(height: 80, width: 80) {\n                url\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n",
+    "text": "query WorksForYouFeedPaginationQuery(\n  $count: Int!\n  $cursor: String\n) {\n  viewer {\n    ...WorksForYouFeed_viewer_1G22uz\n  }\n}\n\nfragment WorksForYouFeed_viewer_1G22uz on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: $count, after: $cursor, forSale: true) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            id\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            image {\n              resized(height: 80, width: 80) {\n                url\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/WorksForYouFeed_viewer.graphql.ts
+++ b/src/__generated__/WorksForYouFeed_viewer.graphql.ts
@@ -32,11 +32,6 @@ export type WorksForYouFeed_viewer = {
     } | null;
     readonly " $refType": "WorksForYouFeed_viewer";
 };
-export type WorksForYouFeed_viewer$data = WorksForYouFeed_viewer;
-export type WorksForYouFeed_viewer$key = {
-    readonly " $data"?: WorksForYouFeed_viewer$data;
-    readonly " $fragmentRefs": FragmentRefs<"WorksForYouFeed_viewer">;
-};
 
 
 

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -34,6 +34,70 @@ query WorksForYouQuery(
   }
 }
 
+fragment WorksForYouFeed_viewer_2l4hpM on Viewer {
+  me {
+    followsAndSaves {
+      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10, forSale: $forSale) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            id
+            href
+            summary
+            artists
+            published_at: publishedAt(format: "MMM DD")
+            artworksConnection {
+              ...ArtworkGrid_artworks
+            }
+            image {
+              resized(height: 80, width: 80) {
+                url
+              }
+            }
+            __typename
+          }
+          cursor
+        }
+      }
+    }
+    id
+  }
+}
+
+fragment WorksForYouArtistFeed_viewer_45bsh6 on Viewer {
+  artist(id: $artistID) {
+    name
+    href
+    counts {
+      artworks
+      for_sale_artworks: forSaleArtworks
+    }
+    image {
+      resized(height: 80, width: 80) {
+        url
+      }
+    }
+    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: 10, filter: $filter) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          id
+          __typename
+        }
+        cursor
+      }
+    }
+    id
+  }
+}
+
 fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   edges {
     __typename
@@ -52,6 +116,35 @@ fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
   }
 }
 
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
 fragment Badge_artwork on Artwork {
   is_biddable: isBiddable
   is_acquireable: isAcquireable
@@ -60,34 +153,6 @@ fragment Badge_artwork on Artwork {
   sale {
     is_preview: isPreview
     display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
     id
   }
 }
@@ -128,94 +193,29 @@ fragment Details_artwork on Artwork {
   }
 }
 
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
+fragment Contact_artwork on Artwork {
   href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment WorksForYouArtistFeed_viewer_45bsh6 on Viewer {
-  artist(id: $artistID) {
-    name
-    href
-    counts {
-      artworks
-      for_sale_artworks: forSaleArtworks
-    }
-    image {
-      resized(height: 80, width: 80) {
-        url
-      }
-    }
-    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: 10, filter: $filter) {
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          id
-          __typename
-        }
-        cursor
-      }
-    }
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
     id
   }
-}
-
-fragment WorksForYouFeed_viewer_2l4hpM on Viewer {
-  me {
-    followsAndSaves {
-      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10, forSale: $forSale) {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            id
-            href
-            summary
-            artists
-            published_at: publishedAt(format: "MMM DD")
-            artworksConnection {
-              ...ArtworkGrid_artworks
-            }
-            image {
-              resized(height: 80, width: 80) {
-                url
-              }
-            }
-            __typename
-          }
-          cursor
-        }
-      }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
     }
     id
   }
@@ -1026,7 +1026,7 @@ return {
     "operationKind": "query",
     "name": "WorksForYouQuery",
     "id": null,
-    "text": "query WorksForYouQuery(\n  $includeSelectedArtist: Boolean!\n  $artistID: String!\n  $forSale: Boolean\n  $filter: [ArtistArtworksFilters]\n) {\n  viewer {\n    ...WorksForYouFeed_viewer_2l4hpM @skip(if: $includeSelectedArtist)\n    ...WorksForYouArtistFeed_viewer_45bsh6 @include(if: $includeSelectedArtist)\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment WorksForYouArtistFeed_viewer_45bsh6 on Viewer {\n  artist(id: $artistID) {\n    name\n    href\n    counts {\n      artworks\n      for_sale_artworks: forSaleArtworks\n    }\n    image {\n      resized(height: 80, width: 80) {\n        url\n      }\n    }\n    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: 10, filter: $filter) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          id\n          __typename\n        }\n        cursor\n      }\n    }\n    id\n  }\n}\n\nfragment WorksForYouFeed_viewer_2l4hpM on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10, forSale: $forSale) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            id\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            image {\n              resized(height: 80, width: 80) {\n                url\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n",
+    "text": "query WorksForYouQuery(\n  $includeSelectedArtist: Boolean!\n  $artistID: String!\n  $forSale: Boolean\n  $filter: [ArtistArtworksFilters]\n) {\n  viewer {\n    ...WorksForYouFeed_viewer_2l4hpM @skip(if: $includeSelectedArtist)\n    ...WorksForYouArtistFeed_viewer_45bsh6 @include(if: $includeSelectedArtist)\n  }\n}\n\nfragment WorksForYouFeed_viewer_2l4hpM on Viewer {\n  me {\n    followsAndSaves {\n      notifications: bundledArtworksByArtistConnection(sort: PUBLISHED_AT_DESC, first: 10, forSale: $forSale) {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            id\n            href\n            summary\n            artists\n            published_at: publishedAt(format: \"MMM DD\")\n            artworksConnection {\n              ...ArtworkGrid_artworks\n            }\n            image {\n              resized(height: 80, width: 80) {\n                url\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment WorksForYouArtistFeed_viewer_45bsh6 on Viewer {\n  artist(id: $artistID) {\n    name\n    href\n    counts {\n      artworks\n      for_sale_artworks: forSaleArtworks\n    }\n    image {\n      resized(height: 80, width: 80) {\n        url\n      }\n    }\n    artworks_connection: artworksConnection(sort: PUBLISHED_AT_DESC, first: 10, filter: $filter) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          id\n          __typename\n        }\n        cursor\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/collectRoutes_ArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/collectRoutes_ArtworkFilterQuery.graphql.ts
@@ -75,191 +75,8 @@ query collectRoutes_ArtworkFilterQuery(
   }
 }
 
-fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
-  id
-  aggregations {
-    slice
-    counts {
-      value
-      name
-      count
-    }
-  }
-  pageInfo {
-    hasNextPage
-    endCursor
-  }
-  pageCursors {
-    ...Pagination_pageCursors
-  }
-  edges {
-    node {
-      id
-    }
-  }
-  ...ArtworkGrid_artworks
-}
-
-fragment ArtworkFilter_viewer_2c4z0P on Viewer {
-  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {
-    id
-    ...ArtworkFilterArtworkGrid2_filtered_artworks
-  }
-}
-
-fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
-  edges {
-    __typename
-    node {
-      id
-      slug
-      href
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...GridItem_artwork
-    }
-    ... on Node {
-      id
-    }
-  }
-}
-
-fragment Badge_artwork on Artwork {
-  is_biddable: isBiddable
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-  href
-  sale {
-    is_preview: isPreview
-    display_timely_at: displayTimelyAt
-    id
-  }
-}
-
 fragment Collect_marketingHubCollections on MarketingCollection {
   ...CollectionsHubsNav_marketingHubCollections
-}
-
-fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {
-  slug
-  title
-  thumbnail
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
-}
-
-fragment Details_artwork on Artwork {
-  href
-  title
-  date
-  sale_message: saleMessage
-  cultural_maker: culturalMaker
-  artists(shallow: true) {
-    id
-    href
-    name
-  }
-  collecting_institution: collectingInstitution
-  partner(shallow: true) {
-    name
-    href
-    id
-  }
-  sale {
-    is_auction: isAuction
-    is_closed: isClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    counts {
-      bidder_positions: bidderPositions
-    }
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    id
-  }
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
 }
 
 fragment SeoProductsForArtworks_artworks on FilterArtworksConnection {
@@ -316,6 +133,189 @@ fragment SeoProductsForArtworks_artworks on FilterArtworksConnection {
       }
     }
   }
+}
+
+fragment ArtworkFilter_viewer_2c4z0P on Viewer {
+  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {
+    id
+    ...ArtworkFilterArtworkGrid2_filtered_artworks
+  }
+}
+
+fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
+  id
+  aggregations {
+    slice
+    counts {
+      value
+      name
+      count
+    }
+  }
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {
+  slug
+  title
+  thumbnail
 }
 */
 
@@ -1422,7 +1422,7 @@ return {
     "operationKind": "query",
     "name": "collectRoutes_ArtworkFilterQuery",
     "id": null,
-    "text": "query collectRoutes_ArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $artistID: String\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $keyword: String\n  $width: String\n) {\n  marketingHubCollections {\n    ...Collect_marketingHubCollections\n    id\n  }\n  filterArtworks: artworksConnection(aggregations: $aggregations, sort: $sort, first: 30) {\n    ...SeoProductsForArtworks_artworks\n    id\n  }\n  viewer {\n    ...ArtworkFilter_viewer_2c4z0P\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2c4z0P on Viewer {\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collect_marketingHubCollections on MarketingCollection {\n  ...CollectionsHubsNav_marketingHubCollections\n}\n\nfragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {\n  slug\n  title\n  thumbnail\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query collectRoutes_ArtworkFilterQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $artistID: String\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $keyword: String\n  $width: String\n) {\n  marketingHubCollections {\n    ...Collect_marketingHubCollections\n    id\n  }\n  filterArtworks: artworksConnection(aggregations: $aggregations, sort: $sort, first: 30) {\n    ...SeoProductsForArtworks_artworks\n    id\n  }\n  viewer {\n    ...ArtworkFilter_viewer_2c4z0P\n  }\n}\n\nfragment Collect_marketingHubCollections on MarketingCollection {\n  ...CollectionsHubsNav_marketingHubCollections\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkFilter_viewer_2c4z0P on Viewer {\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sort: $sort, width: $width, first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {\n  slug\n  title\n  thumbnail\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/createTestEnv_artwork.graphql.ts
+++ b/src/__generated__/createTestEnv_artwork.graphql.ts
@@ -1,18 +1,12 @@
 /* tslint:disable */
 
 import { ReaderFragment } from "relay-runtime";
-import { FragmentRefs } from "relay-runtime";
 export type createTestEnv_artwork = {
     readonly title: string | null;
     readonly artist: {
         readonly name: string | null;
     } | null;
     readonly " $refType": "createTestEnv_artwork";
-};
-export type createTestEnv_artwork$data = createTestEnv_artwork;
-export type createTestEnv_artwork$key = {
-    readonly " $data"?: createTestEnv_artwork$data;
-    readonly " $fragmentRefs": FragmentRefs<"createTestEnv_artwork">;
 };
 
 

--- a/src/__generated__/redirects_order.graphql.ts
+++ b/src/__generated__/redirects_order.graphql.ts
@@ -4,7 +4,6 @@ import { ReaderFragment } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderParticipantEnum = "BUYER" | "SELLER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
-import { FragmentRefs } from "relay-runtime";
 export type redirects_order = {
     readonly internalID: string;
     readonly mode: CommerceOrderModeEnum | null;
@@ -35,11 +34,6 @@ export type redirects_order = {
     } | null;
     readonly awaitingResponseFrom?: CommerceOrderParticipantEnum | null;
     readonly " $refType": "redirects_order";
-};
-export type redirects_order$data = redirects_order;
-export type redirects_order$key = {
-    readonly " $data"?: redirects_order$data;
-    readonly " $fragmentRefs": FragmentRefs<"redirects_order">;
 };
 
 

--- a/src/__generated__/routes_AcceptQuery.graphql.ts
+++ b/src/__generated__/routes_AcceptQuery.graphql.ts
@@ -59,80 +59,6 @@ fragment Accept_order on CommerceOrder {
   ...CreditCardSummaryItem_order
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -173,6 +99,80 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -706,7 +706,7 @@ return {
     "operationKind": "query",
     "name": "routes_AcceptQuery",
     "id": null,
-    "text": "query routes_AcceptQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    id\n  }\n}\n\nfragment Accept_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_AcceptQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Accept_order\n    id\n  }\n}\n\nfragment Accept_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
@@ -35,28 +35,6 @@ fragment ArtistApp_artist on Artist {
   ...NavigationTabs_artist
 }
 
-fragment ArtistHeader_artist on Artist {
-  internalID
-  slug
-  name
-  nationality
-  years
-  counts {
-    follows
-  }
-  carousel {
-    images {
-      href
-      resized(height: 200) {
-        url
-        width
-        height
-      }
-    }
-  }
-  ...FollowArtistButton_artist
-}
-
 fragment ArtistMeta_artist on Artist {
   slug
   name
@@ -127,14 +105,26 @@ fragment ArtistMeta_artist on Artist {
   }
 }
 
-fragment FollowArtistButton_artist on Artist {
-  id
+fragment ArtistHeader_artist on Artist {
   internalID
+  slug
   name
-  is_followed: isFollowed
+  nationality
+  years
   counts {
     follows
   }
+  carousel {
+    images {
+      href
+      resized(height: 200) {
+        url
+        width
+        height
+      }
+    }
+  }
+  ...FollowArtistButton_artist
 }
 
 fragment NavigationTabs_artist on Artist {
@@ -144,6 +134,16 @@ fragment NavigationTabs_artist on Artist {
     articles
     cv(minShowCount: 0)
     auction_lots: auctionLots
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
   }
 }
 */
@@ -712,7 +712,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistTopLevelQuery",
     "id": null,
-    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n            }\n            maxPrice {\n              major\n              currencyCode\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots: auctionLots\n  }\n}\n",
+    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n            }\n            maxPrice {\n              major\n              currencyCode\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  nationality\n  years\n  counts {\n    follows\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    articles\n    cv(minShowCount: 0)\n    auction_lots: auctionLots\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/routes_ArtworkQuery.graphql.ts
@@ -27,23 +27,39 @@ query routes_ArtworkQuery(
   }
 }
 
-fragment ArtistBio_bio on Artist {
-  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
-    text
-  }
-}
-
-fragment ArtistCard_artist on Artist {
-  name
+fragment ArtworkApp_artwork on Artwork {
   slug
-  href
-  image {
-    cropped(width: 400, height: 300) {
-      url
+  internalID
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
+  availability
+  listPrice {
+    __typename
+    ... on PriceRange {
+      display
+    }
+    ... on Money {
+      display
     }
   }
-  formatted_nationality_and_birthday: formattedNationalityAndBirthday
-  ...FollowArtistButton_artist
+  is_in_auction: isInAuction
+  artists {
+    id
+    slug
+    ...ArtistInfo_artist
+  }
+  artist {
+    ...ArtistInfo_artist
+    id
+  }
+  ...ArtworkRelatedArtists_artwork
+  ...ArtworkMeta_artwork
+  ...ArtworkBanner_artwork
+  ...ArtworkSidebar_artwork
+  ...ArtworkDetails_artwork
+  ...ArtworkImageBrowser_artwork
+  ...OtherWorks_artwork
+  ...PricingContext_artwork
 }
 
 fragment ArtistInfo_artist on Artist {
@@ -92,102 +108,68 @@ fragment ArtistInfo_artist on Artist {
   }
 }
 
-fragment ArtistMarketInsights_artist on Artist {
-  collections
-  highlights {
-    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
-      edges {
-        node {
-          categories {
-            slug
+fragment ArtworkRelatedArtists_artwork on Artwork {
+  slug
+  artist {
+    href
+    related {
+      artistsConnection(kind: MAIN, first: 4, after: "") {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            ...ArtistCard_artist
             id
+            __typename
           }
-          id
+          cursor
         }
-        id
       }
     }
-  }
-  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
-    edges {
-      node {
-        price_realized: priceRealized {
-          display(format: "0a")
-        }
-        organization
-        sale_date: saleDate(format: "YYYY")
-        id
-      }
-    }
+    id
   }
 }
 
-fragment ArtworkActions_artwork on Artwork {
-  ...Save_artwork
-  ...ArtworkSharePanel_artwork
-  artists {
+fragment ArtworkMeta_artwork on Artwork {
+  href
+  internalID
+  date
+  artist_names: artistNames
+  sale_message: saleMessage
+  partner {
     name
     id
   }
-  date
-  dimensions {
-    cm
-  }
-  href
-  slug
-  image {
-    internalID
-    url(version: "larger")
-    height
-    width
-  }
-  is_downloadable: isDownloadable
-  is_hangable: isHangable
-  partner {
-    slug
-    id
-  }
-  title
-  sale {
-    is_closed: isClosed
-    is_auction: isAuction
-    id
-  }
-}
-
-fragment ArtworkApp_artwork on Artwork {
-  slug
-  internalID
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-  availability
-  listPrice {
-    __typename
-    ... on PriceRange {
-      display
-    }
-    ... on Money {
-      display
-    }
-  }
+  image_rights: imageRights
   is_in_auction: isInAuction
-  artists {
-    id
-    slug
-    ...ArtistInfo_artist
+  is_acquireable: isAcquireable
+  is_shareable: isShareable
+  meta_image: image {
+    resized(width: 640, height: 640, version: ["large", "medium", "tall"]) {
+      width
+      height
+      url
+    }
   }
-  artist {
-    ...ArtistInfo_artist
-    id
+  meta {
+    title
+    description(limit: 155)
+    long_description: description(limit: 200)
   }
-  ...ArtworkRelatedArtists_artwork
-  ...ArtworkMeta_artwork
-  ...ArtworkBanner_artwork
-  ...ArtworkSidebar_artwork
-  ...ArtworkDetails_artwork
-  ...ArtworkImageBrowser_artwork
-  ...OtherWorks_artwork
-  ...PricingContext_artwork
+  context {
+    __typename
+    ... on Fair {
+      slug
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  ...SeoDataForArtwork_artwork
 }
 
 fragment ArtworkBanner_artwork on Artwork {
@@ -238,6 +220,329 @@ fragment ArtworkBanner_artwork on Artwork {
     ... on Node {
       id
     }
+  }
+}
+
+fragment ArtworkSidebar_artwork on Artwork {
+  is_in_auction: isInAuction
+  ...ArtworkSidebarArtists_artwork
+  ...ArtworkSidebarMetadata_artwork
+  ...ArtworkSidebarAuctionPartnerInfo_artwork
+  ...ArtworkSidebarCurrentBidInfo_artwork
+  ...ArtworkSidebarBidAction_artwork
+  ...ArtworkSidebarCommercial_artwork
+  ...ArtworkSidebarPartnerInfo_artwork
+  ...ArtworkSidebarExtraLinks_artwork
+  ...SecurePayment_artwork
+  ...VerifiedSeller_artwork
+  ...AuthenticityCertificate_artwork
+  sale {
+    is_closed: isClosed
+    ...AuctionTimer_sale
+    id
+  }
+}
+
+fragment ArtworkDetails_artwork on Artwork {
+  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
+  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
+  ...ArtworkDetailsAdditionalInfo_artwork
+  ...ArtworkDetailsArticles_artwork
+  articles(size: 10) {
+    slug
+    id
+  }
+  literature(format: HTML)
+  exhibition_history: exhibitionHistory(format: HTML)
+  provenance(format: HTML)
+}
+
+fragment ArtworkImageBrowser_artwork on Artwork {
+  image_alt: formattedMetadata
+  ...ArtworkActions_artwork
+  image {
+    internalID
+  }
+  images {
+    internalID
+    uri: url(version: ["large"])
+    placeholder: resized(width: 30, height: 30, version: "small") {
+      url
+    }
+    aspectRatio
+    is_zoomable: isZoomable
+    is_default: isDefault
+    deepZoom {
+      Image {
+        xmlns
+        Url
+        Format
+        TileSize
+        Overlap
+        Size {
+          Width
+          Height
+        }
+      }
+    }
+  }
+}
+
+fragment OtherWorks_artwork on Artwork {
+  contextGrids {
+    __typename
+    title
+    ctaTitle
+    ctaHref
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+  }
+  ...RelatedWorksArtworkGrid_artwork
+  slug
+  internalID
+  sale {
+    is_closed: isClosed
+    id
+  }
+  context {
+    __typename
+    ... on Node {
+      id
+    }
+    ... on Fair {
+      id
+    }
+  }
+}
+
+fragment PricingContext_artwork on Artwork {
+  listPrice {
+    __typename
+    ... on PriceRange {
+      maxPrice {
+        minor
+      }
+      minPrice {
+        minor
+      }
+    }
+    ... on Money {
+      minor
+    }
+  }
+  artists {
+    slug
+    id
+  }
+  category
+  pricingContext {
+    appliedFiltersDisplay
+    appliedFilters {
+      dimension
+      category
+    }
+    bins {
+      maxPrice
+      maxPriceCents
+      minPrice
+      minPriceCents
+      numArtworks
+    }
+  }
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment RelatedWorksArtworkGrid_artwork on Artwork {
+  layers {
+    name
+    internalID
+    id
+  }
+  slug
+  layer {
+    name
+    artworksConnection(first: 8) {
+      ...ArtworkGrid_artworks
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+    id
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Save_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment ArtworkActions_artwork on Artwork {
+  ...Save_artwork
+  ...ArtworkSharePanel_artwork
+  artists {
+    name
+    id
+  }
+  date
+  dimensions {
+    cm
+  }
+  href
+  slug
+  image {
+    internalID
+    url(version: "larger")
+    height
+    width
+  }
+  is_downloadable: isDownloadable
+  is_hangable: isHangable
+  partner {
+    slug
+    id
+  }
+  title
+  sale {
+    is_closed: isClosed
+    is_auction: isAuction
+    id
+  }
+}
+
+fragment ArtworkSharePanel_artwork on Artwork {
+  href
+  images {
+    url
+  }
+  artworkMeta: meta {
+    share
   }
 }
 
@@ -317,141 +622,10 @@ fragment ArtworkDetailsArticles_artwork on Artwork {
   }
 }
 
-fragment ArtworkDetails_artwork on Artwork {
-  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork
-  ...ArtworkDetailsAboutTheWorkFromPartner_artwork
-  ...ArtworkDetailsAdditionalInfo_artwork
-  ...ArtworkDetailsArticles_artwork
-  articles(size: 10) {
-    slug
-    id
-  }
-  literature(format: HTML)
-  exhibition_history: exhibitionHistory(format: HTML)
-  provenance(format: HTML)
-}
-
-fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
-  edges {
-    __typename
-    node {
-      id
-      slug
-      href
-      image {
-        aspect_ratio: aspectRatio
-      }
-      ...GridItem_artwork
-    }
-    ... on Node {
-      id
-    }
-  }
-}
-
-fragment ArtworkImageBrowser_artwork on Artwork {
-  image_alt: formattedMetadata
-  ...ArtworkActions_artwork
-  image {
-    internalID
-  }
-  images {
-    internalID
-    uri: url(version: ["large"])
-    placeholder: resized(width: 30, height: 30, version: "small") {
-      url
-    }
-    aspectRatio
-    is_zoomable: isZoomable
-    is_default: isDefault
-    deepZoom {
-      Image {
-        xmlns
-        Url
-        Format
-        TileSize
-        Overlap
-        Size {
-          Width
-          Height
-        }
-      }
-    }
-  }
-}
-
-fragment ArtworkMeta_artwork on Artwork {
-  href
+fragment FollowProfileButton_profile on Profile {
+  id
   internalID
-  date
-  artist_names: artistNames
-  sale_message: saleMessage
-  partner {
-    name
-    id
-  }
-  image_rights: imageRights
-  is_in_auction: isInAuction
-  is_acquireable: isAcquireable
-  is_shareable: isShareable
-  meta_image: image {
-    resized(width: 640, height: 640, version: ["large", "medium", "tall"]) {
-      width
-      height
-      url
-    }
-  }
-  meta {
-    title
-    description(limit: 155)
-    long_description: description(limit: 200)
-  }
-  context {
-    __typename
-    ... on Fair {
-      slug
-      name
-      id
-    }
-    ... on Node {
-      id
-    }
-  }
-  ...SeoDataForArtwork_artwork
-}
-
-fragment ArtworkRelatedArtists_artwork on Artwork {
-  slug
-  artist {
-    href
-    related {
-      artistsConnection(kind: MAIN, first: 4, after: "") {
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            ...ArtistCard_artist
-            id
-            __typename
-          }
-          cursor
-        }
-      }
-    }
-    id
-  }
-}
-
-fragment ArtworkSharePanel_artwork on Artwork {
-  href
-  images {
-    url
-  }
-  artworkMeta: meta {
-    share
-  }
+  is_followed: isFollowed
 }
 
 fragment ArtworkSidebarArtists_artwork on Artwork {
@@ -464,6 +638,21 @@ fragment ArtworkSidebarArtists_artwork on Artwork {
     href
     ...FollowArtistButton_artist_2eN9lh
   }
+}
+
+fragment ArtworkSidebarMetadata_artwork on Artwork {
+  is_biddable: isBiddable
+  edition_sets: editionSets {
+    __typename
+    id
+  }
+  sale_artwork: saleArtwork {
+    lot_label: lotLabel
+    id
+  }
+  ...ArtworkSidebarTitleInfo_artwork
+  ...ArtworkSidebarSizeInfo_piece
+  ...ArtworkSidebarClassification_artwork
 }
 
 fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
@@ -479,76 +668,6 @@ fragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {
     internalID
     is_closed: isClosed
     id
-  }
-}
-
-fragment ArtworkSidebarBidAction_artwork on Artwork {
-  myLotStanding(live: true) {
-    most_recent_bid: mostRecentBid {
-      max_bid: maxBid {
-        cents
-      }
-      id
-    }
-  }
-  slug
-  internalID
-  sale {
-    slug
-    registrationStatus {
-      qualified_for_bidding: qualifiedForBidding
-      id
-    }
-    is_preview: isPreview
-    is_open: isOpen
-    is_live_open: isLiveOpen
-    is_closed: isClosed
-    is_registration_closed: isRegistrationClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    increments {
-      cents
-      display
-    }
-    id
-  }
-}
-
-fragment ArtworkSidebarClassification_artwork on Artwork {
-  attribution_class: attributionClass {
-    short_description: shortDescription
-    id
-  }
-}
-
-fragment ArtworkSidebarCommercial_artwork on Artwork {
-  slug
-  internalID
-  is_for_sale: isForSale
-  is_acquireable: isAcquireable
-  is_inquireable: isInquireable
-  is_offerable: isOfferable
-  listPrice {
-    __typename
-    ... on PriceRange {
-      display
-    }
-    ... on Money {
-      display
-    }
-  }
-  priceIncludesTaxDisplay
-  sale_message: saleMessage
-  shippingInfo
-  shippingOrigin
-  edition_sets: editionSets {
-    internalID
-    id
-    is_acquireable: isAcquireable
-    is_offerable: isOfferable
-    sale_message: saleMessage
-    ...ArtworkSidebarSizeInfo_piece
   }
 }
 
@@ -586,6 +705,81 @@ fragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {
   }
 }
 
+fragment ArtworkSidebarBidAction_artwork on Artwork {
+  myLotStanding(live: true) {
+    most_recent_bid: mostRecentBid {
+      max_bid: maxBid {
+        cents
+      }
+      id
+    }
+  }
+  slug
+  internalID
+  sale {
+    slug
+    registrationStatus {
+      qualified_for_bidding: qualifiedForBidding
+      id
+    }
+    is_preview: isPreview
+    is_open: isOpen
+    is_live_open: isLiveOpen
+    is_closed: isClosed
+    is_registration_closed: isRegistrationClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    increments {
+      cents
+      display
+    }
+    id
+  }
+}
+
+fragment ArtworkSidebarCommercial_artwork on Artwork {
+  slug
+  internalID
+  is_for_sale: isForSale
+  is_acquireable: isAcquireable
+  is_inquireable: isInquireable
+  is_offerable: isOfferable
+  listPrice {
+    __typename
+    ... on PriceRange {
+      display
+    }
+    ... on Money {
+      display
+    }
+  }
+  priceIncludesTaxDisplay
+  sale_message: saleMessage
+  shippingInfo
+  shippingOrigin
+  edition_sets: editionSets {
+    internalID
+    id
+    is_acquireable: isAcquireable
+    is_offerable: isOfferable
+    sale_message: saleMessage
+    ...ArtworkSidebarSizeInfo_piece
+  }
+}
+
+fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+  partner {
+    name
+    href
+    locations {
+      city
+      id
+    }
+    id
+  }
+}
+
 fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   internalID
   is_in_auction: isInAuction
@@ -602,31 +796,28 @@ fragment ArtworkSidebarExtraLinks_artwork on Artwork {
   }
 }
 
-fragment ArtworkSidebarMetadata_artwork on Artwork {
-  is_biddable: isBiddable
-  edition_sets: editionSets {
-    __typename
-    id
-  }
-  sale_artwork: saleArtwork {
-    lot_label: lotLabel
-    id
-  }
-  ...ArtworkSidebarTitleInfo_artwork
-  ...ArtworkSidebarSizeInfo_piece
-  ...ArtworkSidebarClassification_artwork
+fragment SecurePayment_artwork on Artwork {
+  is_acquireable: isAcquireable
+  is_offerable: isOfferable
 }
 
-fragment ArtworkSidebarPartnerInfo_artwork on Artwork {
+fragment VerifiedSeller_artwork on Artwork {
+  is_biddable: isBiddable
   partner {
+    isVerifiedSeller
     name
-    href
-    locations {
-      city
-      id
-    }
     id
   }
+}
+
+fragment AuthenticityCertificate_artwork on Artwork {
+  hasCertificateOfAuthenticity
+  is_biddable: isBiddable
+}
+
+fragment AuctionTimer_sale on Sale {
+  live_start_at: liveStartAt
+  end_at: endAt
 }
 
 fragment ArtworkSidebarSizeInfo_piece on Sellable {
@@ -643,119 +834,10 @@ fragment ArtworkSidebarTitleInfo_artwork on Artwork {
   medium
 }
 
-fragment ArtworkSidebar_artwork on Artwork {
-  is_in_auction: isInAuction
-  ...ArtworkSidebarArtists_artwork
-  ...ArtworkSidebarMetadata_artwork
-  ...ArtworkSidebarAuctionPartnerInfo_artwork
-  ...ArtworkSidebarCurrentBidInfo_artwork
-  ...ArtworkSidebarBidAction_artwork
-  ...ArtworkSidebarCommercial_artwork
-  ...ArtworkSidebarPartnerInfo_artwork
-  ...ArtworkSidebarExtraLinks_artwork
-  ...SecurePayment_artwork
-  ...VerifiedSeller_artwork
-  ...AuthenticityCertificate_artwork
-  sale {
-    is_closed: isClosed
-    ...AuctionTimer_sale
+fragment ArtworkSidebarClassification_artwork on Artwork {
+  attribution_class: attributionClass {
+    short_description: shortDescription
     id
-  }
-}
-
-fragment AuctionTimer_sale on Sale {
-  live_start_at: liveStartAt
-  end_at: endAt
-}
-
-fragment AuthenticityCertificate_artwork on Artwork {
-  hasCertificateOfAuthenticity
-  is_biddable: isBiddable
-}
-
-fragment Badge_artwork on Artwork {
-  is_biddable: isBiddable
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-  href
-  sale {
-    is_preview: isPreview
-    display_timely_at: displayTimelyAt
-    id
-  }
-}
-
-fragment Contact_artwork on Artwork {
-  href
-  is_inquireable: isInquireable
-  sale {
-    is_auction: isAuction
-    is_live_open: isLiveOpen
-    is_open: isOpen
-    is_closed: isClosed
-    id
-  }
-  partner(shallow: true) {
-    type
-    id
-  }
-  sale_artwork: saleArtwork {
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    counts {
-      bidder_positions: bidderPositions
-    }
-    id
-  }
-}
-
-fragment Details_artwork on Artwork {
-  href
-  title
-  date
-  sale_message: saleMessage
-  cultural_maker: culturalMaker
-  artists(shallow: true) {
-    id
-    href
-    name
-  }
-  collecting_institution: collectingInstitution
-  partner(shallow: true) {
-    name
-    href
-    id
-  }
-  sale {
-    is_auction: isAuction
-    is_closed: isClosed
-    id
-  }
-  sale_artwork: saleArtwork {
-    counts {
-      bidder_positions: bidderPositions
-    }
-    highest_bid: highestBid {
-      display
-    }
-    opening_bid: openingBid {
-      display
-    }
-    id
-  }
-}
-
-fragment FollowArtistButton_artist on Artist {
-  id
-  internalID
-  name
-  is_followed: isFollowed
-  counts {
-    follows
   }
 }
 
@@ -768,16 +850,6 @@ fragment FollowArtistButton_artist_2eN9lh on Artist {
     follows
   }
   ...FollowArtistPopover_artist
-}
-
-fragment FollowArtistPopoverRow_artist on Artist {
-  internalID
-  name
-  image {
-    cropped(width: 45, height: 45) {
-      url
-    }
-  }
 }
 
 fragment FollowArtistPopover_artist on Artist {
@@ -794,160 +866,14 @@ fragment FollowArtistPopover_artist on Artist {
   }
 }
 
-fragment FollowProfileButton_profile on Profile {
-  id
+fragment FollowArtistPopoverRow_artist on Artist {
   internalID
-  is_followed: isFollowed
-}
-
-fragment GridItem_artwork on Artwork {
-  internalID
-  title
-  image_title: imageTitle
-  image {
-    placeholder
-    url(version: "large")
-    aspect_ratio: aspectRatio
-  }
-  href
-  ...Metadata_artwork
-  ...Save_artwork
-  ...Badge_artwork
-}
-
-fragment Metadata_artwork on Artwork {
-  ...Details_artwork
-  ...Contact_artwork
-  href
-}
-
-fragment OtherWorks_artwork on Artwork {
-  contextGrids {
-    __typename
-    title
-    ctaTitle
-    ctaHref
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
-    }
-  }
-  ...RelatedWorksArtworkGrid_artwork
-  slug
-  internalID
-  sale {
-    is_closed: isClosed
-    id
-  }
-  context {
-    __typename
-    ... on Node {
-      id
-    }
-    ... on Fair {
-      id
-    }
-  }
-}
-
-fragment PricingContext_artwork on Artwork {
-  listPrice {
-    __typename
-    ... on PriceRange {
-      maxPrice {
-        minor
-      }
-      minPrice {
-        minor
-      }
-    }
-    ... on Money {
-      minor
-    }
-  }
-  artists {
-    slug
-    id
-  }
-  category
-  pricingContext {
-    appliedFiltersDisplay
-    appliedFilters {
-      dimension
-      category
-    }
-    bins {
-      maxPrice
-      maxPriceCents
-      minPrice
-      minPriceCents
-      numArtworks
-    }
-  }
-}
-
-fragment RelatedWorksArtworkGrid_artwork on Artwork {
-  layers {
-    name
-    internalID
-    id
-  }
-  slug
-  layer {
-    name
-    artworksConnection(first: 8) {
-      ...ArtworkGrid_artworks
-      edges {
-        node {
-          slug
-          id
-        }
-      }
-    }
-    id
-  }
-}
-
-fragment Save_artwork on Artwork {
-  id
-  internalID
-  slug
-  is_saved: isSaved
-  title
-}
-
-fragment SecurePayment_artwork on Artwork {
-  is_acquireable: isAcquireable
-  is_offerable: isOfferable
-}
-
-fragment SelectedExhibitions_exhibitions on Show {
-  partner {
-    __typename
-    ... on ExternalPartner {
-      name
-      id
-    }
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-  }
   name
-  start_at: startAt(format: "YYYY")
-  cover_image: coverImage {
-    cropped(width: 800, height: 600) {
+  image {
+    cropped(width: 45, height: 45) {
       url
     }
   }
-  city
 }
 
 fragment SeoDataForArtwork_artwork on Artwork {
@@ -998,12 +924,86 @@ fragment SeoDataForArtwork_artwork on Artwork {
   }
 }
 
-fragment VerifiedSeller_artwork on Artwork {
-  is_biddable: isBiddable
+fragment ArtistCard_artist on Artist {
+  name
+  slug
+  href
+  image {
+    cropped(width: 400, height: 300) {
+      url
+    }
+  }
+  formatted_nationality_and_birthday: formattedNationalityAndBirthday
+  ...FollowArtistButton_artist
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+
+fragment SelectedExhibitions_exhibitions on Show {
   partner {
-    isVerifiedSeller
-    name
-    id
+    __typename
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+  }
+  name
+  start_at: startAt(format: "YYYY")
+  cover_image: coverImage {
+    cropped(width: 800, height: 600) {
+      url
+    }
+  }
+  city
+}
+
+fragment ArtistBio_bio on Artist {
+  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
+    text
+  }
+}
+
+fragment ArtistMarketInsights_artist on Artist {
+  collections
+  highlights {
+    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            slug
+            id
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {
+    edges {
+      node {
+        price_realized: priceRealized {
+          display(format: "0a")
+        }
+        organization
+        sale_date: saleDate(format: "YYYY")
+        id
+      }
+    }
   }
 }
 */
@@ -3520,7 +3520,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtworkQuery",
     "id": null,
-    "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...PricingContext_artwork\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    initials\n    id\n  }\n  sale {\n    is_auction: isAuction\n    isBenefit\n    isGalleryAuction\n    cover_image: coverImage {\n      url(version: \"square\")\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        id\n      }\n      id\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artist_names: artistNames\n  sale_message: saleMessage\n  partner {\n    name\n    id\n  }\n  image_rights: imageRights\n  is_in_auction: isInAuction\n  is_acquireable: isAcquireable\n  is_shareable: isShareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n    ... on Fair {\n      id\n    }\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  price_currency: priceCurrency\n  sale_message: saleMessage\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artist_names: artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
+    "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...PricingContext_artwork\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artist_names: artistNames\n  sale_message: saleMessage\n  partner {\n    name\n    id\n  }\n  image_rights: imageRights\n  is_in_auction: isInAuction\n  is_acquireable: isAcquireable\n  is_shareable: isShareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    initials\n    id\n  }\n  sale {\n    is_auction: isAuction\n    isBenefit\n    isGalleryAuction\n    cover_image: coverImage {\n      url(version: \"square\")\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        id\n      }\n      id\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n    ... on Fair {\n      id\n    }\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  price_currency: priceCurrency\n  sale_message: saleMessage\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artist_names: artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_AuctionResultsQuery.graphql.ts
+++ b/src/__generated__/routes_AuctionResultsQuery.graphql.ts
@@ -27,25 +27,8 @@ query routes_AuctionResultsQuery(
   }
 }
 
-fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
-  title
-  dimension_text: dimensionText
-  organization
-  images {
-    thumbnail {
-      url
-    }
-  }
-  description
-  date_text: dateText
-  sale_date_text: saleDateText
-  price_realized: priceRealized {
-    display
-    cents_usd: centsUSD
-  }
-  estimate {
-    display
-  }
+fragment AuctionResults_artist on Artist {
+  ...ArtistAuctionResults_artist
 }
 
 fragment ArtistAuctionResults_artist on Artist {
@@ -68,10 +51,6 @@ fragment ArtistAuctionResults_artist on Artist {
   }
 }
 
-fragment AuctionResults_artist on Artist {
-  ...ArtistAuctionResults_artist
-}
-
 fragment Pagination_pageCursors on PageCursors {
   around {
     cursor
@@ -91,6 +70,27 @@ fragment Pagination_pageCursors on PageCursors {
   previous {
     cursor
     page
+  }
+}
+
+fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
+  title
+  dimension_text: dimensionText
+  organization
+  images {
+    thumbnail {
+      url
+    }
+  }
+  description
+  date_text: dateText
+  sale_date_text: saleDateText
+  price_realized: priceRealized {
+    display
+    cents_usd: centsUSD
+  }
+  estimate {
+    display
   }
 }
 */
@@ -440,7 +440,7 @@ return {
     "operationKind": "query",
     "name": "routes_AuctionResultsQuery",
     "id": null,
-    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_CVQuery.graphql.ts
+++ b/src/__generated__/routes_CVQuery.graphql.ts
@@ -26,9 +26,24 @@ query routes_CVQuery(
   }
 }
 
-fragment CVItem_artist_47e96d on Artist {
+fragment CV_viewer on Viewer {
+  artist_soloShows: artist(id: $artistID) {
+    ...CVItem_artist_ieWPx
+    id
+  }
+  artist_groupShows: artist(id: $artistID) {
+    ...CVItem_artist_4DszuY
+    id
+  }
+  artist_fairBooths: artist(id: $artistID) {
+    ...CVItem_artist_47e96d
+    id
+  }
+}
+
+fragment CVItem_artist_ieWPx on Artist {
   slug
-  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {
+  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {
     pageInfo {
       hasNextPage
       endCursor
@@ -96,9 +111,9 @@ fragment CVItem_artist_4DszuY on Artist {
   }
 }
 
-fragment CVItem_artist_ieWPx on Artist {
+fragment CVItem_artist_47e96d on Artist {
   slug
-  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {
+  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {
     pageInfo {
       hasNextPage
       endCursor
@@ -128,21 +143,6 @@ fragment CVItem_artist_ieWPx on Artist {
       }
       cursor
     }
-  }
-}
-
-fragment CV_viewer on Viewer {
-  artist_soloShows: artist(id: $artistID) {
-    ...CVItem_artist_ieWPx
-    id
-  }
-  artist_groupShows: artist(id: $artistID) {
-    ...CVItem_artist_4DszuY
-    id
-  }
-  artist_fairBooths: artist(id: $artistID) {
-    ...CVItem_artist_47e96d
-    id
   }
 }
 */
@@ -520,7 +520,7 @@ return {
     "operationKind": "query",
     "name": "routes_CVQuery",
     "id": null,
-    "text": "query routes_CVQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...CV_viewer\n  }\n}\n\nfragment CVItem_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CV_viewer on Viewer {\n  artist_soloShows: artist(id: $artistID) {\n    ...CVItem_artist_ieWPx\n    id\n  }\n  artist_groupShows: artist(id: $artistID) {\n    ...CVItem_artist_4DszuY\n    id\n  }\n  artist_fairBooths: artist(id: $artistID) {\n    ...CVItem_artist_47e96d\n    id\n  }\n}\n",
+    "text": "query routes_CVQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...CV_viewer\n  }\n}\n\nfragment CV_viewer on Viewer {\n  artist_soloShows: artist(id: $artistID) {\n    ...CVItem_artist_ieWPx\n    id\n  }\n  artist_groupShows: artist(id: $artistID) {\n    ...CVItem_artist_4DszuY\n    id\n  }\n  artist_fairBooths: artist(id: $artistID) {\n    ...CVItem_artist_47e96d\n    id\n  }\n}\n\nfragment CVItem_artist_ieWPx on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: true, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_4DszuY on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: false, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment CVItem_artist_47e96d on Artist {\n  slug\n  showsConnection(first: 10, sort: START_AT_DESC, atAFair: true, soloShow: false, isReference: true, visibleToPublic: false) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n            href\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        start_at: startAt(format: \"YYYY\")\n        city\n        href\n        __typename\n      }\n      cursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -130,16 +130,6 @@ query routes_ConfirmBidQuery(
   }
 }
 
-fragment BidForm_saleArtwork on SaleArtwork {
-  minimumNextBid {
-    cents
-  }
-  increments(useMyMaxBid: true) {
-    cents
-    display
-  }
-}
-
 fragment LotInfo_artwork on Artwork {
   internalID
   date
@@ -155,6 +145,16 @@ fragment LotInfo_saleArtwork on SaleArtwork {
   lotLabel
   minimumNextBid {
     amount
+    cents
+    display
+  }
+}
+
+fragment BidForm_saleArtwork on SaleArtwork {
+  minimumNextBid {
+    cents
+  }
+  increments(useMyMaxBid: true) {
     cents
     display
   }
@@ -521,7 +521,7 @@ return {
     "operationKind": "query",
     "name": "routes_ConfirmBidQuery",
     "id": null,
-    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    id\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n      internalID\n      slug\n      sale {\n        id\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n      }\n    }\n  }\n  me {\n    id\n    internalID\n    hasQualifiedCreditCards\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    id\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n      internalID\n      slug\n      sale {\n        id\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n      }\n    }\n  }\n  me {\n    id\n    internalID\n    hasQualifiedCreditCards\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_CounterQuery.graphql.ts
+++ b/src/__generated__/routes_CounterQuery.graphql.ts
@@ -28,6 +28,83 @@ query routes_CounterQuery(
   }
 }
 
+fragment Counter_order on CommerceOrder {
+  internalID
+  mode
+  state
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  stateExpiresAt
+  ... on CommerceOfferOrder {
+    lastOffer {
+      createdAt
+      id
+    }
+    myLastOffer {
+      internalID
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+}
+
+fragment TransactionDetailsSummaryItem_order on CommerceOrder {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+    myLastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+  }
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -62,39 +139,23 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
   }
 }
 
-fragment Counter_order on CommerceOrder {
-  internalID
-  mode
+fragment ShippingSummaryItem_order on CommerceOrder {
   state
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  stateExpiresAt
-  ... on CommerceOfferOrder {
-    lastOffer {
-      createdAt
-      id
-    }
-    myLastOffer {
-      internalID
-      id
-    }
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
   }
   lineItems {
     edges {
       node {
         artwork {
-          slug
+          shippingOrigin
           id
         }
         id
       }
     }
   }
-  ...TransactionDetailsSummaryItem_order
-  ...ArtworkSummaryItem_order
-  ...ShippingSummaryItem_order
-  ...CreditCardSummaryItem_order
-  ...OfferHistoryItem_order
 }
 
 fragment CreditCardSummaryItem_order on CommerceOrder {
@@ -142,67 +203,6 @@ fragment ShippingAddress_ship on CommerceShip {
   region
   country
   phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment TransactionDetailsSummaryItem_order on CommerceOrder {
-  __typename
-  mode
-  shippingTotal(precision: 2)
-  shippingTotalCents
-  taxTotal(precision: 2)
-  taxTotalCents
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  buyerTotal(precision: 2)
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-    myLastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-  }
 }
 */
 
@@ -772,7 +772,7 @@ return {
     "operationKind": "query",
     "name": "routes_CounterQuery",
     "id": null,
-    "text": "query routes_CounterQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Counter_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Counter_order on CommerceOrder {\n  internalID\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  stateExpiresAt\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      id\n    }\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_CounterQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Counter_order\n    id\n  }\n}\n\nfragment Counter_order on CommerceOrder {\n  internalID\n  mode\n  state\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  stateExpiresAt\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      id\n    }\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_NewPaymentQuery.graphql.ts
+++ b/src/__generated__/routes_NewPaymentQuery.graphql.ts
@@ -35,40 +35,6 @@ query routes_NewPaymentQuery(
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment NewPayment_me on Me {
   ...PaymentPicker_me
 }
@@ -103,21 +69,6 @@ fragment NewPayment_order on CommerceOrder {
   ...PaymentPicker_order
   ...ArtworkSummaryItem_order
   ...TransactionDetailsSummaryItem_order
-}
-
-fragment PaymentPicker_me on Me {
-  creditCards(first: 100) {
-    edges {
-      node {
-        internalID
-        brand
-        lastDigits
-        expirationMonth
-        expirationYear
-        id
-      }
-    }
-  }
 }
 
 fragment PaymentPicker_order on CommerceOrder {
@@ -167,6 +118,40 @@ fragment PaymentPicker_order on CommerceOrder {
   }
 }
 
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -205,6 +190,21 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       fromParticipant
       note
       id
+    }
+  }
+}
+
+fragment PaymentPicker_me on Me {
+  creditCards(first: 100) {
+    edges {
+      node {
+        internalID
+        brand
+        lastDigits
+        expirationMonth
+        expirationYear
+        id
+      }
     }
   }
 }
@@ -847,7 +847,7 @@ return {
     "operationKind": "query",
     "name": "routes_NewPaymentQuery",
     "id": null,
-    "text": "query routes_NewPaymentQuery(\n  $orderID: ID!\n) {\n  me {\n    ...NewPayment_me\n    id\n  }\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...NewPayment_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment NewPayment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment NewPayment_order on CommerceOrder {\n  internalID\n  mode\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_NewPaymentQuery(\n  $orderID: ID!\n) {\n  me {\n    ...NewPayment_me\n    id\n  }\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...NewPayment_order\n    id\n  }\n}\n\nfragment NewPayment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment NewPayment_order on CommerceOrder {\n  internalID\n  mode\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_OfferQuery.graphql.ts
+++ b/src/__generated__/routes_OfferQuery.graphql.ts
@@ -28,6 +28,28 @@ query routes_OfferQuery(
   }
 }
 
+fragment Offer_order on CommerceOrder {
+  internalID
+  mode
+  state
+  totalListPrice(precision: 2)
+  totalListPriceCents
+  currencyCode
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ...ArtworkSummaryItem_order
+  ...TransactionDetailsSummaryItem_order
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -60,28 +82,6 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
       }
     }
   }
-}
-
-fragment Offer_order on CommerceOrder {
-  internalID
-  mode
-  state
-  totalListPrice(precision: 2)
-  totalListPriceCents
-  currencyCode
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ...ArtworkSummaryItem_order
-  ...TransactionDetailsSummaryItem_order
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -517,7 +517,7 @@ return {
     "operationKind": "query",
     "name": "routes_OfferQuery",
     "id": null,
-    "text": "query routes_OfferQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  internalID\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_OfferQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Offer_order\n    id\n  }\n}\n\nfragment Offer_order on CommerceOrder {\n  internalID\n  mode\n  state\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_PaymentQuery.graphql.ts
+++ b/src/__generated__/routes_PaymentQuery.graphql.ts
@@ -35,53 +35,27 @@ query routes_PaymentQuery(
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
+fragment Payment_me on Me {
+  ...PaymentPicker_me
+}
+
+fragment Payment_order on CommerceOrder {
+  internalID
+  mode
   lineItems {
     edges {
       node {
         artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
+          slug
           id
         }
         id
       }
     }
   }
-}
-
-fragment PaymentPicker_me on Me {
-  creditCards(first: 100) {
-    edges {
-      node {
-        internalID
-        brand
-        lastDigits
-        expirationMonth
-        expirationYear
-        id
-      }
-    }
-  }
+  ...PaymentPicker_order
+  ...ArtworkSummaryItem_order
+  ...TransactionDetailsSummaryItem_order
 }
 
 fragment PaymentPicker_order on CommerceOrder {
@@ -131,27 +105,38 @@ fragment PaymentPicker_order on CommerceOrder {
   }
 }
 
-fragment Payment_me on Me {
-  ...PaymentPicker_me
-}
-
-fragment Payment_order on CommerceOrder {
-  internalID
-  mode
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
   lineItems {
     edges {
       node {
         artwork {
-          slug
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
           id
         }
         id
       }
     }
   }
-  ...PaymentPicker_order
-  ...ArtworkSummaryItem_order
-  ...TransactionDetailsSummaryItem_order
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -192,6 +177,21 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       fromParticipant
       note
       id
+    }
+  }
+}
+
+fragment PaymentPicker_me on Me {
+  creditCards(first: 100) {
+    edges {
+      node {
+        internalID
+        brand
+        lastDigits
+        expirationMonth
+        expirationYear
+        id
+      }
     }
   }
 }
@@ -789,7 +789,7 @@ return {
     "operationKind": "query",
     "name": "routes_PaymentQuery",
     "id": null,
-    "text": "query routes_PaymentQuery(\n  $orderID: ID!\n) {\n  me {\n    ...Payment_me\n    id\n  }\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Payment_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Payment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment Payment_order on CommerceOrder {\n  internalID\n  mode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_PaymentQuery(\n  $orderID: ID!\n) {\n  me {\n    ...Payment_me\n    id\n  }\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Payment_order\n    id\n  }\n}\n\nfragment Payment_me on Me {\n  ...PaymentPicker_me\n}\n\nfragment Payment_order on CommerceOrder {\n  internalID\n  mode\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ...PaymentPicker_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_RegisterQuery.graphql.ts
+++ b/src/__generated__/routes_RegisterQuery.graphql.ts
@@ -75,14 +75,14 @@ query routes_RegisterQuery(
   }
 }
 
-fragment Register_me on Me {
-  internalID
-}
-
 fragment Register_sale on Sale {
   slug
   internalID
   status
+}
+
+fragment Register_me on Me {
+  internalID
 }
 */
 
@@ -289,7 +289,7 @@ return {
     "operationKind": "query",
     "name": "routes_RegisterQuery",
     "id": null,
-    "text": "query routes_RegisterQuery(\n  $saleID: String!\n) {\n  sale(id: $saleID) @principalField {\n    slug\n    isAuction\n    isRegistrationClosed\n    isPreview\n    isOpen\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    ...Register_sale\n    id\n  }\n  me {\n    hasQualifiedCreditCards\n    ...Register_me\n    id\n  }\n}\n\nfragment Register_me on Me {\n  internalID\n}\n\nfragment Register_sale on Sale {\n  slug\n  internalID\n  status\n}\n",
+    "text": "query routes_RegisterQuery(\n  $saleID: String!\n) {\n  sale(id: $saleID) @principalField {\n    slug\n    isAuction\n    isRegistrationClosed\n    isPreview\n    isOpen\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    ...Register_sale\n    id\n  }\n  me {\n    hasQualifiedCreditCards\n    ...Register_me\n    id\n  }\n}\n\nfragment Register_sale on Sale {\n  slug\n  internalID\n  status\n}\n\nfragment Register_me on Me {\n  internalID\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_RejectQuery.graphql.ts
+++ b/src/__generated__/routes_RejectQuery.graphql.ts
@@ -28,6 +28,30 @@ query routes_RejectQuery(
   }
 }
 
+fragment Reject_order on CommerceOrder {
+  internalID
+  stateExpiresAt
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      createdAt
+      id
+    }
+  }
+  ...ArtworkSummaryItem_order
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -60,30 +84,6 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
       }
     }
   }
-}
-
-fragment Reject_order on CommerceOrder {
-  internalID
-  stateExpiresAt
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      createdAt
-      id
-    }
-  }
-  ...ArtworkSummaryItem_order
 }
 */
 
@@ -351,7 +351,7 @@ return {
     "operationKind": "query",
     "name": "routes_RejectQuery",
     "id": null,
-    "text": "query routes_RejectQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Reject_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Reject_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n}\n",
+    "text": "query routes_RejectQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Reject_order\n    id\n  }\n}\n\nfragment Reject_order on CommerceOrder {\n  internalID\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      createdAt\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_RespondQuery.graphql.ts
+++ b/src/__generated__/routes_RespondQuery.graphql.ts
@@ -28,6 +28,88 @@ query routes_RespondQuery(
   }
 }
 
+fragment Respond_order on CommerceOrder {
+  internalID
+  mode
+  state
+  currencyCode
+  itemsTotal(precision: 2)
+  itemsTotalCents
+  totalListPrice(precision: 2)
+  totalListPriceCents
+  stateExpiresAt
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+  ... on CommerceOfferOrder {
+    lastOffer {
+      createdAt
+      internalID
+      note
+      id
+    }
+    myLastOffer {
+      createdAt
+      id
+    }
+  }
+  ...TransactionDetailsSummaryItem_order
+  ...ArtworkSummaryItem_order
+  ...ShippingSummaryItem_order
+  ...CreditCardSummaryItem_order
+  ...OfferHistoryItem_order
+}
+
+fragment TransactionDetailsSummaryItem_order on CommerceOrder {
+  __typename
+  mode
+  shippingTotal(precision: 2)
+  shippingTotalCents
+  taxTotal(precision: 2)
+  taxTotalCents
+  itemsTotal(precision: 2)
+  totalListPrice(precision: 2)
+  buyerTotal(precision: 2)
+  ... on CommerceOfferOrder {
+    lastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+    myLastOffer {
+      internalID
+      amount(precision: 2)
+      amountCents
+      shippingTotal(precision: 2)
+      shippingTotalCents
+      taxTotal(precision: 2)
+      taxTotalCents
+      buyerTotal(precision: 2)
+      buyerTotalCents
+      fromParticipant
+      note
+      id
+    }
+  }
+}
+
 fragment ArtworkSummaryItem_order on CommerceOrder {
   sellerDetails {
     __typename
@@ -54,6 +136,25 @@ fragment ArtworkSummaryItem_order on CommerceOrder {
               url
             }
           }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
           id
         }
         id
@@ -98,46 +199,6 @@ fragment OfferHistoryItem_order on CommerceOrder {
   totalListPrice(precision: 2)
 }
 
-fragment Respond_order on CommerceOrder {
-  internalID
-  mode
-  state
-  currencyCode
-  itemsTotal(precision: 2)
-  itemsTotalCents
-  totalListPrice(precision: 2)
-  totalListPriceCents
-  stateExpiresAt
-  lineItems {
-    edges {
-      node {
-        artwork {
-          slug
-          id
-        }
-        id
-      }
-    }
-  }
-  ... on CommerceOfferOrder {
-    lastOffer {
-      createdAt
-      internalID
-      note
-      id
-    }
-    myLastOffer {
-      createdAt
-      id
-    }
-  }
-  ...TransactionDetailsSummaryItem_order
-  ...ArtworkSummaryItem_order
-  ...ShippingSummaryItem_order
-  ...CreditCardSummaryItem_order
-  ...OfferHistoryItem_order
-}
-
 fragment ShippingAddress_ship on CommerceShip {
   name
   addressLine1
@@ -147,67 +208,6 @@ fragment ShippingAddress_ship on CommerceShip {
   region
   country
   phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment TransactionDetailsSummaryItem_order on CommerceOrder {
-  __typename
-  mode
-  shippingTotal(precision: 2)
-  shippingTotalCents
-  taxTotal(precision: 2)
-  taxTotalCents
-  itemsTotal(precision: 2)
-  totalListPrice(precision: 2)
-  buyerTotal(precision: 2)
-  ... on CommerceOfferOrder {
-    lastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-    myLastOffer {
-      internalID
-      amount(precision: 2)
-      amountCents
-      shippingTotal(precision: 2)
-      shippingTotalCents
-      taxTotal(precision: 2)
-      taxTotalCents
-      buyerTotal(precision: 2)
-      buyerTotalCents
-      fromParticipant
-      note
-      id
-    }
-  }
 }
 */
 
@@ -800,7 +800,7 @@ return {
     "operationKind": "query",
     "name": "routes_RespondQuery",
     "id": null,
-    "text": "query routes_RespondQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Respond_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_RespondQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Respond_order\n    id\n  }\n}\n\nfragment Respond_order on CommerceOrder {\n  internalID\n  mode\n  state\n  currencyCode\n  itemsTotal(precision: 2)\n  itemsTotalCents\n  totalListPrice(precision: 2)\n  totalListPriceCents\n  stateExpiresAt\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    lastOffer {\n      createdAt\n      internalID\n      note\n      id\n    }\n    myLastOffer {\n      createdAt\n      id\n    }\n  }\n  ...TransactionDetailsSummaryItem_order\n  ...ArtworkSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferHistoryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferHistoryItem_order on CommerceOrder {\n  ... on CommerceOfferOrder {\n    offers {\n      edges {\n        node {\n          internalID\n          amount(precision: 2)\n          createdAt(format: \"MMM D\")\n          fromParticipant\n          id\n        }\n      }\n    }\n    lastOffer {\n      internalID\n      fromParticipant\n      amount(precision: 2)\n      shippingTotal(precision: 2)\n      taxTotal(precision: 2)\n      note\n      id\n    }\n  }\n  totalListPrice(precision: 2)\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ReviewQuery.graphql.ts
+++ b/src/__generated__/routes_ReviewQuery.graphql.ts
@@ -28,93 +28,6 @@ query routes_ReviewQuery(
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ItemReview_lineItem on CommerceLineItem {
-  artwork {
-    artist_names: artistNames
-    title
-    date
-    medium
-    dimensions {
-      in
-      cm
-    }
-    attribution_class: attributionClass {
-      shortDescription
-      id
-    }
-    image {
-      resized(width: 185) {
-        url
-      }
-    }
-    edition_sets: editionSets {
-      internalID
-      dimensions {
-        in
-        cm
-      }
-      id
-    }
-    id
-  }
-  editionSetId
-}
-
-fragment OfferSummaryItem_order on CommerceOrder {
-  totalListPrice(precision: 2)
-  ... on CommerceOfferOrder {
-    myLastOffer {
-      amount(precision: 2)
-      note
-      id
-    }
-  }
-}
-
 fragment Review_order on CommerceOrder {
   internalID
   mode
@@ -149,28 +62,64 @@ fragment Review_order on CommerceOrder {
   ...OfferSummaryItem_order
 }
 
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
+fragment ItemReview_lineItem on CommerceLineItem {
+  artwork {
+    artist_names: artistNames
+    title
+    date
+    medium
+    dimensions {
+      in
+      cm
+    }
+    attribution_class: attributionClass {
+      shortDescription
+      id
+    }
+    image {
+      resized(width: 185) {
+        url
+      }
+    }
+    edition_sets: editionSets {
+      internalID
+      dimensions {
+        in
+        cm
+      }
+      id
+    }
+    id
+  }
+  editionSetId
 }
 
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
     __typename
-    ...ShippingAddress_ship
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
   }
   lineItems {
     edges {
       node {
         artwork {
+          artist_names: artistNames
+          title
+          date
           shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
           id
         }
         id
@@ -219,6 +168,57 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment OfferSummaryItem_order on CommerceOrder {
+  totalListPrice(precision: 2)
+  ... on CommerceOfferOrder {
+    myLastOffer {
+      amount(precision: 2)
+      note
+      id
+    }
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -829,7 +829,7 @@ return {
     "operationKind": "query",
     "name": "routes_ReviewQuery",
     "id": null,
-    "text": "query routes_ReviewQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names: artistNames\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class: attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    edition_sets: editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  totalListPrice(precision: 2)\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  internalID\n  mode\n  itemsTotal(precision: 2)\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferSummaryItem_order\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_ReviewQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Review_order\n    id\n  }\n}\n\nfragment Review_order on CommerceOrder {\n  internalID\n  mode\n  itemsTotal(precision: 2)\n  lineItems {\n    edges {\n      node {\n        ...ItemReview_lineItem\n        artwork {\n          slug\n          internalID\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      id\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  ...OfferSummaryItem_order\n}\n\nfragment ItemReview_lineItem on CommerceLineItem {\n  artwork {\n    artist_names: artistNames\n    title\n    date\n    medium\n    dimensions {\n      in\n      cm\n    }\n    attribution_class: attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      resized(width: 185) {\n        url\n      }\n    }\n    edition_sets: editionSets {\n      internalID\n      dimensions {\n        in\n        cm\n      }\n      id\n    }\n    id\n  }\n  editionSetId\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment OfferSummaryItem_order on CommerceOrder {\n  totalListPrice(precision: 2)\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      amount(precision: 2)\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -28,28 +28,6 @@ query routes_SearchResultsArtistsQuery(
   }
 }
 
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
 fragment SearchResultsArtists_viewer_2iLyA0 on Viewer {
   searchConnection(query: $term, first: 10, page: $page, entities: [ARTIST]) @principalField {
     pageInfo {
@@ -74,6 +52,28 @@ fragment SearchResultsArtists_viewer_2iLyA0 on Viewer {
         }
       }
     }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
   }
 }
 */
@@ -365,7 +365,7 @@ return {
     "operationKind": "query",
     "name": "routes_SearchResultsArtistsQuery",
     "id": null,
-    "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2iLyA0\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2iLyA0 on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2iLyA0\n  }\n}\n\nfragment SearchResultsArtists_viewer_2iLyA0 on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
@@ -31,28 +31,6 @@ query routes_SearchResultsEntityQuery(
   }
 }
 
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
-  }
-}
-
 fragment SearchResultsEntity_viewer_1qCJIT on Viewer {
   searchConnection(query: $term, first: 10, page: $page, entities: $entities) @principalField {
     pageInfo {
@@ -78,6 +56,28 @@ fragment SearchResultsEntity_viewer_1qCJIT on Viewer {
         }
       }
     }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
   }
 }
 */
@@ -382,7 +382,7 @@ return {
     "operationKind": "query",
     "name": "routes_SearchResultsEntityQuery",
     "id": null,
-    "text": "query routes_SearchResultsEntityQuery(\n  $term: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_1qCJIT\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsEntity_viewer_1qCJIT on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query routes_SearchResultsEntityQuery(\n  $term: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_1qCJIT\n  }\n}\n\nfragment SearchResultsEntity_viewer_1qCJIT on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_SearchResultsTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsTopLevelQuery.graphql.ts
@@ -26,16 +26,6 @@ query routes_SearchResultsTopLevelQuery(
   }
 }
 
-fragment NavigationTabs_searchableConnection on SearchableConnection {
-  aggregations {
-    slice
-    counts {
-      count
-      name
-    }
-  }
-}
-
 fragment SearchApp_viewer_4hh6ED on Viewer {
   searchConnection(query: $term, first: 1, aggregations: [TYPE]) {
     aggregations {
@@ -65,6 +55,16 @@ fragment SearchApp_viewer_4hh6ED on Viewer {
       total
     }
     id
+  }
+}
+
+fragment NavigationTabs_searchableConnection on SearchableConnection {
+  aggregations {
+    slice
+    counts {
+      count
+      name
+    }
   }
 }
 */
@@ -317,7 +317,7 @@ return {
     "operationKind": "query",
     "name": "routes_SearchResultsTopLevelQuery",
     "id": null,
-    "text": "query routes_SearchResultsTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  searchConnection(query: $term, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $term, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n",
+    "text": "query routes_SearchResultsTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  searchConnection(query: $term, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $term, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ShippingQuery.graphql.ts
+++ b/src/__generated__/routes_ShippingQuery.graphql.ts
@@ -28,40 +28,6 @@ query routes_ShippingQuery(
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment Shipping_order on CommerceOrder {
   internalID
   mode
@@ -95,6 +61,40 @@ fragment Shipping_order on CommerceOrder {
   }
   ...ArtworkSummaryItem_order
   ...TransactionDetailsSummaryItem_order
+}
+
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
 }
 
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
@@ -606,7 +606,7 @@ return {
     "operationKind": "query",
     "name": "routes_ShippingQuery",
     "id": null,
-    "text": "query routes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  internalID\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          pickup_available: pickupAvailable\n          onlyShipsDomestically\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    id\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  internalID\n  mode\n  state\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          pickup_available: pickupAvailable\n          onlyShipsDomestically\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_ShowsQuery.graphql.ts
+++ b/src/__generated__/routes_ShowsQuery.graphql.ts
@@ -26,6 +26,61 @@ query routes_ShowsQuery(
   }
 }
 
+fragment Shows_viewer on Viewer {
+  artist_currentShows: artist(id: $artistID) {
+    ...ArtistShows_artist_43oec1
+    id
+  }
+  artist_upcomingShows: artist(id: $artistID) {
+    ...ArtistShows_artist_12Fjro
+    id
+  }
+  artist_pastShows: artist(id: $artistID) {
+    ...ArtistShows_artist_3dp4w3
+    id
+  }
+}
+
+fragment ArtistShows_artist_43oec1 on Artist {
+  slug
+  showsConnection(first: 4, sort: END_AT_ASC, status: "running") {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    edges {
+      node {
+        partner {
+          __typename
+          ... on ExternalPartner {
+            name
+            id
+          }
+          ... on Partner {
+            name
+          }
+          ... on Node {
+            id
+          }
+        }
+        name
+        href
+        exhibition_period: exhibitionPeriod
+        cover_image: coverImage {
+          cropped(width: 800, height: 600) {
+            url
+          }
+        }
+        city
+        id
+      }
+    }
+  }
+}
+
 fragment ArtistShows_artist_12Fjro on Artist {
   slug
   showsConnection(first: 4, sort: START_AT_ASC, status: "upcoming") {
@@ -106,46 +161,6 @@ fragment ArtistShows_artist_3dp4w3 on Artist {
   }
 }
 
-fragment ArtistShows_artist_43oec1 on Artist {
-  slug
-  showsConnection(first: 4, sort: END_AT_ASC, status: "running") {
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    pageCursors {
-      ...Pagination_pageCursors
-    }
-    edges {
-      node {
-        partner {
-          __typename
-          ... on ExternalPartner {
-            name
-            id
-          }
-          ... on Partner {
-            name
-          }
-          ... on Node {
-            id
-          }
-        }
-        name
-        href
-        exhibition_period: exhibitionPeriod
-        cover_image: coverImage {
-          cropped(width: 800, height: 600) {
-            url
-          }
-        }
-        city
-        id
-      }
-    }
-  }
-}
-
 fragment Pagination_pageCursors on PageCursors {
   around {
     cursor
@@ -165,21 +180,6 @@ fragment Pagination_pageCursors on PageCursors {
   previous {
     cursor
     page
-  }
-}
-
-fragment Shows_viewer on Viewer {
-  artist_currentShows: artist(id: $artistID) {
-    ...ArtistShows_artist_43oec1
-    id
-  }
-  artist_upcomingShows: artist(id: $artistID) {
-    ...ArtistShows_artist_12Fjro
-    id
-  }
-  artist_pastShows: artist(id: $artistID) {
-    ...ArtistShows_artist_3dp4w3
-    id
   }
 }
 */
@@ -603,7 +603,7 @@ return {
     "operationKind": "query",
     "name": "routes_ShowsQuery",
     "id": null,
-    "text": "query routes_ShowsQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...Shows_viewer\n  }\n}\n\nfragment ArtistShows_artist_12Fjro on Artist {\n  slug\n  showsConnection(first: 4, sort: START_AT_ASC, status: \"upcoming\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_3dp4w3 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_DESC, status: \"closed\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_43oec1 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_ASC, status: \"running\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Shows_viewer on Viewer {\n  artist_currentShows: artist(id: $artistID) {\n    ...ArtistShows_artist_43oec1\n    id\n  }\n  artist_upcomingShows: artist(id: $artistID) {\n    ...ArtistShows_artist_12Fjro\n    id\n  }\n  artist_pastShows: artist(id: $artistID) {\n    ...ArtistShows_artist_3dp4w3\n    id\n  }\n}\n",
+    "text": "query routes_ShowsQuery(\n  $artistID: String!\n) {\n  viewer {\n    ...Shows_viewer\n  }\n}\n\nfragment Shows_viewer on Viewer {\n  artist_currentShows: artist(id: $artistID) {\n    ...ArtistShows_artist_43oec1\n    id\n  }\n  artist_upcomingShows: artist(id: $artistID) {\n    ...ArtistShows_artist_12Fjro\n    id\n  }\n  artist_pastShows: artist(id: $artistID) {\n    ...ArtistShows_artist_3dp4w3\n    id\n  }\n}\n\nfragment ArtistShows_artist_43oec1 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_ASC, status: \"running\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_12Fjro on Artist {\n  slug\n  showsConnection(first: 4, sort: START_AT_ASC, status: \"upcoming\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistShows_artist_3dp4w3 on Artist {\n  slug\n  showsConnection(first: 4, sort: END_AT_DESC, status: \"closed\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        partner {\n          __typename\n          ... on ExternalPartner {\n            name\n            id\n          }\n          ... on Partner {\n            name\n          }\n          ... on Node {\n            id\n          }\n        }\n        name\n        href\n        exhibition_period: exhibitionPeriod\n        cover_image: coverImage {\n          cropped(width: 800, height: 600) {\n            url\n          }\n        }\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_StatusQuery.graphql.ts
+++ b/src/__generated__/routes_StatusQuery.graphql.ts
@@ -28,80 +28,6 @@ query routes_StatusQuery(
   }
 }
 
-fragment ArtworkSummaryItem_order on CommerceOrder {
-  sellerDetails {
-    __typename
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-    ... on User {
-      id
-    }
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          artist_names: artistNames
-          title
-          date
-          shippingOrigin
-          image {
-            resized_ArtworkSummaryItem: resized(width: 55) {
-              url
-            }
-          }
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
-fragment CreditCardSummaryItem_order on CommerceOrder {
-  creditCard {
-    brand
-    lastDigits
-    expirationYear
-    expirationMonth
-    id
-  }
-}
-
-fragment ShippingAddress_ship on CommerceShip {
-  name
-  addressLine1
-  addressLine2
-  city
-  postalCode
-  region
-  country
-  phoneNumber
-}
-
-fragment ShippingSummaryItem_order on CommerceOrder {
-  state
-  requestedFulfillment {
-    __typename
-    ...ShippingAddress_ship
-  }
-  lineItems {
-    edges {
-      node {
-        artwork {
-          shippingOrigin
-          id
-        }
-        id
-      }
-    }
-  }
-}
-
 fragment Status_order on CommerceOrder {
   __typename
   internalID
@@ -154,6 +80,40 @@ fragment Status_order on CommerceOrder {
   }
 }
 
+fragment ArtworkSummaryItem_order on CommerceOrder {
+  sellerDetails {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+    ... on User {
+      id
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          artist_names: artistNames
+          title
+          date
+          shippingOrigin
+          image {
+            resized_ArtworkSummaryItem: resized(width: 55) {
+              url
+            }
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
 fragment TransactionDetailsSummaryItem_order on CommerceOrder {
   __typename
   mode
@@ -194,6 +154,46 @@ fragment TransactionDetailsSummaryItem_order on CommerceOrder {
       id
     }
   }
+}
+
+fragment ShippingSummaryItem_order on CommerceOrder {
+  state
+  requestedFulfillment {
+    __typename
+    ...ShippingAddress_ship
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          shippingOrigin
+          id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment CreditCardSummaryItem_order on CommerceOrder {
+  creditCard {
+    brand
+    lastDigits
+    expirationYear
+    expirationMonth
+    id
+  }
+}
+
+fragment ShippingAddress_ship on CommerceShip {
+  name
+  addressLine1
+  addressLine2
+  city
+  postalCode
+  region
+  country
+  phoneNumber
 }
 */
 
@@ -763,7 +763,7 @@ return {
     "operationKind": "query",
     "name": "routes_StatusQuery",
     "id": null,
-    "text": "query routes_StatusQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Status_order\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  internalID\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      id\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n",
+    "text": "query routes_StatusQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Status_order\n    id\n  }\n}\n\nfragment Status_order on CommerceOrder {\n  __typename\n  internalID\n  code\n  state\n  mode\n  stateReason\n  stateExpiresAt(format: \"MMM D\")\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...ShippingSummaryItem_order\n  ...CreditCardSummaryItem_order\n  lineItems {\n    edges {\n      node {\n        fulfillments {\n          edges {\n            node {\n              courier\n              trackingId\n              estimatedDelivery(format: \"MMM Do, YYYY\")\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      id\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n    ... on User {\n      id\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          artist_names: artistNames\n          title\n          date\n          shippingOrigin\n          image {\n            resized_ArtworkSummaryItem: resized(width: 55) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __typename\n  mode\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  totalListPrice(precision: 2)\n  buyerTotal(precision: 2)\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n\nfragment ShippingSummaryItem_order on CommerceOrder {\n  state\n  requestedFulfillment {\n    __typename\n    ...ShippingAddress_ship\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          shippingOrigin\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CreditCardSummaryItem_order on CommerceOrder {\n  creditCard {\n    brand\n    lastDigits\n    expirationYear\n    expirationMonth\n    id\n  }\n}\n\nfragment ShippingAddress_ship on CommerceShip {\n  name\n  addressLine1\n  addressLine2\n  city\n  postalCode\n  region\n  country\n  phoneNumber\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
This removes the entry points impression event from `src/Components/v2/CollectionsHubsHomepageNav.tsx`. We remove it here because it fires too early and should be fired it from [force](https://github.com/artsy/force/pull/4784) upon the user scrolling within a specific area.