### PR TITLE
Meta: Merge recent auctions team product work into master

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -25,7 +25,7 @@ interface Props {
   showPricingTransparency?: boolean
 }
 
-interface FormValues {
+export interface FormValues {
   selectedBid: string
   agreeToTerms: boolean
 }
@@ -112,6 +112,7 @@ export const BidForm: React.FC<Props> = ({
           isSubmitting,
           setFieldValue,
           setFieldTouched,
+          status,
         }) => {
           return (
             <Form>
@@ -166,6 +167,12 @@ export const BidForm: React.FC<Props> = ({
                         )}
                       </Box>
                     </>
+                  )}
+
+                  {status && (
+                    <Sans textAlign="center" size="3" color="red100" mb={2}>
+                      {status}.
+                    </Sans>
                   )}
 
                   <Button

--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -7,6 +7,7 @@ import {
   Separator,
   Serif,
 } from "@artsy/palette"
+import { BidForm_me } from "__generated__/BidForm_me.graphql"
 import { BidForm_saleArtwork } from "__generated__/BidForm_saleArtwork.graphql"
 import { PricingTransparency } from "Apps/Auction/Components/PricingTransparency"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
@@ -17,10 +18,11 @@ import { createFragmentContainer, graphql } from "react-relay"
 import Yup from "yup"
 
 interface Props {
-  showPricingTransparency?: boolean
-  saleArtwork: BidForm_saleArtwork
   initialSelectedBid?: string
+  me: BidForm_me
   onSubmit: (values: FormikValues, actions: FormikActions<object>) => void
+  saleArtwork: BidForm_saleArtwork
+  showPricingTransparency?: boolean
 }
 
 interface FormValues {
@@ -28,7 +30,11 @@ interface FormValues {
   agreeToTerms: boolean
 }
 
-const validationSchema = Yup.object().shape({
+const validationSchemaForRegisteredUsers = Yup.object().shape({
+  selectedBid: Yup.string().required(),
+})
+
+const validationSchemaForUnregisteredUsersWithCreditCard = Yup.object().shape({
   selectedBid: Yup.string().required(),
   agreeToTerms: Yup.bool().oneOf(
     [true],
@@ -57,11 +63,24 @@ const getSelectedBid = ({
   return selectedIncrement.value
 }
 
+const determineDisplayRequirements = (
+  bidder: BidForm_saleArtwork["sale"]["registrationStatus"],
+  me: BidForm_me
+) => {
+  const isRegistered = !!bidder
+
+  return {
+    requiresCheckbox: !isRegistered,
+    requiresPaymentInformation: !(isRegistered || me.hasQualifiedCreditCards),
+  }
+}
+
 export const BidForm: React.FC<Props> = ({
+  initialSelectedBid,
+  me,
   onSubmit,
   saleArtwork,
   showPricingTransparency = false,
-  initialSelectedBid,
 }) => {
   const displayIncrements = dropWhile(
     saleArtwork.increments,
@@ -69,6 +88,13 @@ export const BidForm: React.FC<Props> = ({
   ).map(inc => ({ value: inc.cents.toString(), text: inc.display }))
 
   const selectedBid = getSelectedBid({ initialSelectedBid, displayIncrements })
+  const { requiresCheckbox } = determineDisplayRequirements(
+    saleArtwork.sale.registrationStatus,
+    me
+  )
+  const validationSchema = requiresCheckbox
+    ? validationSchemaForUnregisteredUsersWithCreditCard
+    : validationSchemaForRegisteredUsers
 
   return (
     <Box maxWidth={550}>
@@ -109,30 +135,41 @@ export const BidForm: React.FC<Props> = ({
                   )}
                   {showPricingTransparency && <PricingTransparency />}
                 </Flex>
-                <Separator />
+
                 <Flex
-                  py={3}
+                  pb={3}
                   flexDirection="column"
                   justifyContent="center"
                   width="100%"
                 >
-                  <Box mx="auto" mb={3}>
-                    <ConditionsOfSaleCheckbox
-                      selected={values.agreeToTerms}
-                      onSelect={value => {
-                        setFieldValue("agreeToTerms", value)
-                        setFieldTouched("agreeToTerms")
-                      }}
-                    />
-                    {touched.agreeToTerms && errors.agreeToTerms && (
-                      <Sans mt={1} color="red100" size="2" textAlign="center">
-                        {errors.agreeToTerms}
-                      </Sans>
-                    )}
-                  </Box>
+                  {requiresCheckbox && (
+                    <>
+                      <Separator mb={3} />
+
+                      <Box mx="auto" mb={3}>
+                        <ConditionsOfSaleCheckbox
+                          selected={values.agreeToTerms}
+                          onSelect={value => {
+                            setFieldValue("agreeToTerms", value)
+                            setFieldTouched("agreeToTerms")
+                          }}
+                        />
+                        {touched.agreeToTerms && errors.agreeToTerms && (
+                          <Sans
+                            mt={1}
+                            color="red100"
+                            size="2"
+                            textAlign="center"
+                          >
+                            {errors.agreeToTerms}
+                          </Sans>
+                        )}
+                      </Box>
+                    </>
+                  )}
+
                   <Button
                     size="large"
-                    mt={3}
                     width="100%"
                     loading={isSubmitting}
                     {...{ type: "submit" } as any}
@@ -159,6 +196,16 @@ export const BidFormFragmentContainer = createFragmentContainer(BidForm, {
         cents
         display
       }
+      sale {
+        registrationStatus {
+          qualifiedForBidding
+        }
+      }
+    }
+  `,
+  me: graphql`
+    fragment BidForm_me on Me {
+      hasQualifiedCreditCards
     }
   `,
 })

--- a/src/Apps/Auction/Components/CreditCardInstructions.tsx
+++ b/src/Apps/Auction/Components/CreditCardInstructions.tsx
@@ -1,0 +1,18 @@
+import { Serif } from "@artsy/palette"
+import React from "react"
+
+export const CreditCardInstructions = () => {
+  return (
+    <>
+      <Serif size="4" color="black100">
+        Please enter your credit card information below. The name on your Artsy
+        account must match the name on the card, and a valid credit card is
+        required in order to bid.
+      </Serif>
+      <Serif size="4" mt={2} color="black100">
+        Registration is free. Artsy will never charge this card without your
+        permission, and you are not required to use this card to pay if you win.
+      </Serif>
+    </>
+  )
+}

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
+import { CreditCardInstructions } from "Apps/Auction/Components/CreditCardInstructions"
 import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
 import { ConditionsOfSaleCheckbox } from "Components/Auction/ConditionsOfSaleCheckbox"
@@ -221,15 +222,8 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = props => {
 
   return (
     <Box maxWidth={550}>
-      <Serif size="4" color="black100">
-        Please enter your credit card information below. The name on your Artsy
-        account must match the name on the card, and a valid credit card is
-        required in order to bid.
-      </Serif>
-      <Serif size="4" mt={2} color="black100">
-        Registration is free. Artsy will never charge this card without your
-        permission, and you are not required to use this card to pay if you win.
-      </Serif>
+      <CreditCardInstructions />
+
       <Box mt={2}>
         <Formik
           initialValues={initialValues}

--- a/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
@@ -1,0 +1,33 @@
+import {
+  BidderPositionQuery,
+  BidderPositionQueryVariables,
+} from "__generated__/BidderPositionQuery.graphql"
+import { graphql } from "react-relay"
+import { Environment, fetchQuery } from "relay-runtime"
+
+export const bidderPositionQuery = (
+  environment: Environment,
+  variables: BidderPositionQueryVariables
+) => {
+  return fetchQuery<BidderPositionQuery>(
+    environment,
+    graphql`
+      query BidderPositionQuery($bidderPositionID: String!) {
+        me {
+          bidderPosition(id: $bidderPositionID) {
+            status
+            messageHeader
+            position {
+              id
+              suggestedNextBid {
+                cents
+                display
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables
+  )
+}

--- a/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
@@ -28,6 +28,9 @@ export const bidderPositionQuery = (
         }
       }
     `,
-    variables
+    variables,
+    {
+      force: true,
+    }
   )
 }

--- a/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/BidderPositionQuery.tsx
@@ -18,7 +18,7 @@ export const bidderPositionQuery = (
             status
             messageHeader
             position {
-              id
+              internalID
               suggestedNextBid {
                 cents
                 display

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -5,8 +5,12 @@ import {
   ConfirmBidCreateBidderPositionMutationResponse,
 } from "__generated__/ConfirmBidCreateBidderPositionMutation.graphql"
 import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
-import { BidFormFragmentContainer as BidForm } from "Apps/Auction/Components/BidForm"
+import {
+  BidFormFragmentContainer as BidForm,
+  FormValues,
+} from "Apps/Auction/Components/BidForm"
 import { LotInfoFragmentContainer as LotInfo } from "Apps/Auction/Components/LotInfo"
+import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositionQuery"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { track } from "Artsy"
@@ -26,9 +30,9 @@ import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 
-import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositionQuery"
-
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
+
+type BidFormActions = FormikActions<FormValues>
 
 interface ConfirmBidProps {
   artwork: routes_ConfirmBidQueryResponse["artwork"]
@@ -45,21 +49,15 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   const { artwork, me, relay } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
-
+  const { environment } = relay
   const { trackEvent } = useTracking()
 
   function createBidderPosition(maxBidAmountCents: number) {
-    return new Promise(async (resolve, reject) => {
-      commitMutation<ConfirmBidCreateBidderPositionMutation>(
-        relay.environment,
-        {
-          onCompleted: data => {
-            resolve(data)
-          },
-          onError: error => {
-            reject(error)
-          },
-          // TODO: Inputs to the mutation might have changed case of the keys!
+    return new Promise<ConfirmBidCreateBidderPositionMutationResponse>(
+      (resolve, reject) => {
+        commitMutation<ConfirmBidCreateBidderPositionMutation>(environment, {
+          onCompleted: data => resolve(data),
+          onError: error => reject(error),
           mutation: graphql`
             mutation ConfirmBidCreateBidderPositionMutation(
               $input: BidderPositionInput!
@@ -78,7 +76,6 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
                   }
                   status
                   messageHeader
-                  messageDescriptionMD
                 }
               }
             }
@@ -90,31 +87,18 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
               maxBidAmountCents,
             },
           },
-        }
-      )
-    })
+        })
+      }
+    )
   }
 
-  function handleMutationError(
-    actions: FormikActions<object>,
-    error: Error,
-    bidderId: string
-  ) {
+  function onJsError(actions: BidFormActions, error: Error, bidderId: string) {
     logger.error(error)
-
-    let errorMessages: string[]
-    if (Array.isArray(error)) {
-      errorMessages = error.map(e => e.message)
-    } else if (typeof error === "string") {
-      errorMessages = [error]
-    } else if (error.message) {
-      errorMessages = [error.message]
-    }
-
-    trackConfirmBidFailed(bidderId, errorMessages)
-
+    trackConfirmBidFailed(bidderId, [`JavaScript error: ${error.message}`])
     actions.setSubmitting(false)
-    actions.setStatus("submissionFailed")
+    actions.setStatus(
+      "Something went wrong while processing your bid. Please make sure your internet connection is active and try again"
+    )
   }
 
   function trackConfirmBidFailed(bidderId: string, errors: string[]) {
@@ -145,98 +129,95 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     })
   }
 
