### PR TITLE
Do not include seller in structured data when no partner profile image

### DIFF
--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -124,10 +124,14 @@ export const SeoDataForArtworkFragmentContainer = createFragmentContainer(
 
 export const offerAttributes = (artwork: SeoDataForArtwork_artwork) => {
   if (!artwork.listPrice || artwork.is_price_hidden) return null
-  const seller = {
+  const galleryProfileImage = get(
+    artwork,
+    a => a.partner.profile.image.resized.url
+  )
+  const seller = galleryProfileImage && {
     "@type": "ArtGallery",
     name: get(artwork, a => a.partner.name),
-    image: get(artwork, a => a.partner.profile.image.resized.url),
+    image: galleryProfileImage,
   }
   const availability = AVAILABILITY[artwork.availability]
   switch (artwork.listPrice.__typename) {

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.test.tsx
@@ -271,6 +271,33 @@ describe("SeoDataForArtwork", () => {
 
         expect(getProductData(wrapper).offers).toBeFalsy()
       })
+
+      it("Does not render seller within offer when profile image (required) is not present", async () => {
+        const wrapper = await getWrapper({
+          ...SeoDataForArtworkFixture,
+          partner: {
+            id: "opaque-partner-id",
+            name: "Wright",
+            type: "Auction House",
+            profile: {
+              id: "opaque-profile-id",
+              image: null,
+            },
+          },
+          listPrice: {
+            __typename: "PriceRange",
+            maxPrice: {
+              major: 1000,
+            },
+            minPrice: {
+              major: 100,
+              currencyCode: "USD",
+            },
+          },
+        })
+
+        expect(getProductData(wrapper).offers.seller).toBeFalsy()
+      })
     })
     describe("Artwork dimensions", () => {
       it("renders no dimensions when dimensions aren't parseable", async () => {


### PR DESCRIPTION
Doing QA on https://github.com/artsy/reaction/pull/3019 realized seller image is required by google (thanks invoicing demo partner for surfacing this problem)