### PR TITLE
Remove impression event

### DIFF
--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -14,16 +14,10 @@ interface CollectionsHubsHomepageNavProps {
 }
 
 export const CollectionsHubsHomepageNav = track(
-  {
-    context_page: AnalyticsSchema.PageName.HomePage,
-    context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
-    subject: AnalyticsSchema.Subject.FeaturedCategories,
-    action_type: AnalyticsSchema.ActionType.Impression,
-  },
+  {},
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {
   const { trackEvent } = useTracking()
-  trackEvent({})
   return (
     <CSSGrid
       as="aside"

--- a/src/Components/v2/CollectionsHubsHomepageNav.tsx
+++ b/src/Components/v2/CollectionsHubsHomepageNav.tsx
@@ -14,7 +14,11 @@ interface CollectionsHubsHomepageNavProps {
 }
 
 export const CollectionsHubsHomepageNav = track(
-  {},
+  {
+    context_page: AnalyticsSchema.PageName.HomePage,
+    context_module: AnalyticsSchema.ContextModule.CollectionHubEntryPoint,
+    subject: AnalyticsSchema.Subject.FeaturedCategories,
+  },
   { dispatch: data => Events.postEvent(data) }
 )((props: CollectionsHubsHomepageNavProps) => {
   const { trackEvent } = useTracking()


### PR DESCRIPTION
This removes the entry points impression event from `src/Components/v2/CollectionsHubsHomepageNav.tsx`. We remove it here because it fires too early and should be fired from [force](https://github.com/artsy/force/pull/4784) upon the user scrolling within a specific area.

I closed https://github.com/artsy/reaction/pull/3021 in favor of this PR to not include the generated files.