-  function handleSubmit(
-    values: { selectedBid: number },
-    actions: FormikActions<object>
-  ) {
+  function handleSubmit(values: FormValues, actions: BidFormActions) {
     const selectedBid = Number(values.selectedBid)
-    const possibleExistingBidderId: string | null = sale.registrationStatus
-      ? sale.registrationStatus.internalID
-      : null
+    const possibleExistingBidderId: string | null =
+      sale.registrationStatus && sale.registrationStatus.internalID
 
     createBidderPosition(selectedBid)
-      .then((data: ConfirmBidCreateBidderPositionMutationResponse) => {
-        if (data.createBidderPosition.result.status !== "SUCCESS") {
-          trackConfirmBidFailed(possibleExistingBidderId, [
-            "ConfirmBidCreateBidderPositionMutation failed",
-          ])
-        } else {
-          const bidderIdFromMutation =
-            data.createBidderPosition.result.position.saleArtwork.sale
-              .registrationStatus.internalID
-          verifyBidderPosition({
-            data,
-            bidderId: bidderIdFromMutation,
-            selectedBid,
-          })
-        }
-      })
-      .catch(error => {
-        handleMutationError(actions, error, possibleExistingBidderId)
-        actions.setSubmitting(false)
-      })
+      .then(data =>
+        verifyBidderPosition({
+          actions,
+          data,
+          selectedBid,
+          possibleExistingBidderId,
+        })
+      )
+      .catch(error => onJsError(actions, error, possibleExistingBidderId))
   }
 
   function verifyBidderPosition({
+    actions,
     data,
-    bidderId,
+    possibleExistingBidderId,
     selectedBid,
   }: {
+    actions: BidFormActions
     data: ConfirmBidCreateBidderPositionMutationResponse
-    bidderId: string
+    possibleExistingBidderId: string
     selectedBid: number
   }) {
     const { result } = data.createBidderPosition
-    const { position } = result
+    const { position, messageHeader } = result
+    const bidderId =
+      possibleExistingBidderId ||
+      (position &&
+        position.saleArtwork &&
+        position.saleArtwork.sale &&
+        position.saleArtwork.sale.registrationStatus.internalID)
 
     if (result.status === "SUCCESS") {
-      bidderPositionQuery(relay.environment, {
+      bidderPositionQuery(environment, {
         bidderPositionID: position.internalID,
       })
-        .then(response =>
-          checkBidderPosition({ data: response, bidderId, selectedBid })
+        .then(res =>
+          checkBidderPosition({ actions, data: res, bidderId, selectedBid })
         )
-        .catch(error => console.error(error)) // TODO: Implement error handling. story: AUCT-713
+        .catch(error => onJsError(actions, error, bidderId))
     } else {
-      // TODO: Implement error handling. story: AUCT-713
-      console.error("Bid result was not SUCCESS:", data)
+      actions.setStatus(messageHeader)
+      actions.setSubmitting(false)
+      trackConfirmBidFailed(bidderId, [messageHeader])
     }
   }
 
   function checkBidderPosition({
+    actions,
     data,
     bidderId,
     selectedBid,
   }: {
+    actions: BidFormActions
     data: BidderPositionQueryResponse
     bidderId: string
     selectedBid: number
   }) {
     const { bidderPosition } = data.me
+    const { status, position, messageHeader } = bidderPosition
 
-    if (bidderPosition.status === "PENDING" && pollCount < MAX_POLL_ATTEMPTS) {
+    if (status === "PENDING" && pollCount < MAX_POLL_ATTEMPTS) {
       // initiating new request here (vs setInterval) to make sure we wait for
       // the previous call to return before making a new one
       setTimeout(
         () =>
-          bidderPositionQuery(relay.environment, {
-            bidderPositionID: bidderPosition.position.internalID,
+          bidderPositionQuery(environment, {
+            bidderPositionID: position.internalID,
           })
-            .then(response =>
-              checkBidderPosition({ data: response, bidderId, selectedBid })
+            .then(res =>
+              checkBidderPosition({ actions, data: res, bidderId, selectedBid })
             )
-            .catch(error => console.error(error)), // TODO: Implement error handling. story: AUCT-713
+            .catch(error => onJsError(actions, error, bidderId)),
         1000
       )
 
       pollCount += 1
-    } else if (bidderPosition.status === "WINNING") {
-      const positionId = data.me.bidderPosition.position.internalID
-      trackConfirmBidSuccess(positionId, bidderId, selectedBid)
-
+    } else if (status === "WINNING") {
+      trackConfirmBidSuccess(position.internalID, bidderId, selectedBid)
       window.location.assign(`${sd.APP_URL}/artwork/${artwork.slug}`)
     } else {
-      // TODO: Implement error handling. story: AUCT-713
+      actions.setStatus(messageHeader)
+      actions.setSubmitting(false)
+      trackConfirmBidFailed(bidderId, [messageHeader])
     }
   }
 

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Separator, Serif } from "@artsy/palette"
+import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
 import {
   ConfirmBidCreateBidderPositionMutation,
   ConfirmBidCreateBidderPositionMutationResponse,
@@ -25,6 +26,8 @@ import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 
+import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositionQuery"
+
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
 interface ConfirmBidProps {
@@ -34,8 +37,12 @@ interface ConfirmBidProps {
   location: Location
 }
 
+const MAX_POLL_ATTEMPTS = 20
+
 export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
-  const { artwork } = props
+  let pollCount = 0
+
+  const { artwork, relay } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
 
@@ -44,7 +51,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   function createBidderPosition(maxBidAmountCents: number) {
     return new Promise(async (resolve, reject) => {
       commitMutation<ConfirmBidCreateBidderPositionMutation>(
-        props.relay.environment,
+        relay.environment,
         {
           onCompleted: data => {
             resolve(data)
@@ -136,8 +143,9 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     actions: FormikActions<object>
   ) {
     const bidderId = sale.registrationStatus.internalID
+    const selectedBid = Number(values.selectedBid)
 
-    createBidderPosition(Number(values.selectedBid))
+    createBidderPosition(selectedBid)
       .then((data: ConfirmBidCreateBidderPositionMutationResponse) => {
         if (data.createBidderPosition.result.status !== "SUCCESS") {
           trackConfirmBidFailed(bidderId, [
@@ -150,14 +158,76 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
           window.location.assign(
             `${sd.APP_URL}/auction/${sale.slug}/artwork/${artwork.slug}`
           )
+          verifyBidderPosition({ data, bidderId, selectedBid })
         }
       })
       .catch(error => {
         handleMutationError(actions, error, bidderId)
-      })
-      .finally(() => {
         actions.setSubmitting(false)
       })
+  }
+
+  function verifyBidderPosition({
+    data,
+    bidderId,
+    selectedBid,
+  }: {
+    data: ConfirmBidCreateBidderPositionMutationResponse
+    bidderId: string
+    selectedBid: number
+  }) {
+    const { result } = data.createBidderPosition
+    const { position } = result
+
+    if (result.status === "SUCCESS") {
+      bidderPositionQuery(relay.environment, {
+        bidderPositionID: position.internalID,
+      })
+        .then(response =>
+          checkBidderPosition({ data: response, bidderId, selectedBid })
+        )
+        .catch(error => console.error(error)) // TODO: Implement error handling. story: AUCT-713
+    } else {
+      // TODO: Implement error handling. story: AUCT-713
+      console.error("Bid result was not SUCCESS:", data)
+    }
+  }
+
+  function checkBidderPosition({
+    data,
+    bidderId,
+    selectedBid,
+  }: {
+    data: BidderPositionQueryResponse
+    bidderId: string
+    selectedBid: number
+  }) {
+    const { bidderPosition } = data.me
+
+    if (bidderPosition.status === "PENDING" && pollCount < MAX_POLL_ATTEMPTS) {
+      // initiating new request here (vs setInterval) to make sure we wait for
+      // the previous call to return before making a new one
+      setTimeout(
+        () =>
+          bidderPositionQuery(relay.environment, {
+            bidderPositionID: bidderPosition.position.id,
+          })
+            .then(response =>
+              checkBidderPosition({ data: response, bidderId, selectedBid })
+            )
+            .catch(error => console.error(error)), // TODO: Implement error handling. story: AUCT-713
+        1000
+      )
+
+      pollCount += 1
+    } else if (bidderPosition.status === "WINNING") {
+      const positionId = data.me.bidderPosition.position.id
+      trackConfirmBidSuccess(positionId, bidderId, selectedBid)
+
+      window.location.assign(`${sd.APP_URL}/artwork/${artwork.id}`)
+    } else {
+      // TODO: Implement error handling. story: AUCT-713
+    }
   }
 
   return (

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -42,7 +42,7 @@ const MAX_POLL_ATTEMPTS = 20
 export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   let pollCount = 0
 
-  const { artwork, relay } = props
+  const { artwork, me, relay } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
 
@@ -70,8 +70,8 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
                     internalID
                   }
                   status
-                  message_header: messageHeader
-                  message_description_md: messageDescriptionMD
+                  messageHeader
+                  messageDescriptionMD
                 }
               }
             }
@@ -152,12 +152,6 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
             "ConfirmBidCreateBidderPositionMutation failed",
           ])
         } else {
-          const positionId =
-            data.createBidderPosition.result.position.internalID
-          trackConfirmBidSuccess(positionId, bidderId, values.selectedBid)
-          window.location.assign(
-            `${sd.APP_URL}/auction/${sale.slug}/artwork/${artwork.slug}`
-          )
           verifyBidderPosition({ data, bidderId, selectedBid })
         }
       })
@@ -210,7 +204,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
       setTimeout(
         () =>
           bidderPositionQuery(relay.environment, {
-            bidderPositionID: bidderPosition.position.id,
+            bidderPositionID: bidderPosition.position.internalID,
           })
             .then(response =>
               checkBidderPosition({ data: response, bidderId, selectedBid })
@@ -221,10 +215,10 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
       pollCount += 1
     } else if (bidderPosition.status === "WINNING") {
-      const positionId = data.me.bidderPosition.position.id
+      const positionId = data.me.bidderPosition.position.internalID
       trackConfirmBidSuccess(positionId, bidderId, selectedBid)
 
-      window.location.assign(`${sd.APP_URL}/artwork/${artwork.id}`)
+      window.location.assign(`${sd.APP_URL}/artwork/${artwork.slug}`)
     } else {
       // TODO: Implement error handling. story: AUCT-713
     }
@@ -233,16 +227,22 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   return (
     <AppContainer>
       <Title>Confirm Bid | Artsy</Title>
+
       <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
         <Serif size="8">Confirm your bid</Serif>
+
         <Separator />
+
         <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork} />
+
         <Separator />
+
         <BidForm
           initialSelectedBid={getInitialSelectedBid(props.location)}
           showPricingTransparency={false}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
+          me={me}
         />
       </Box>
     </AppContainer>

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Separator, Serif } from "@artsy/palette"
 import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
+import { ConfirmBid_me } from "__generated__/ConfirmBid_me.graphql"
 import {
   ConfirmBidCreateBidderPositionMutation,
   ConfirmBidCreateBidderPositionMutationResponse,
@@ -7,10 +8,12 @@ import {
 import { routes_ConfirmBidQueryResponse } from "__generated__/routes_ConfirmBidQuery.graphql"
 import {
   BidFormFragmentContainer as BidForm,
+  determineDisplayRequirements,
   FormValues,
 } from "Apps/Auction/Components/BidForm"
 import { LotInfoFragmentContainer as LotInfo } from "Apps/Auction/Components/LotInfo"
 import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositionQuery"
+import { createCreditCardAndUpdatePhone } from "Apps/Auction/Routes/Register"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { trackPageViewWrapper } from "Apps/Order/Utils/trackPageViewWrapper"
 import { track } from "Artsy"
@@ -18,7 +21,7 @@ import * as Schema from "Artsy/Analytics/Schema"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { FormikActions } from "formik"
 import qs from "qs"
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Title } from "react-head"
 import {
   commitMutation,
@@ -26,6 +29,12 @@ import {
   graphql,
   RelayProp,
 } from "react-relay"
+import {
+  Elements,
+  injectStripe,
+  ReactStripeElements,
+  StripeProvider,
+} from "react-stripe-elements"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
@@ -34,9 +43,9 @@ const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
 type BidFormActions = FormikActions<FormValues>
 
-interface ConfirmBidProps {
+interface ConfirmBidProps extends ReactStripeElements.InjectedStripeProps {
   artwork: routes_ConfirmBidQueryResponse["artwork"]
-  me: routes_ConfirmBidQueryResponse["me"]
+  me: ConfirmBid_me
   relay: RelayProp
   location: Location
 }
@@ -46,11 +55,15 @@ const MAX_POLL_ATTEMPTS = 20
 export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   let pollCount = 0
 
-  const { artwork, me, relay } = props
+  const { artwork, me, relay, stripe } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
   const { environment } = relay
   const { trackEvent } = useTracking()
+  const { requiresPaymentInformation } = determineDisplayRequirements(
+    (sale as any).registrationStatus,
+    me as any
+  )
 
   function createBidderPosition(maxBidAmountCents: number) {
     return new Promise<ConfirmBidCreateBidderPositionMutationResponse>(
@@ -129,10 +142,45 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     })
   }
 
-  function handleSubmit(values: FormValues, actions: BidFormActions) {
+  const createTokenFromAddress = async (address: stripe.TokenOptions) => {
+    const { error, token } = await stripe.createToken(address)
+
+    if (error) {
+      throw new Error(`Stripe error: ${error.message || error.decline_code}`)
+    } else {
+      return token
+    }
+  }
+
+  async function handleSubmit(values: FormValues, actions: BidFormActions) {
     const selectedBid = Number(values.selectedBid)
     const possibleExistingBidderId: string | null =
       sale.registrationStatus && sale.registrationStatus.internalID
+
+    if (requiresPaymentInformation) {
+      try {
+        const { address } = values
+        const stripeAddress = {
+          name: address.name,
+          address_line1: address.addressLine1,
+          address_line2: address.addressLine2,
+          address_country: address.country,
+          address_city: address.city,
+          address_state: address.region,
+          address_zip: address.postalCode,
+        }
+
+        const token = await createTokenFromAddress(stripeAddress)
+        await createCreditCardAndUpdatePhone(
+          environment,
+          address.phoneNumber,
+          token.id
+        )
+      } catch (error) {
+        onJsError(actions, error, possibleExistingBidderId)
+        return
+      }
+    }
 
     createBidderPosition(selectedBid)
       .then(data =>
@@ -239,7 +287,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
           showPricingTransparency={false}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
-          me={me}
+          me={me as any}
         />
       </Box>
     </AppContainer>
@@ -254,6 +302,40 @@ const getInitialSelectedBid = (location: Location): string | undefined => {
   )
 }
 
+const StripeInjectedConfirmBidRoute = injectStripe(ConfirmBidRoute)
+
+export const StripeWrappedConfirmBidRoute: React.FC<
+  ConfirmBidProps
+> = props => {
+  const [stripe, setStripe] = useState(null)
+
+  function setupStripe() {
+    setStripe(window.Stripe(sd.STRIPE_PUBLISHABLE_KEY))
+  }
+
+  useEffect(() => {
+    if (window.Stripe) {
+      setStripe(window.Stripe(sd.STRIPE_PUBLISHABLE_KEY))
+    } else {
+      document.querySelector("#stripe-js").addEventListener("load", setupStripe)
+
+      return () => {
+        document
+          .querySelector("#stripe-js")
+          .removeEventListener("load", setupStripe)
+      }
+    }
+  }, [])
+
+  return (
+    <StripeProvider stripe={stripe}>
+      <Elements>
+        <StripeInjectedConfirmBidRoute {...props} />
+      </Elements>
+    </StripeProvider>
+  )
+}
+
 const TrackingWrappedConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   const Component = track<ConfirmBidProps>(p => ({
     context_page: Schema.PageName.AuctionConfirmBidPage,
@@ -261,12 +343,20 @@ const TrackingWrappedConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     artwork_slug: p.artwork.slug,
     sale_id: p.artwork.saleArtwork.sale.internalID,
     user_id: p.me.internalID,
-  }))(ConfirmBidRoute)
+  }))(StripeWrappedConfirmBidRoute)
 
   return <Component {...props} />
 }
 
 export const ConfirmBidRouteFragmentContainer = createFragmentContainer(
   trackPageViewWrapper(TrackingWrappedConfirmBidRoute),
-  {}
+  {
+    me: graphql`
+      fragment ConfirmBid_me on Me {
+        internalID
+        hasQualifiedCreditCards
+        ...BidForm_me
+      }
+    `,
+  }
 )

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -1,3 +1,4 @@
+import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
 import { ConfirmBidCreateBidderPositionMutationResponse } from "__generated__/ConfirmBidCreateBidderPositionMutation.graphql"
 
 export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutationResponse = {
@@ -20,6 +21,32 @@ export const createBidderPositionFailed: ConfirmBidCreateBidderPositionMutationR
       status: "FAILED",
       message_header: "The `createBidderPosition` mutation failed.",
       message_description_md: null,
+    },
+  },
+}
+
+export const confirmBidBidderPositionQueryWithWinning: BidderPositionQueryResponse = {
+  me: {
+    bidderPosition: {
+      status: "WINNING",
+      messageHeader: null,
+      position: {
+        id: "winning-bidder-position-id-from-polling",
+        suggestedNextBid: null,
+      },
+    },
+  },
+}
+
+export const confirmBidBidderPositionQueryWithPending: BidderPositionQueryResponse = {
+  me: {
+    bidderPosition: {
+      status: "PENDING",
+      messageHeader: null,
+      position: {
+        id: "pending-bidder-position-id-from-polling",
+        suggestedNextBid: null,
+      },
     },
   },
 }

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -16,7 +16,6 @@ export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutat
       },
       status: "SUCCESS",
       messageHeader: null,
-      messageDescriptionMD: null,
     },
   },
 }
@@ -36,7 +35,6 @@ export const createBidderPositionSuccessfulAndBidder: ConfirmBidCreateBidderPosi
       },
       status: "SUCCESS",
       messageHeader: null,
-      messageDescriptionMD: null,
     },
   },
 }
