### PR TITLE
Grow-1479 Blank thumbnail on collections with generated banner 

### DIFF
--- a/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
@@ -59,6 +59,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
                   <Media greaterThan="xs">{index < 3 && <Separator />}</Media>
 
                   <EntityHeader
+                    initials=" "
                     py={2}
                     href={`/collection/${collection.slug}`}
                     imageUrl={imageUrl || undefined}

--- a/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
@@ -58,6 +58,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
                   <Media at="xs">{index === 0 && <Separator />}</Media>
                   <Media greaterThan="xs">{index < 3 && <Separator />}</Media>
 
+                  {/* A empty space in initials to generate a blank avatar when there's no imageUrl*/}
                   <EntityHeader
                     initials=" "
                     py={2}

--- a/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/Apps/Collect2/Routes/Collections/Components/CollectionsGrid.tsx
@@ -58,7 +58,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
                   <Media at="xs">{index === 0 && <Separator />}</Media>
                   <Media greaterThan="xs">{index < 3 && <Separator />}</Media>
 
-                  {/* A empty space in initials to generate a blank avatar when there's no imageUrl*/}
+                  {/* An empty space in initials to generate a blank avatar when there's no imageUrl */}
                   <EntityHeader
                     initials=" "
                     py={2}


### PR DESCRIPTION
Address : [Grow 1479](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1479)

<img width="1248" alt="Screen Shot 2019-11-21 at 13 46 00" src="https://user-images.githubusercontent.com/45926410/69366947-52497f00-0c65-11ea-892c-9218c4f1e335.png">

Object: If there is no custom image header, it shows a gray circle. 


Those circle things are using `EntityHeader` from Palette. In Palette, we have [this](https://github.com/artsy/palette/blob/0ce2ed7da2cdce43bbad51709ae4bebe4545bf03/packages/palette/src/elements/EntityHeader/EntityHeader.tsx#L49). And then, the `EntityHeader` actually import `avatar`. Inside the avatar, it has condition checking(see [here](https://github.com/artsy/palette/blob/0ce2ed7da2cdce43bbad51709ae4bebe4545bf03/packages/palette/src/elements/Avatar/Avatar.shared.tsx#L66)), if it has imgURL, then it shows headerIMG, otherwise, it shows `initials string`. 
So, I just pass an empty space to `initials string`. It will render a gray circle.