@@ -46,8 +44,7 @@ export const createBidderPositionFailed: ConfirmBidCreateBidderPositionMutationR
     result: {
       position: null,
       status: "FAILED",
-      messageHeader: "The `createBidderPosition` mutation failed.",
-      messageDescriptionMD: null,
+      messageHeader: "Sale Closed to Bids",
     },
   },
 }
@@ -70,6 +67,19 @@ export const confirmBidBidderPositionQueryWithPending: BidderPositionQueryRespon
     bidderPosition: {
       status: "PENDING",
       messageHeader: null,
+      position: {
+        internalID: "pending-bidder-position-id-from-polling",
+        suggestedNextBid: null,
+      },
+    },
+  },
+}
+
+export const confirmBidBidderPositionQueryWithOutbid: BidderPositionQueryResponse = {
+  me: {
+    bidderPosition: {
+      status: "OUTBID",
+      messageHeader: "Your bid wasn’t high enough",
       position: {
         internalID: "pending-bidder-position-id-from-polling",
         suggestedNextBid: null,

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -8,8 +8,8 @@ export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutat
         internalID: "positionid",
       },
       status: "SUCCESS",
-      message_header: null,
-      message_description_md: null,
+      messageHeader: null,
+      messageDescriptionMD: null,
     },
   },
 }
@@ -19,8 +19,8 @@ export const createBidderPositionFailed: ConfirmBidCreateBidderPositionMutationR
     result: {
       position: null,
       status: "FAILED",
-      message_header: "The `createBidderPosition` mutation failed.",
-      message_description_md: null,
+      messageHeader: "The `createBidderPosition` mutation failed.",
+      messageDescriptionMD: null,
     },
   },
 }
@@ -31,7 +31,7 @@ export const confirmBidBidderPositionQueryWithWinning: BidderPositionQueryRespon
       status: "WINNING",
       messageHeader: null,
       position: {
-        id: "winning-bidder-position-id-from-polling",
+        internalID: "winning-bidder-position-id-from-polling",
         suggestedNextBid: null,
       },
     },
@@ -44,7 +44,7 @@ export const confirmBidBidderPositionQueryWithPending: BidderPositionQueryRespon
       status: "PENDING",
       messageHeader: null,
       position: {
-        id: "pending-bidder-position-id-from-polling",
+        internalID: "pending-bidder-position-id-from-polling",
         suggestedNextBid: null,
       },
     },

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -6,6 +6,33 @@ export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutat
     result: {
       position: {
         internalID: "positionid",
+        saleArtwork: {
+          sale: {
+            registrationStatus: {
+              internalID: "existing-bidder-id",
+            },
+          },
+        },
+      },
+      status: "SUCCESS",
+      messageHeader: null,
+      messageDescriptionMD: null,
+    },
+  },
+}
+
+export const createBidderPositionSuccessfulAndBidder: ConfirmBidCreateBidderPositionMutationResponse = {
+  createBidderPosition: {
+    result: {
+      position: {
+        internalID: "positionid",
+        saleArtwork: {
+          sale: {
+            registrationStatus: {
+              internalID: "new-bidder-id",
+            },
+          },
+        },
       },
       status: "SUCCESS",
       messageHeader: null,

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -82,6 +82,7 @@ const setupTestEnv = ({
         me {
           internalID
           hasQualifiedCreditCards
+          ...BidForm_me
         }
       }
     `,
@@ -120,9 +121,9 @@ describe("Routes/ConfirmBid", () => {
         }),
         {
           input: {
-            artwork_id: "artworkslug",
-            max_bid_amount_cents: 5000000,
-            sale_id: "saleslug",
+            artworkID: "artworkid",
+            maxBidAmountCents: 5000000,
+            saleID: "saleid",
           },
         }
       )
@@ -145,7 +146,7 @@ describe("Routes/ConfirmBid", () => {
 
         expect(window.location.assign).toHaveBeenCalledWith(
           `https://example.com/artwork/${
-            ConfirmBidQueryResponseFixture.artwork.id
+            ConfirmBidQueryResponseFixture.artwork.slug
           }`
         )
         done()
@@ -200,9 +201,9 @@ describe("Routes/ConfirmBid", () => {
         }),
         {
           input: {
-            artwork_id: "artworkslug",
-            max_bid_amount_cents: 5000000,
-            sale_id: "saleslug",
+            artworkID: "artworkid",
+            maxBidAmountCents: 5000000,
+            saleID: "saleid",
           },
         }
       )
@@ -258,9 +259,9 @@ describe("Routes/ConfirmBid", () => {
       //   }),
       //   {
       //     input: {
-      //       artwork_id: "artworkslug",
-      //       max_bid_amount_cents: 5000000,
-      //       sale_id: "saleslug",
+      //       artworkID: "artworkid",
+      //       maxBidAmountCents: 5000000,
+      //       saleID: "saleid",
       //     },
       //   }
       // )
@@ -281,21 +282,6 @@ describe("Routes/ConfirmBid", () => {
   })
 
   describe("preselected bid amounts", () => {
-    const mockData = {
-      ...ConfirmBidQueryResponseFixture,
-      artwork: {
-        ...ConfirmBidQueryResponseFixture.artwork,
-        saleArtwork: {
-          ...ConfirmBidQueryResponseFixture.artwork.saleArtwork,
-          increments: [
-            { cents: 5000000, display: "$50,000" },
-            { cents: 6000000, display: "$60,000" },
-            { cents: 7000000, display: "$70,000" },
-          ],
-        },
-      },
-    }
-
     it("pre-fills the bid select box with a value from the query string that is available in increments", async () => {
       const specialSelectedBidAmount = "7000000"
       const search = `?bid=${specialSelectedBidAmount}`

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -102,136 +102,182 @@ describe("Routes/ConfirmBid", () => {
     jest.resetAllMocks()
   })
 
-  it("successfully places a bid and redirect to artwork page", async done => {
-    const env = setupTestEnv()
-    const page = await env.buildPage()
+  describe("for registered users", () => {
+    it("allows the user to place a bid without agreeing to terms", async done => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
 
-    env.mutations.useResultsOnce(createBidderPositionSuccessful)
-    mockBidderPositionQuery.mockResolvedValue(
-      confirmBidBidderPositionQueryWithPending
-    )
+      env.mutations.useResultsOnce(createBidderPositionSuccessful)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithPending
+      )
 
-    await page.agreeToTerms()
-    await page.submitForm()
+      await page.submitForm()
 
-    expect(env.mutations.mockFetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ConfirmBidCreateBidderPositionMutation",
-      }),
-      {
-        input: {
-          artworkID: "artworkid",
-          maxBidAmountCents: 5000000,
-          saleID: "saleid",
-        },
-      }
-    )
+      expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ConfirmBidCreateBidderPositionMutation",
+        }),
+        {
+          input: {
+            artwork_id: "artworkslug",
+            max_bid_amount_cents: 5000000,
+            sale_id: "saleslug",
+          },
+        }
+      )
 
-    expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
-    expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
-      bidderPositionID: "positionid",
-    })
-
-    mockBidderPositionQuery.mockReset()
-    mockBidderPositionQuery.mockResolvedValue(
-      confirmBidBidderPositionQueryWithWinning
-    )
-
-    setTimeout(() => {
       expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
       expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
-        bidderPositionID: "pending-bidder-position-id-from-polling",
+        bidderPositionID: "positionid",
       })
 
-      expect(window.location.assign).toHaveBeenCalledWith(
-        `https://example.com/artwork/${
-          ConfirmBidQueryResponseFixture.artwork.id
-        }`
+      mockBidderPositionQuery.mockReset()
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
       )
-      done()
-    }, 1001)
-  })
 
-  it("tracks a success event to Segment including Criteo info", async done => {
-    const env = setupTestEnv()
-    const page = await env.buildPage()
-    env.mutations.useResultsOnce(createBidderPositionSuccessful)
-    mockBidderPositionQuery.mockResolvedValue(
-      confirmBidBidderPositionQueryWithWinning
-    )
+      setTimeout(() => {
+        expect(mockBidderPositionQuery).toHaveBeenCalledTimes(1)
+        expect(mockBidderPositionQuery.mock.calls[0][1]).toEqual({
+          bidderPositionID: "pending-bidder-position-id-from-polling",
+        })
 
-    await page.agreeToTerms()
-    await page.submitForm()
+        expect(window.location.assign).toHaveBeenCalledWith(
+          `https://example.com/artwork/${
+            ConfirmBidQueryResponseFixture.artwork.id
+          }`
+        )
+        done()
+      }, 1001)
+    })
 
-    setTimeout(() => {
-      expect(mockPostEvent).toHaveBeenCalledTimes(1)
-      expect(mockPostEvent).toHaveBeenCalledWith({
-        action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+    it("tracks a success event to Segment including Criteo info", async done => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+      env.mutations.useResultsOnce(createBidderPositionSuccessful)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
+      )
+
+      await page.submitForm()
+
+      setTimeout(() => {
+        expect(mockPostEvent).toHaveBeenCalledTimes(1)
+        expect(mockPostEvent).toHaveBeenCalledWith({
+          action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+          context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+          auction_slug: "saleslug",
+          artwork_slug: "artworkslug",
+          bidder_id: "bidderid",
+          bidder_position_id: "winning-bidder-position-id-from-polling",
+          sale_id: "saleid",
+          user_id: "my-user-id",
+          order_id: "bidderid",
+          products: [
+            {
+              product_id: "artworkid",
+              quantity: 1,
+              price: 50000,
+            },
+          ],
+        })
+        done()
+      }, 1001)
+    })
+
+    it("send an error event to analytics if the mutation fails", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+
+      env.mutations.useResultsOnce(createBidderPositionFailed)
+
+      await page.submitForm()
+
+      expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ConfirmBidCreateBidderPositionMutation",
+        }),
+        {
+          input: {
+            artwork_id: "artworkslug",
+            max_bid_amount_cents: 5000000,
+            sale_id: "saleslug",
+          },
+        }
+      )
+
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["ConfirmBidCreateBidderPositionMutation failed"],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
         bidder_id: "bidderid",
-        bidder_position_id: "winning-bidder-position-id-from-polling",
         sale_id: "saleid",
         user_id: "my-user-id",
-        order_id: "bidderid",
-        products: [
-          {
-            product_id: "artworkid",
-            quantity: 1,
-            price: 50000,
-          },
-        ],
       })
-      done()
-    }, 1001)
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(window.location.assign).not.toHaveBeenCalled()
+    })
   })
 
-  it("send an error event to analytics if the mutation fails", async () => {
-    const env = setupTestEnv()
-    const page = await env.buildPage()
-
-    env.mutations.useResultsOnce(createBidderPositionFailed)
-
-    await page.agreeToTerms()
-    await page.submitForm()
-
-    expect(env.mutations.mockFetch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "ConfirmBidCreateBidderPositionMutation",
-      }),
+  describe("for unregistered users with a credit card on file", () => {
+    const FixtureForUnregisteredUserWithCreditCard = deepMerge(
+      ConfirmBidQueryResponseFixture,
       {
-        input: {
-          artworkID: "artworkid",
-          maxBidAmountCents: 5000000,
-          saleID: "saleid",
+        me: {
+          hasQualifiedCreditCards: true,
+        },
+        artwork: {
+          saleArtwork: {
+            sale: {
+              registrationStatus: null,
+            },
+          },
         },
       }
     )
 
-    expect(mockPostEvent).toBeCalledWith({
-      action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
-      context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
-      error_messages: ["ConfirmBidCreateBidderPositionMutation failed"],
-      auction_slug: "saleslug",
-      artwork_slug: "artworkslug",
-      bidder_id: "bidderid",
-      sale_id: "saleid",
-      user_id: "my-user-id",
+    it("allows the user to place a bid after agreeing to terms", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+
+      // env.mutations.useResultsOnce(createBidderPositionSuccessful)
+      // mockBidderPositionQuery.mockResolvedValue(confirmBidBidderPositionQueryWithPending)
+
+      await page.agreeToTerms()
+      // await page.submitForm()
+
+      // TODO: Uncomment once https://artsyproduct.atlassian.net/browse/AUCT-716 is fixed.
+      // expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+      //   expect.objectContaining({
+      //     name: "ConfirmBidCreateBidderPositionMutation",
+      //   }),
+      //   {
+      //     input: {
+      //       artwork_id: "artworkslug",
+      //       max_bid_amount_cents: 5000000,
+      //       sale_id: "saleslug",
+      //     },
+      //   }
+      // )
     })
-    expect(mockPostEvent).toHaveBeenCalledTimes(1)
-    expect(window.location.assign).not.toHaveBeenCalled()
-  })
 
-  it("requires user to agree to terms", async () => {
-    const env = setupTestEnv()
-    const page = await env.buildPage()
+    it("displays an error when user did not agree to terms but tried to submit", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
 
-    await page.submitForm()
+      await page.submitForm()
 
-    expect(env.mutations.mockFetch).not.toBeCalled()
-    expect(window.location.assign).not.toHaveBeenCalled()
-    expect(page.text()).toContain("You must agree to the Conditions of Sale")
+      expect(env.mutations.mockFetch).not.toBeCalled()
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain("You must agree to the Conditions of Sale")
+    })
   })
 
   describe("preselected bid amounts", () => {
@@ -254,19 +300,7 @@ describe("Routes/ConfirmBid", () => {
       const specialSelectedBidAmount = "7000000"
       const search = `?bid=${specialSelectedBidAmount}`
       const env = setupTestEnv({ location: { search } })
-      const page = await env.buildPage({
-        mockData: deepMerge(ConfirmBidQueryResponseFixture, {
-          artwork: {
-            saleArtwork: {
-              increments: [
-                { cents: 5000000, display: "$50,000" },
-                { cents: 6000000, display: "$60,000" },
-                { cents: 7000000, display: "$70,000" },
-              ],
-            },
-          },
-        }),
-      })
+      const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe(
         specialSelectedBidAmount
@@ -277,19 +311,7 @@ describe("Routes/ConfirmBid", () => {
       const specialSelectedBidAmount = "42000000"
       const search = `?bid=${specialSelectedBidAmount}`
       const env = setupTestEnv({ location: { search } })
-      const page = await env.buildPage({
-        mockData: deepMerge(ConfirmBidQueryResponseFixture, {
-          artwork: {
-            saleArtwork: {
-              increments: [
-                { cents: 5000000, display: "$50,000" },
-                { cents: 6000000, display: "$60,000" },
-                { cents: 7000000, display: "$70,000" },
-              ],
-            },
-          },
-        }),
-      })
+      const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
     })
@@ -298,19 +320,7 @@ describe("Routes/ConfirmBid", () => {
       const specialSelectedBidAmount = "420000"
       const search = `?bid=${specialSelectedBidAmount}`
       const env = setupTestEnv({ location: { search } })
-      const page = await env.buildPage({
-        mockData: deepMerge(ConfirmBidQueryResponseFixture, {
-          artwork: {
-            saleArtwork: {
-              increments: [
-                { cents: 5000000, display: "$50,000" },
-                { cents: 6000000, display: "$60,000" },
-                { cents: 7000000, display: "$70,000" },
-              ],
-            },
-          },
-        }),
-      })
+      const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
     })
@@ -319,7 +329,8 @@ describe("Routes/ConfirmBid", () => {
       const specialSelectedBidAmount = "50 thousand and 00/100 dollars"
       const search = `?bid=${specialSelectedBidAmount}`
       const env = setupTestEnv({ location: { search } })
-      const page = await env.buildPage({ mockData })
+      const page = await env.buildPage()
+
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
     })
   })

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -18,6 +18,7 @@ import {
   confirmBidBidderPositionQueryWithWinning,
   createBidderPositionFailed,
   createBidderPositionSuccessful,
+  createBidderPositionSuccessfulAndBidder,
 } from "../__fixtures__/MutationResults/createBidderPosition"
 import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
 import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
@@ -153,7 +154,7 @@ describe("Routes/ConfirmBid", () => {
       }, 1001)
     })
 
-    it("tracks a success event to Segment including Criteo info", async done => {
+    it("tracks a success event to Segment including Criteo info", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage()
       env.mutations.useResultsOnce(createBidderPositionSuccessful)
@@ -163,28 +164,25 @@ describe("Routes/ConfirmBid", () => {
 
       await page.submitForm()
 
-      setTimeout(() => {
-        expect(mockPostEvent).toHaveBeenCalledTimes(1)
-        expect(mockPostEvent).toHaveBeenCalledWith({
-          action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
-          context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
-          auction_slug: "saleslug",
-          artwork_slug: "artworkslug",
-          bidder_id: "bidderid",
-          bidder_position_id: "winning-bidder-position-id-from-polling",
-          sale_id: "saleid",
-          user_id: "my-user-id",
-          order_id: "bidderid",
-          products: [
-            {
-              product_id: "artworkid",
-              quantity: 1,
-              price: 50000,
-            },
-          ],
-        })
-        done()
-      }, 1001)
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "existing-bidder-id",
+        bidder_position_id: "winning-bidder-position-id-from-polling",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+        order_id: "existing-bidder-id",
+        products: [
+          {
+            product_id: "artworkid",
+            quantity: 1,
+            price: 50000,
+          },
+        ],
+      })
     })
 
     it("send an error event to analytics if the mutation fails", async () => {
@@ -214,7 +212,7 @@ describe("Routes/ConfirmBid", () => {
         error_messages: ["ConfirmBidCreateBidderPositionMutation failed"],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
-        bidder_id: "bidderid",
+        bidder_id: "existing-bidder-id",
         sale_id: "saleid",
         user_id: "my-user-id",
       })
@@ -246,25 +244,60 @@ describe("Routes/ConfirmBid", () => {
         mockData: FixtureForUnregisteredUserWithCreditCard,
       })
 
-      // env.mutations.useResultsOnce(createBidderPositionSuccessful)
-      // mockBidderPositionQuery.mockResolvedValue(confirmBidBidderPositionQueryWithPending)
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
+      )
 
       await page.agreeToTerms()
-      // await page.submitForm()
+      await page.submitForm()
 
-      // TODO: Uncomment once https://artsyproduct.atlassian.net/browse/AUCT-716 is fixed.
-      // expect(env.mutations.mockFetch).toHaveBeenCalledWith(
-      //   expect.objectContaining({
-      //     name: "ConfirmBidCreateBidderPositionMutation",
-      //   }),
-      //   {
-      //     input: {
-      //       artworkID: "artworkid",
-      //       maxBidAmountCents: 5000000,
-      //       saleID: "saleid",
-      //     },
-      //   }
-      // )
+      expect(env.mutations.mockFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ConfirmBidCreateBidderPositionMutation",
+        }),
+        {
+          input: {
+            artworkID: "artworkid",
+            maxBidAmountCents: 5000000,
+            saleID: "saleid",
+          },
+        }
+      )
+    })
+
+    it("tracks a success event to Segment including Criteo info", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
+      )
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "new-bidder-id",
+        bidder_position_id: "winning-bidder-position-id-from-polling",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+        order_id: "new-bidder-id",
+        products: [
+          {
+            product_id: "artworkid",
+            quantity: 1,
+            price: 50000,
+          },
+        ],
+      })
     })
 
     it("displays an error when user did not agree to terms but tried to submit", async () => {

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -14,6 +14,7 @@ import { bidderPositionQuery } from "Apps/Auction/Routes/ConfirmBid/BidderPositi
 import { AnalyticsSchema } from "Artsy/Analytics"
 import { TrackingProp } from "react-tracking"
 import {
+  confirmBidBidderPositionQueryWithOutbid,
   confirmBidBidderPositionQueryWithPending,
   confirmBidBidderPositionQueryWithWinning,
   createBidderPositionFailed,
@@ -185,7 +186,47 @@ describe("Routes/ConfirmBid", () => {
       })
     })
 
-    it("send an error event to analytics if the mutation fails", async () => {
+    it("displays an error message when the mutation returns a GraphQL error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+
+      env.mutations.useResultsOnce(createBidderPositionFailed)
+
+      await page.submitForm()
+
+      expect(page.text()).toContain("Sale Closed to Bids.")
+      expect(window.location.assign).not.toHaveBeenCalled()
+    })
+
+    it("displays an error message when the mutation throws a JS error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+
+      env.mutations.mockNetworkFailureOnce()
+
+      await page.submitForm()
+
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain(
+        "Please make sure your internet connection is active and try again"
+      )
+    })
+
+    it("displays an error message when polling receives a non-success status", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithOutbid
+      )
+
+      await page.submitForm()
+
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain("Your bid wasn’t high enough.")
+    })
+
+    it("tracks an error when the mutation returns a GraphQL error", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage()
 
@@ -206,18 +247,61 @@ describe("Routes/ConfirmBid", () => {
         }
       )
 
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
       expect(mockPostEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
-        error_messages: ["ConfirmBidCreateBidderPositionMutation failed"],
+        error_messages: ["Sale Closed to Bids"],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
         bidder_id: "existing-bidder-id",
         sale_id: "saleid",
         user_id: "my-user-id",
       })
+    })
+
+    it("tracks an error when the mutation throws a JS error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+
+      env.mutations.mockNetworkFailureOnce()
+
+      await page.submitForm()
+
       expect(mockPostEvent).toHaveBeenCalledTimes(1)
-      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["JavaScript error: failed to fetch"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "existing-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("tracks an error when polling receives a non-success status", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithOutbid
+      )
+
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["Your bid wasn’t high enough"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "existing-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
     })
   })
 
@@ -311,6 +395,78 @@ describe("Routes/ConfirmBid", () => {
       expect(env.mutations.mockFetch).not.toBeCalled()
       expect(window.location.assign).not.toHaveBeenCalled()
       expect(page.text()).toContain("You must agree to the Conditions of Sale")
+    })
+
+    it("tracks an error without bidder id when the mutation returns a GraphQL error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+      env.mutations.useResultsOnce(createBidderPositionFailed)
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["Sale Closed to Bids"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("tracks an error without bidder id when the mutation throws a JS error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+      env.mutations.mockNetworkFailureOnce()
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["JavaScript error: failed to fetch"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("tracks an error with bidder id when polling receives a non-success status", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithOutbid
+      )
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["Your bid wasn’t high enough"],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "new-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
     })
   })
 

--- a/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
+++ b/src/Apps/Auction/Routes/__tests__/Utils/ConfirmBidTestPage.tsx
@@ -1,4 +1,7 @@
 import { Checkbox } from "@artsy/palette"
+
+import { ValidFormValues } from "Apps/Auction/Routes/__tests__/Utils/RegisterTestPage"
+import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { expectOne, RootTestPage } from "DevTools/RootTestPage"
 
 export class ConfirmBidTestPage extends RootTestPage {
@@ -7,19 +10,37 @@ export class ConfirmBidTestPage extends RootTestPage {
       btn.text().includes("Confirm bid")
     )
   }
+
   get selectBidAmountInput() {
     return expectOne(this.find("select"))
   }
+
   get form() {
     return expectOne(this.find("form"))
   }
+
+  get addressInput() {
+    return expectOne(this.form.find(AddressForm))
+  }
+
   get agreeToTermsInput() {
     return expectOne(this.form.find(Checkbox))
   }
+
+  async fillAddressForm(address: Address) {
+    this.addressInput.props().onChange(address, "city")
+  }
+
+  async fillFormWithValidValues() {
+    this.fillAddressForm(ValidFormValues)
+    await this.update()
+  }
+
   async agreeToTerms() {
     this.agreeToTermsInput.props().onSelect(true)
     await this.update()
   }
+
   async submitForm() {
     this.form.simulate("submit")
     await this.update()

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -4,7 +4,7 @@ export const ConfirmBidQueryResponseFixture: routes_ConfirmBidQueryRawResponse =
   me: {
     id: "opaque-my-user-id",
     internalID: "my-user-id",
-    hasQualifiedCreditCards: false,
+    hasQualifiedCreditCards: true,
   },
   artwork: {
     id: "opaque-artworkid",

--- a/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
+++ b/src/Apps/Auction/__fixtures__/routes_ConfirmBidQuery.ts
@@ -39,7 +39,7 @@ export const ConfirmBidQueryResponseFixture: routes_ConfirmBidQueryRawResponse =
         isRegistrationClosed: false,
         registrationStatus: {
           id: "opaque-bidderid",
-          internalID: "bidderid",
+          internalID: "existing-bidder-id",
           qualifiedForBidding: true,
         },
       },

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -60,6 +60,7 @@ export const routes: RouteConfig[] = [
           }
         }
         me {
+          ...BidForm_me
           id
           internalID
           hasQualifiedCreditCards

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -35,35 +35,31 @@ export const routes: RouteConfig[] = [
       query routes_ConfirmBidQuery($saleID: String!, $artworkID: String!)
         @raw_response_type {
         artwork(id: $artworkID) {
-          ...LotInfo_artwork
-          id
           internalID
           slug
           saleArtwork(saleID: $saleID) {
-            ...LotInfo_saleArtwork
-            ...BidForm_saleArtwork
-            id
             internalID
             slug
             sale {
-              id
-              registrationStatus {
-                internalID
-                qualifiedForBidding
-              }
               internalID
               slug
               name
               isClosed
               isRegistrationClosed
+              registrationStatus {
+                internalID
+                qualifiedForBidding
+              }
             }
+            ...LotInfo_saleArtwork
+            ...BidForm_saleArtwork
           }
+          ...LotInfo_artwork
         }
         me {
-          ...BidForm_me
-          id
           internalID
           hasQualifiedCreditCards
+          ...ConfirmBid_me
         }
       }
     `,

--- a/src/DevTools/createTestEnv.tsx
+++ b/src/DevTools/createTestEnv.tsx
@@ -75,6 +75,10 @@ class TestEnv<MutationNames extends string, TestPage extends RootTestPage> {
       {} as any
     )
 
+    beforeEach(() => {
+      this.errors = []
+    })
+
     afterEach(() => {
       const _errors = this.errors
       this.errors = []

--- a/src/__generated__/ArtistInfo_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistInfo_Test_Query.graphql.ts
@@ -99,6 +99,12 @@ query ArtistInfo_Test_Query {
   }
 }
 
+fragment ArtistBio_bio on Artist {
+  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
+    text
+  }
+}
+
 fragment ArtistInfo_artist on Artist {
   internalID
   slug
@@ -145,36 +151,6 @@ fragment ArtistInfo_artist on Artist {
   }
 }
 
-fragment SelectedExhibitions_exhibitions on Show {
-  partner {
-    __typename
-    ... on ExternalPartner {
-      name
-      id
-    }
-    ... on Partner {
-      name
-    }
-    ... on Node {
-      id
-    }
-  }
-  name
-  start_at: startAt(format: "YYYY")
-  cover_image: coverImage {
-    cropped(width: 800, height: 600) {
-      url
-    }
-  }
-  city
-}
-
-fragment ArtistBio_bio on Artist {
-  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {
-    text
-  }
-}
-
 fragment ArtistMarketInsights_artist on Artist {
   collections
   highlights {
@@ -213,6 +189,30 @@ fragment FollowArtistButton_artist on Artist {
   counts {
     follows
   }
+}
+
+fragment SelectedExhibitions_exhibitions on Show {
+  partner {
+    __typename
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Partner {
+      name
+    }
+    ... on Node {
+      id
+    }
+  }
+  name
+  start_at: startAt(format: "YYYY")
+  cover_image: coverImage {
+    cropped(width: 800, height: 600) {
+      url
+    }
+  }
+  city
 }
 */
 
@@ -706,7 +706,7 @@ return {
     "operationKind": "query",
     "name": "ArtistInfo_Test_Query",
     "id": null,
-    "text": "query ArtistInfo_Test_Query {\n  artist(id: \"banksy\") {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
+    "text": "query ArtistInfo_Test_Query {\n  artist(id: \"banksy\") {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biography_blurb: biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/BidForm_me.graphql.ts
+++ b/src/__generated__/BidForm_me.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type BidForm_me = {
+    readonly hasQualifiedCreditCards: boolean | null;
+    readonly " $refType": "BidForm_me";
+};
+export type BidForm_me$data = BidForm_me;
+export type BidForm_me$key = {
+    readonly " $data"?: BidForm_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "BidForm_me",
+  "type": "Me",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hasQualifiedCreditCards",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '8ed9070855d2bf5bf240dd4b90da4955';
+export default node;

--- a/src/__generated__/BidForm_saleArtwork.graphql.ts
+++ b/src/__generated__/BidForm_saleArtwork.graphql.ts
@@ -10,6 +10,11 @@ export type BidForm_saleArtwork = {
         readonly cents: number | null;
         readonly display: string | null;
     } | null> | null;
+    readonly sale: {
+        readonly registrationStatus: {
+            readonly qualifiedForBidding: boolean | null;
+        } | null;
+    } | null;
     readonly " $refType": "BidForm_saleArtwork";
 };
 export type BidForm_saleArtwork$data = BidForm_saleArtwork;
@@ -71,9 +76,38 @@ return {
           "storageKey": null
         }
       ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "sale",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Sale",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "registrationStatus",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Bidder",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "qualifiedForBidding",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
     }
   ]
 };
 })();
-(node as any).hash = 'e929d0b1f453429bad6f2adb041f92a9';
+(node as any).hash = 'd5f35722b95804bd4fd260470c7ad8fa';
 export default node;

--- a/src/__generated__/BidderPositionQuery.graphql.ts
+++ b/src/__generated__/BidderPositionQuery.graphql.ts
@@ -10,7 +10,7 @@ export type BidderPositionQueryResponse = {
             readonly status: string;
             readonly messageHeader: string | null;
             readonly position: {
-                readonly id: string;
+                readonly internalID: string;
                 readonly suggestedNextBid: {
                     readonly cents: number | null;
                     readonly display: string | null;
@@ -35,11 +35,12 @@ query BidderPositionQuery(
       status
       messageHeader
       position {
-        id
+        internalID
         suggestedNextBid {
           cents
           display
         }
+        id
       }
     }
     id
@@ -56,80 +57,65 @@ var v0 = [
     "defaultValue": null
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "bidderPositionID"
+  }
+],
+v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "status",
   "args": null,
   "storageKey": null
 },
-v2 = {
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "messageHeader",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
   "kind": "LinkedField",
   "alias": null,
-  "name": "bidderPosition",
+  "name": "suggestedNextBid",
   "storageKey": null,
-  "args": [
-    {
-      "kind": "Variable",
-      "name": "id",
-      "variableName": "bidderPositionID"
-    }
-  ],
-  "concreteType": "BidderPositionResult",
+  "args": null,
+  "concreteType": "BidderPositionSuggestedNextBid",
   "plural": false,
   "selections": [
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "status",
+      "name": "cents",
       "args": null,
       "storageKey": null
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "messageHeader",
+      "name": "display",
       "args": null,
       "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "position",
-      "storageKey": null,
-      "args": null,
-      "concreteType": "BidderPosition",
-      "plural": false,
-      "selections": [
-        (v1/*: any*/),
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "suggestedNextBid",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "BidderPositionSuggestedNextBid",
-          "plural": false,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "cents",
-              "args": null,
-              "storageKey": null
-            },
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "display",
-              "args": null,
-              "storageKey": null
-            }
-          ]
-        }
-      ]
     }
   ]
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
@@ -149,7 +135,32 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
-          (v2/*: any*/)
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "bidderPosition",
+            "storageKey": null,
+            "args": (v1/*: any*/),
+            "concreteType": "BidderPositionResult",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "position",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "BidderPosition",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/)
+                ]
+              }
+            ]
+          }
         ]
       }
     ]
@@ -168,8 +179,34 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v1/*: any*/)
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "bidderPosition",
+            "storageKey": null,
+            "args": (v1/*: any*/),
+            "concreteType": "BidderPositionResult",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "position",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "BidderPosition",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/)
+                ]
+              }
+            ]
+          },
+          (v6/*: any*/)
         ]
       }
     ]
@@ -178,10 +215,10 @@ return {
     "operationKind": "query",
     "name": "BidderPositionQuery",
     "id": null,
-    "text": "query BidderPositionQuery(\n  $bidderPositionID: String!\n) {\n  me {\n    bidderPosition(id: $bidderPositionID) {\n      status\n      messageHeader\n      position {\n        id\n        suggestedNextBid {\n          cents\n          display\n        }\n      }\n    }\n    id\n  }\n}\n",
+    "text": "query BidderPositionQuery(\n  $bidderPositionID: String!\n) {\n  me {\n    bidderPosition(id: $bidderPositionID) {\n      status\n      messageHeader\n      position {\n        internalID\n        suggestedNextBid {\n          cents\n          display\n        }\n        id\n      }\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '6aa78c481c1eaf99b5323a9d2ffd6baf';
+(node as any).hash = '824ae5e154436e7ff5d954d947fd8ad6';
 export default node;

--- a/src/__generated__/BidderPositionQuery.graphql.ts
+++ b/src/__generated__/BidderPositionQuery.graphql.ts
@@ -1,0 +1,187 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type BidderPositionQueryVariables = {
+    bidderPositionID: string;
+};
+export type BidderPositionQueryResponse = {
+    readonly me: {
+        readonly bidderPosition: {
+            readonly status: string;
+            readonly messageHeader: string | null;
+            readonly position: {
+                readonly id: string;
+                readonly suggestedNextBid: {
+                    readonly cents: number | null;
+                    readonly display: string | null;
+                } | null;
+            } | null;
+        } | null;
+    } | null;
+};
+export type BidderPositionQuery = {
+    readonly response: BidderPositionQueryResponse;
+    readonly variables: BidderPositionQueryVariables;
+};
+
+
+
+/*
+query BidderPositionQuery(
+  $bidderPositionID: String!
+) {
+  me {
+    bidderPosition(id: $bidderPositionID) {
+      status
+      messageHeader
+      position {
+        id
+        suggestedNextBid {
+          cents
+          display
+        }
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "bidderPositionID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "bidderPosition",
+  "storageKey": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "id",
+      "variableName": "bidderPositionID"
+    }
+  ],
+  "concreteType": "BidderPositionResult",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "status",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "messageHeader",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "position",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "BidderPosition",
+      "plural": false,
+      "selections": [
+        (v1/*: any*/),
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "suggestedNextBid",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "BidderPositionSuggestedNextBid",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cents",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "display",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "BidderPositionQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "BidderPositionQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v1/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "BidderPositionQuery",
+    "id": null,
+    "text": "query BidderPositionQuery(\n  $bidderPositionID: String!\n) {\n  me {\n    bidderPosition(id: $bidderPositionID) {\n      status\n      messageHeader\n      position {\n        id\n        suggestedNextBid {\n          cents\n          display\n        }\n      }\n    }\n    id\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '6aa78c481c1eaf99b5323a9d2ffd6baf';
+export default node;

--- a/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
+++ b/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
@@ -15,6 +15,13 @@ export type ConfirmBidCreateBidderPositionMutationResponse = {
         readonly result: {
             readonly position: {
                 readonly internalID: string;
+                readonly saleArtwork: {
+                    readonly sale: {
+                        readonly registrationStatus: {
+                            readonly internalID: string;
+                        } | null;
+                    } | null;
+                } | null;
             } | null;
             readonly status: string;
             readonly messageHeader: string | null;
@@ -37,6 +44,16 @@ mutation ConfirmBidCreateBidderPositionMutation(
     result {
       position {
         internalID
+        saleArtwork {
+          sale {
+            registrationStatus {
+              internalID
+              id
+            }
+            id
+          }
+          id
+        }
         id
       }
       status
@@ -90,6 +107,13 @@ v5 = {
   "name": "messageDescriptionMD",
   "args": null,
   "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
 };
 return {
   "kind": "Request",
@@ -127,7 +151,41 @@ return {
                 "concreteType": "BidderPosition",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/)
+                  (v2/*: any*/),
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "saleArtwork",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "registrationStatus",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Bidder",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/)
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
                 ]
               },
               (v3/*: any*/),
@@ -173,12 +231,43 @@ return {
                 "selections": [
                   (v2/*: any*/),
                   {
-                    "kind": "ScalarField",
+                    "kind": "LinkedField",
                     "alias": null,
-                    "name": "id",
+                    "name": "saleArtwork",
+                    "storageKey": null,
                     "args": null,
-                    "storageKey": null
-                  }
+                    "concreteType": "SaleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "registrationStatus",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Bidder",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v6/*: any*/)
+                            ]
+                          },
+                          (v6/*: any*/)
+                        ]
+                      },
+                      (v6/*: any*/)
+                    ]
+                  },
+                  (v6/*: any*/)
                 ]
               },
               (v3/*: any*/),
@@ -194,10 +283,10 @@ return {
     "operationKind": "mutation",
     "name": "ConfirmBidCreateBidderPositionMutation",
     "id": null,
-    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        id\n      }\n      status\n      messageHeader\n      messageDescriptionMD\n    }\n  }\n}\n",
+    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        saleArtwork {\n          sale {\n            registrationStatus {\n              internalID\n              id\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n      status\n      messageHeader\n      messageDescriptionMD\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '221ace778bd3446ce1d9695869417e38';
+(node as any).hash = 'd78638aac3fa507d0dbbbd3b9e7f0987';
 export default node;

--- a/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
+++ b/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
@@ -25,7 +25,6 @@ export type ConfirmBidCreateBidderPositionMutationResponse = {
             } | null;
             readonly status: string;
             readonly messageHeader: string | null;
-            readonly messageDescriptionMD: string | null;
         } | null;
     } | null;
 };
@@ -58,7 +57,6 @@ mutation ConfirmBidCreateBidderPositionMutation(
       }
       status
       messageHeader
-      messageDescriptionMD
     }
   }
 }
@@ -102,13 +100,6 @@ v4 = {
   "storageKey": null
 },
 v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "messageDescriptionMD",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -189,8 +180,7 @@ return {
                 ]
               },
               (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/)
+              (v4/*: any*/)
             ]
           }
         ]
@@ -258,21 +248,20 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v6/*: any*/)
+                              (v5/*: any*/)
                             ]
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
-                      (v6/*: any*/)
+                      (v5/*: any*/)
                     ]
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ]
               },
               (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/)
+              (v4/*: any*/)
             ]
           }
         ]
@@ -283,10 +272,10 @@ return {
     "operationKind": "mutation",
     "name": "ConfirmBidCreateBidderPositionMutation",
     "id": null,
-    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        saleArtwork {\n          sale {\n            registrationStatus {\n              internalID\n              id\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n      status\n      messageHeader\n      messageDescriptionMD\n    }\n  }\n}\n",
+    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        saleArtwork {\n          sale {\n            registrationStatus {\n              internalID\n              id\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n      status\n      messageHeader\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'd78638aac3fa507d0dbbbd3b9e7f0987';
+(node as any).hash = '1ed3f093df63d0401ed964616a1597d6';
 export default node;

--- a/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
+++ b/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
@@ -17,8 +17,8 @@ export type ConfirmBidCreateBidderPositionMutationResponse = {
                 readonly internalID: string;
             } | null;
             readonly status: string;
-            readonly message_header: string | null;
-            readonly message_description_md: string | null;
+            readonly messageHeader: string | null;
+            readonly messageDescriptionMD: string | null;
         } | null;
     } | null;
 };
@@ -40,8 +40,8 @@ mutation ConfirmBidCreateBidderPositionMutation(
         id
       }
       status
-      message_header: messageHeader
-      message_description_md: messageDescriptionMD
+      messageHeader
+      messageDescriptionMD
     }
   }
 }
@@ -79,14 +79,14 @@ v3 = {
 },
 v4 = {
   "kind": "ScalarField",
-  "alias": "message_header",
+  "alias": null,
   "name": "messageHeader",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
-  "alias": "message_description_md",
+  "alias": null,
   "name": "messageDescriptionMD",
   "args": null,
   "storageKey": null
@@ -194,10 +194,10 @@ return {
     "operationKind": "mutation",
     "name": "ConfirmBidCreateBidderPositionMutation",
     "id": null,
-    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        id\n      }\n      status\n      message_header: messageHeader\n      message_description_md: messageDescriptionMD\n    }\n  }\n}\n",
+    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        id\n      }\n      status\n      messageHeader\n      messageDescriptionMD\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '5a8747e92cb3ca78c7dac7a73739afa4';
+(node as any).hash = '221ace778bd3446ce1d9695869417e38';
 export default node;

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -28,6 +28,7 @@ export type ConfirmBidValidTestQueryResponse = {
     readonly me: {
         readonly internalID: string;
         readonly hasQualifiedCreditCards: boolean | null;
+        readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
     } | null;
 };
 export type ConfirmBidValidTestQueryRawResponse = {
@@ -52,21 +53,21 @@ export type ConfirmBidValidTestQueryRawResponse = {
                 readonly cents: number | null;
                 readonly display: string | null;
             }) | null> | null;
-            readonly internalID: string;
-            readonly slug: string;
             readonly sale: ({
                 readonly registrationStatus: ({
-                    readonly internalID: string;
                     readonly qualifiedForBidding: boolean | null;
                     readonly id: string | null;
+                    readonly internalID: string;
                 }) | null;
+                readonly id: string | null;
                 readonly internalID: string;
                 readonly slug: string;
                 readonly name: string | null;
                 readonly isClosed: boolean | null;
                 readonly isRegistrationClosed: boolean | null;
-                readonly id: string | null;
             }) | null;
+            readonly internalID: string;
+            readonly slug: string;
             readonly id: string | null;
         }) | null;
         readonly id: string | null;
@@ -116,8 +117,13 @@ query ConfirmBidValidTestQuery {
   me {
     internalID
     hasQualifiedCreditCards
+    ...BidForm_me
     id
   }
+}
+
+fragment BidForm_me on Me {
+  hasQualifiedCreditCards
 }
 
 fragment BidForm_saleArtwork on SaleArtwork {
@@ -127,6 +133,13 @@ fragment BidForm_saleArtwork on SaleArtwork {
   increments(useMyMaxBid: true) {
     cents
     display
+  }
+  sale {
+    registrationStatus {
+      qualifiedForBidding
+      id
+    }
+    id
   }
 }
 
@@ -325,7 +338,12 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v8/*: any*/)
+          (v8/*: any*/),
+          {
+            "kind": "FragmentSpread",
+            "name": "BidForm_me",
+            "args": null
+          }
         ]
       }
     ]
@@ -447,8 +465,6 @@ return {
                   (v10/*: any*/)
                 ]
               },
-              (v1/*: any*/),
-              (v2/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -467,19 +483,21 @@ return {
                     "concreteType": "Bidder",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
                       (v4/*: any*/),
-                      (v11/*: any*/)
+                      (v11/*: any*/),
+                      (v1/*: any*/)
                     ]
                   },
+                  (v11/*: any*/),
                   (v1/*: any*/),
                   (v2/*: any*/),
                   (v5/*: any*/),
                   (v6/*: any*/),
-                  (v7/*: any*/),
-                  (v11/*: any*/)
+                  (v7/*: any*/)
                 ]
               },
+              (v1/*: any*/),
+              (v2/*: any*/),
               (v11/*: any*/)
             ]
           },
@@ -506,10 +524,10 @@ return {
     "operationKind": "query",
     "name": "ConfirmBidValidTestQuery",
     "id": null,
-    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    id\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...BidForm_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'dd99a91dec5bf720e9913f28b9c3a287';
+(node as any).hash = '81de3be64f83444ed368cc81e9446048';
 export default node;

--- a/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidValidTestQuery.graphql.ts
@@ -28,7 +28,7 @@ export type ConfirmBidValidTestQueryResponse = {
     readonly me: {
         readonly internalID: string;
         readonly hasQualifiedCreditCards: boolean | null;
-        readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
+        readonly " $fragmentRefs": FragmentRefs<"ConfirmBid_me">;
     } | null;
 };
 export type ConfirmBidValidTestQueryRawResponse = {
@@ -117,7 +117,7 @@ query ConfirmBidValidTestQuery {
   me {
     internalID
     hasQualifiedCreditCards
-    ...BidForm_me
+    ...ConfirmBid_me
     id
   }
 }
@@ -141,6 +141,12 @@ fragment BidForm_saleArtwork on SaleArtwork {
     }
     id
   }
+}
+
+fragment ConfirmBid_me on Me {
+  internalID
+  hasQualifiedCreditCards
+  ...BidForm_me
 }
 
 fragment LotInfo_artwork on Artwork {
@@ -341,7 +347,7 @@ return {
           (v8/*: any*/),
           {
             "kind": "FragmentSpread",
-            "name": "BidForm_me",
+            "name": "ConfirmBid_me",
             "args": null
           }
         ]
@@ -524,10 +530,10 @@ return {
     "operationKind": "query",
     "name": "ConfirmBidValidTestQuery",
     "id": null,
-    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...BidForm_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query ConfirmBidValidTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...LotInfo_artwork\n    internalID\n    slug\n    saleArtwork(saleID: \"example-auction-id\") {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      internalID\n      slug\n      sale {\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        id\n      }\n      id\n    }\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '81de3be64f83444ed368cc81e9446048';
+(node as any).hash = 'd3d5f2a63505fcb755a39be2083b2f77';
 export default node;

--- a/src/__generated__/ConfirmBid_me.graphql.ts
+++ b/src/__generated__/ConfirmBid_me.graphql.ts
@@ -1,0 +1,48 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ConfirmBid_me = {
+    readonly internalID: string;
+    readonly hasQualifiedCreditCards: boolean | null;
+    readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
+    readonly " $refType": "ConfirmBid_me";
+};
+export type ConfirmBid_me$data = ConfirmBid_me;
+export type ConfirmBid_me$key = {
+    readonly " $data"?: ConfirmBid_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"ConfirmBid_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ConfirmBid_me",
+  "type": "Me",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hasQualifiedCreditCards",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "BidForm_me",
+      "args": null
+    }
+  ]
+};
+(node as any).hash = 'bb8ac1b1d0c2ddcd9f84e73755eb4a7e';
+export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -8,46 +8,52 @@ export type routes_ConfirmBidQueryVariables = {
 };
 export type routes_ConfirmBidQueryResponse = {
     readonly artwork: {
-        readonly id: string;
         readonly internalID: string;
         readonly slug: string;
         readonly saleArtwork: {
-            readonly id: string;
             readonly internalID: string;
             readonly slug: string;
             readonly sale: {
-                readonly id: string;
-                readonly registrationStatus: {
-                    readonly internalID: string;
-                    readonly qualifiedForBidding: boolean | null;
-                } | null;
                 readonly internalID: string;
                 readonly slug: string;
                 readonly name: string | null;
                 readonly isClosed: boolean | null;
                 readonly isRegistrationClosed: boolean | null;
+                readonly registrationStatus: {
+                    readonly internalID: string;
+                    readonly qualifiedForBidding: boolean | null;
+                } | null;
             } | null;
             readonly " $fragmentRefs": FragmentRefs<"LotInfo_saleArtwork" | "BidForm_saleArtwork">;
         } | null;
         readonly " $fragmentRefs": FragmentRefs<"LotInfo_artwork">;
     } | null;
     readonly me: {
-        readonly id: string;
         readonly internalID: string;
         readonly hasQualifiedCreditCards: boolean | null;
-        readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
+        readonly " $fragmentRefs": FragmentRefs<"ConfirmBid_me">;
     } | null;
 };
 export type routes_ConfirmBidQueryRawResponse = {
     readonly artwork: ({
         readonly internalID: string;
-        readonly date: string | null;
-        readonly title: string | null;
-        readonly imageUrl: string | null;
-        readonly artistNames: string | null;
-        readonly id: string;
         readonly slug: string;
         readonly saleArtwork: ({
+            readonly internalID: string;
+            readonly slug: string;
+            readonly sale: ({
+                readonly internalID: string;
+                readonly slug: string;
+                readonly name: string | null;
+                readonly isClosed: boolean | null;
+                readonly isRegistrationClosed: boolean | null;
+                readonly registrationStatus: ({
+                    readonly internalID: string;
+                    readonly qualifiedForBidding: boolean | null;
+                    readonly id: string | null;
+                }) | null;
+                readonly id: string | null;
+            }) | null;
             readonly counts: ({
                 readonly bidderPositions: number | null;
             }) | null;
@@ -61,28 +67,18 @@ export type routes_ConfirmBidQueryRawResponse = {
                 readonly cents: number | null;
                 readonly display: string | null;
             }) | null> | null;
-            readonly sale: ({
-                readonly registrationStatus: ({
-                    readonly qualifiedForBidding: boolean | null;
-                    readonly id: string | null;
-                    readonly internalID: string;
-                }) | null;
-                readonly id: string | null;
-                readonly internalID: string;
-                readonly slug: string;
-                readonly name: string | null;
-                readonly isClosed: boolean | null;
-                readonly isRegistrationClosed: boolean | null;
-            }) | null;
-            readonly id: string;
-            readonly internalID: string;
-            readonly slug: string;
+            readonly id: string | null;
         }) | null;
+        readonly date: string | null;
+        readonly title: string | null;
+        readonly imageUrl: string | null;
+        readonly artistNames: string | null;
+        readonly id: string | null;
     }) | null;
     readonly me: ({
-        readonly hasQualifiedCreditCards: boolean | null;
-        readonly id: string;
         readonly internalID: string;
+        readonly hasQualifiedCreditCards: boolean | null;
+        readonly id: string | null;
     }) | null;
 };
 export type routes_ConfirmBidQuery = {
@@ -99,36 +95,36 @@ query routes_ConfirmBidQuery(
   $artworkID: String!
 ) {
   artwork(id: $artworkID) {
-    ...LotInfo_artwork
-    id
     internalID
     slug
     saleArtwork(saleID: $saleID) {
-      ...LotInfo_saleArtwork
-      ...BidForm_saleArtwork
-      id
       internalID
       slug
       sale {
-        id
-        registrationStatus {
-          internalID
-          qualifiedForBidding
-          id
-        }
         internalID
         slug
         name
         isClosed
         isRegistrationClosed
+        registrationStatus {
+          internalID
+          qualifiedForBidding
+          id
+        }
+        id
       }
+      ...LotInfo_saleArtwork
+      ...BidForm_saleArtwork
+      id
     }
+    ...LotInfo_artwork
+    id
   }
   me {
-    ...BidForm_me
-    id
     internalID
     hasQualifiedCreditCards
+    ...ConfirmBid_me
+    id
   }
 }
 
@@ -151,6 +147,12 @@ fragment BidForm_saleArtwork on SaleArtwork {
     }
     id
   }
+}
+
+fragment ConfirmBid_me on Me {
+  internalID
+  hasQualifiedCreditCards
+  ...BidForm_me
 }
 
 fragment LotInfo_artwork on Artwork {
@@ -199,63 +201,63 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "saleID",
     "variableName": "saleID"
   }
 ],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "qualifiedForBidding",
-  "args": null,
-  "storageKey": null
-},
-v7 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "isClosed",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "isRegistrationClosed",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "qualifiedForBidding",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "hasQualifiedCreditCards",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
   "args": null,
   "storageKey": null
 },
@@ -293,19 +295,17 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
-          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "saleArtwork",
             "storageKey": null,
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "SaleArtwork",
             "plural": false,
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v4/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -316,6 +316,10 @@ return {
                 "plural": false,
                 "selections": [
                   (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -325,15 +329,10 @@ return {
                     "concreteType": "Bidder",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/)
+                      (v2/*: any*/),
+                      (v8/*: any*/)
                     ]
-                  },
-                  (v3/*: any*/),
-                  (v4/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  }
                 ]
               },
               {
@@ -365,11 +364,10 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v3/*: any*/),
-          (v10/*: any*/),
+          (v9/*: any*/),
           {
             "kind": "FragmentSpread",
-            "name": "BidForm_me",
+            "name": "ConfirmBid_me",
             "args": null
           }
         ]
@@ -390,46 +388,50 @@ return {
         "concreteType": "Artwork",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "date",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "imageUrl",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "artistNames",
-            "args": null,
-            "storageKey": null
-          },
           (v2/*: any*/),
-          (v4/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "saleArtwork",
             "storageKey": null,
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "SaleArtwork",
             "plural": false,
             "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "sale",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Sale",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "registrationStatus",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Bidder",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v8/*: any*/),
+                      (v10/*: any*/)
+                    ]
+                  },
+                  (v10/*: any*/)
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -494,42 +496,38 @@ return {
                   (v12/*: any*/)
                 ]
               },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "sale",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Sale",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "registrationStatus",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "Bidder",
-                    "plural": false,
-                    "selections": [
-                      (v6/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/)
-                    ]
-                  },
-                  (v2/*: any*/),
-                  (v3/*: any*/),
-                  (v4/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/),
-                  (v9/*: any*/)
-                ]
-              },
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/)
+              (v10/*: any*/)
             ]
-          }
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "date",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "imageUrl",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "artistNames",
+            "args": null,
+            "storageKey": null
+          },
+          (v10/*: any*/)
         ]
       },
       {
@@ -541,9 +539,9 @@ return {
         "concreteType": "Me",
         "plural": false,
         "selections": [
-          (v10/*: any*/),
           (v2/*: any*/),
-          (v3/*: any*/)
+          (v9/*: any*/),
+          (v10/*: any*/)
         ]
       }
     ]
@@ -552,10 +550,10 @@ return {
     "operationKind": "query",
     "name": "routes_ConfirmBidQuery",
     "id": null,
-    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    id\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n      internalID\n      slug\n      sale {\n        id\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n      }\n    }\n  }\n  me {\n    ...BidForm_me\n    id\n    internalID\n    hasQualifiedCreditCards\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      internalID\n      slug\n      sale {\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        id\n      }\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n    }\n    ...LotInfo_artwork\n    id\n  }\n  me {\n    internalID\n    hasQualifiedCreditCards\n    ...ConfirmBid_me\n    id\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment ConfirmBid_me on Me {\n  internalID\n  hasQualifiedCreditCards\n  ...BidForm_me\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'a9ac6e44bed74f754b5fd3d6d8170c53';
+(node as any).hash = '8486526a66852558b11319cc76d7fa2e';
 export default node;

--- a/src/__generated__/routes_ConfirmBidQuery.graphql.ts
+++ b/src/__generated__/routes_ConfirmBidQuery.graphql.ts
@@ -35,6 +35,7 @@ export type routes_ConfirmBidQueryResponse = {
         readonly id: string;
         readonly internalID: string;
         readonly hasQualifiedCreditCards: boolean | null;
+        readonly " $fragmentRefs": FragmentRefs<"BidForm_me">;
     } | null;
 };
 export type routes_ConfirmBidQueryRawResponse = {
@@ -60,28 +61,28 @@ export type routes_ConfirmBidQueryRawResponse = {
                 readonly cents: number | null;
                 readonly display: string | null;
             }) | null> | null;
-            readonly id: string;
-            readonly internalID: string;
-            readonly slug: string;
             readonly sale: ({
-                readonly id: string;
                 readonly registrationStatus: ({
-                    readonly internalID: string;
                     readonly qualifiedForBidding: boolean | null;
                     readonly id: string | null;
+                    readonly internalID: string;
                 }) | null;
+                readonly id: string | null;
                 readonly internalID: string;
                 readonly slug: string;
                 readonly name: string | null;
                 readonly isClosed: boolean | null;
                 readonly isRegistrationClosed: boolean | null;
             }) | null;
+            readonly id: string;
+            readonly internalID: string;
+            readonly slug: string;
         }) | null;
     }) | null;
     readonly me: ({
+        readonly hasQualifiedCreditCards: boolean | null;
         readonly id: string;
         readonly internalID: string;
-        readonly hasQualifiedCreditCards: boolean | null;
     }) | null;
 };
 export type routes_ConfirmBidQuery = {
@@ -124,10 +125,15 @@ query routes_ConfirmBidQuery(
     }
   }
   me {
+    ...BidForm_me
     id
     internalID
     hasQualifiedCreditCards
   }
+}
+
+fragment BidForm_me on Me {
+  hasQualifiedCreditCards
 }
 
 fragment BidForm_saleArtwork on SaleArtwork {
@@ -137,6 +143,13 @@ fragment BidForm_saleArtwork on SaleArtwork {
   increments(useMyMaxBid: true) {
     cents
     display
+  }
+  sale {
+    registrationStatus {
+      qualifiedForBidding
+      id
+    }
+    id
   }
 }
 
@@ -240,24 +253,11 @@ v9 = {
   "storageKey": null
 },
 v10 = {
-  "kind": "LinkedField",
+  "kind": "ScalarField",
   "alias": null,
-  "name": "me",
-  "storageKey": null,
+  "name": "hasQualifiedCreditCards",
   "args": null,
-  "concreteType": "Me",
-  "plural": false,
-  "selections": [
-    (v2/*: any*/),
-    (v3/*: any*/),
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "hasQualifiedCreditCards",
-      "args": null,
-      "storageKey": null
-    }
-  ]
+  "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
@@ -355,7 +355,25 @@ return {
           }
         ]
       },
-      (v10/*: any*/)
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v10/*: any*/),
+          {
+            "kind": "FragmentSpread",
+            "name": "BidForm_me",
+            "args": null
+          }
+        ]
+      }
     ]
   },
   "operation": {
@@ -476,9 +494,6 @@ return {
                   (v12/*: any*/)
                 ]
               },
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -488,7 +503,6 @@ return {
                 "concreteType": "Sale",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -498,33 +512,50 @@ return {
                     "concreteType": "Bidder",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
                       (v6/*: any*/),
-                      (v2/*: any*/)
+                      (v2/*: any*/),
+                      (v3/*: any*/)
                     ]
                   },
+                  (v2/*: any*/),
                   (v3/*: any*/),
                   (v4/*: any*/),
                   (v7/*: any*/),
                   (v8/*: any*/),
                   (v9/*: any*/)
                 ]
-              }
+              },
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
             ]
           }
         ]
       },
-      (v10/*: any*/)
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          (v10/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ]
+      }
     ]
   },
   "params": {
     "operationKind": "query",
     "name": "routes_ConfirmBidQuery",
     "id": null,
-    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    id\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n      internalID\n      slug\n      sale {\n        id\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n      }\n    }\n  }\n  me {\n    id\n    internalID\n    hasQualifiedCreditCards\n  }\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
+    "text": "query routes_ConfirmBidQuery(\n  $saleID: String!\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...LotInfo_artwork\n    id\n    internalID\n    slug\n    saleArtwork(saleID: $saleID) {\n      ...LotInfo_saleArtwork\n      ...BidForm_saleArtwork\n      id\n      internalID\n      slug\n      sale {\n        id\n        registrationStatus {\n          internalID\n          qualifiedForBidding\n          id\n        }\n        internalID\n        slug\n        name\n        isClosed\n        isRegistrationClosed\n      }\n    }\n  }\n  me {\n    ...BidForm_me\n    id\n    internalID\n    hasQualifiedCreditCards\n  }\n}\n\nfragment BidForm_me on Me {\n  hasQualifiedCreditCards\n}\n\nfragment BidForm_saleArtwork on SaleArtwork {\n  minimumNextBid {\n    cents\n  }\n  increments(useMyMaxBid: true) {\n    cents\n    display\n  }\n  sale {\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n}\n\nfragment LotInfo_artwork on Artwork {\n  internalID\n  date\n  title\n  imageUrl\n  artistNames\n}\n\nfragment LotInfo_saleArtwork on SaleArtwork {\n  counts {\n    bidderPositions\n  }\n  lotLabel\n  minimumNextBid {\n    amount\n    cents\n    display\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'f5270b1663262ae28c6dd19035b6b258';
+(node as any).hash = 'a9ac6e44bed74f754b5fd3d6d8170c53';
 export default node;


### PR DESCRIPTION
The Auctions production team has been working off of the `auct-pt-master` release branch while efforts to migrate `master` to use the Metaphysics V2 API was in-progress and other product work was frozen.

This PR includes rebased commits from the following PRs:

- User without an existing credit card should be able to bid and register #3011 
- User should be notified of an outbid or (any non-winning status) when attempting to confirm a bid #3000 
- User should be redirected to artwork page after confirmation that a bid is winning #2980 

jira ticket :lock:: https://artsyproduct.atlassian.net/browse/AUCT-746