### PR TITLE
Track validation errors and registration submitted events

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -20,6 +20,7 @@ import Yup from "yup"
 import { CreditCardInstructions } from "Apps/Auction/Components/CreditCardInstructions"
 import { Address, AddressForm } from "Apps/Order/Components/AddressForm"
 import { CreditCardInput } from "Apps/Order/Components/CreditCardInput"
+import { OnSubmitValidationError, TrackErrors } from "./RegistrationForm"
 
 interface Props {
   initialSelectedBid?: string
@@ -27,6 +28,7 @@ interface Props {
   onSubmit: (values: FormikValues, actions: FormikActions<object>) => void
   saleArtwork: BidForm_saleArtwork
   showPricingTransparency?: boolean
+  trackSubmissionErrors: TrackErrors
 }
 
 export interface FormValues {
@@ -114,6 +116,7 @@ export const BidForm: React.FC<Props> = ({
   onSubmit,
   saleArtwork,
   showPricingTransparency = false,
+  trackSubmissionErrors,
 }) => {
   const displayIncrements = dropWhile(
     saleArtwork.increments,
@@ -155,12 +158,26 @@ export const BidForm: React.FC<Props> = ({
           touched,
           errors,
           isSubmitting,
+          isValid,
           setFieldValue,
           setFieldTouched,
+          setSubmitting,
           status,
+          submitCount,
         }) => {
           return (
             <Form>
+              <OnSubmitValidationError
+                cb={trackSubmissionErrors}
+                formikProps={{
+                  errors,
+                  isSubmitting,
+                  isValid,
+                  setSubmitting,
+                  submitCount,
+                }}
+              />
+
               <Flex flexDirection="column">
                 <Flex flexDirection="column" py={4}>
                   <Serif pb={0.5} size="4t" weight="semibold" color="black100">

--- a/src/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/Apps/Auction/Components/RegistrationForm.tsx
@@ -7,20 +7,13 @@ import { ErrorModal } from "Components/Modal/ErrorModal"
 import { Form, Formik, FormikActions, FormikProps } from "formik"
 import React, { useEffect, useState } from "react"
 import {
-  CardElement,
   Elements,
   injectStripe,
   ReactStripeElements,
   StripeProvider,
 } from "react-stripe-elements"
 import { data as sd } from "sharify"
-import styled from "styled-components"
 import * as Yup from "yup"
-
-export const StyledCardElement = styled(CardElement)`
-  width: 100%;
-  padding: 9px 10px;
-`
 
 export interface FormResult {
   token: stripe.Token
@@ -125,7 +118,7 @@ const validationSchema = Yup.object().shape({
   ),
 })
 
-type TrackErrors = (errors: string[]) => void
+export type TrackErrors = (errors: string[]) => void
 
 /*
   This component exists only to capture formik's renderProps and track form
@@ -139,9 +132,9 @@ type TrackErrors = (errors: string[]) => void
   Background:
     https://github.com/jaredpalmer/formik/issues/1484#issuecomment-490558973
  */
-const OnSubmitValidationError: React.FC<{
+export const OnSubmitValidationError: React.FC<{
   cb: TrackErrors
-  formikProps: FormikProps<FormValues>
+  formikProps: Partial<FormikProps<FormValues>>
 }> = props => {
   const { cb, formikProps } = props
 

--- a/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -10,6 +10,7 @@ export const createBidderPositionSuccessful: ConfirmBidCreateBidderPositionMutat
           sale: {
             registrationStatus: {
               internalID: "existing-bidder-id",
+              qualifiedForBidding: true,
             },
           },
         },
@@ -29,6 +30,7 @@ export const createBidderPositionSuccessfulAndBidder: ConfirmBidCreateBidderPosi
           sale: {
             registrationStatus: {
               internalID: "new-bidder-id",
+              qualifiedForBidding: true,
             },
           },
         },

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -381,7 +381,7 @@ describe("Routes/ConfirmBid", () => {
       )
     })
 
-    it("tracks a success event to Segment including Criteo info", async () => {
+    it("tracks registration submitted and success events to Segment including Criteo info", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage({
         mockData: FixtureForUnregisteredUserWithCreditCard,
@@ -437,7 +437,7 @@ describe("Routes/ConfirmBid", () => {
       expect(page.text()).toContain("You must agree to the Conditions of Sale")
     })
 
-    it("tracks an error without bidder id when the mutation returns a GraphQL error", async () => {
+    it("tracks a registration submitted event and an error without bidder id when the mutation returns a GraphQL error", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage({
         mockData: FixtureForUnregisteredUserWithCreditCard,
@@ -492,7 +492,7 @@ describe("Routes/ConfirmBid", () => {
       })
     })
 
-    it("tracks an error with bidder id when polling receives a non-success status", async () => {
+    it("tracks a registration submitted event and an error with bidder id when polling receives a non-success status", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage({
         mockData: FixtureForUnregisteredUserWithCreditCard,
@@ -524,6 +524,50 @@ describe("Routes/ConfirmBid", () => {
         bidder_id: "new-bidder-id",
         sale_id: "saleid",
         user_id: "my-user-id",
+      })
+    })
+
+    it("does not track registration submitted twice when newly registered bidder places two bids on the same page", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithCreditCard,
+      })
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithOutbid
+      )
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      mockPostEvent.mockClear()
+      mockBidderPositionQuery.mockReset()
+      env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
+      mockBidderPositionQuery.mockResolvedValue(
+        confirmBidBidderPositionQueryWithWinning
+      )
+
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "new-bidder-id",
+        bidder_position_id: "winning-bidder-position-id-from-polling",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+        order_id: "new-bidder-id",
+        products: [
+          {
+            product_id: "artworkid",
+            quantity: 1,
+            price: 50000,
+          },
+        ],
       })
     })
   })

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -394,8 +394,17 @@ describe("Routes/ConfirmBid", () => {
       await page.agreeToTerms()
       await page.submitForm()
 
-      expect(mockPostEvent).toHaveBeenCalledTimes(1)
-      expect(mockPostEvent).toHaveBeenCalledWith({
+      expect(mockPostEvent).toHaveBeenCalledTimes(2)
+      expect(mockPostEvent.mock.calls[0][0]).toEqual({
+        action_type: AnalyticsSchema.ActionType.RegistrationSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "new-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+      expect(mockPostEvent.mock.calls[1][0]).toEqual({
         action_type: AnalyticsSchema.ActionType.ConfirmBidSubmitted,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
         auction_slug: "saleslug",
@@ -438,8 +447,17 @@ describe("Routes/ConfirmBid", () => {
       await page.agreeToTerms()
       await page.submitForm()
 
-      expect(mockPostEvent).toHaveBeenCalledTimes(1)
-      expect(mockPostEvent).toBeCalledWith({
+      expect(mockPostEvent).toHaveBeenCalledTimes(2)
+      expect(mockPostEvent.mock.calls[0][0]).toEqual({
+        action_type: AnalyticsSchema.ActionType.RegistrationSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+      expect(mockPostEvent.mock.calls[1][0]).toEqual({
         action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
         error_messages: ["Sale Closed to Bids"],
@@ -487,8 +505,17 @@ describe("Routes/ConfirmBid", () => {
       await page.agreeToTerms()
       await page.submitForm()
 
-      expect(mockPostEvent).toHaveBeenCalledTimes(1)
-      expect(mockPostEvent).toBeCalledWith({
+      expect(mockPostEvent).toHaveBeenCalledTimes(2)
+      expect(mockPostEvent.mock.calls[0][0]).toEqual({
+        action_type: AnalyticsSchema.ActionType.RegistrationSubmitted,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "new-bidder-id",
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+      expect(mockPostEvent.mock.calls[1][0]).toEqual({
         action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
         error_messages: ["Your bid wasn’t high enough"],
@@ -652,6 +679,34 @@ describe("Routes/ConfirmBid", () => {
         error_messages: [
           "JavaScript error: The `createCreditCard` mutation failed.",
         ],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("tracks an error when there are validation errors in the form", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue(stripeTokenResponse)
+
+      const address = Object.assign({}, ValidFormValues)
+      address.phoneNumber = "    "
+
+      await page.fillAddressForm(address)
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["Telephone is required"],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
         bidder_id: null,

--- a/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
+++ b/src/__generated__/ConfirmBidCreateBidderPositionMutation.graphql.ts
@@ -19,6 +19,7 @@ export type ConfirmBidCreateBidderPositionMutationResponse = {
                     readonly sale: {
                         readonly registrationStatus: {
                             readonly internalID: string;
+                            readonly qualifiedForBidding: boolean | null;
                         } | null;
                     } | null;
                 } | null;
@@ -47,6 +48,7 @@ mutation ConfirmBidCreateBidderPositionMutation(
           sale {
             registrationStatus {
               internalID
+              qualifiedForBidding
               id
             }
             id
@@ -88,18 +90,25 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "status",
+  "name": "qualifiedForBidding",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "messageHeader",
+  "name": "status",
   "args": null,
   "storageKey": null
 },
 v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "messageHeader",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -170,7 +179,8 @@ return {
                             "concreteType": "Bidder",
                             "plural": false,
                             "selections": [
-                              (v2/*: any*/)
+                              (v2/*: any*/),
+                              (v3/*: any*/)
                             ]
                           }
                         ]
@@ -179,8 +189,8 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/),
-              (v4/*: any*/)
+              (v4/*: any*/),
+              (v5/*: any*/)
             ]
           }
         ]
@@ -248,20 +258,21 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v5/*: any*/)
+                              (v3/*: any*/),
+                              (v6/*: any*/)
                             ]
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ]
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ]
               },
-              (v3/*: any*/),
-              (v4/*: any*/)
+              (v4/*: any*/),
+              (v5/*: any*/)
             ]
           }
         ]
@@ -272,10 +283,10 @@ return {
     "operationKind": "mutation",
     "name": "ConfirmBidCreateBidderPositionMutation",
     "id": null,
-    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        saleArtwork {\n          sale {\n            registrationStatus {\n              internalID\n              id\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n      status\n      messageHeader\n    }\n  }\n}\n",
+    "text": "mutation ConfirmBidCreateBidderPositionMutation(\n  $input: BidderPositionInput!\n) {\n  createBidderPosition(input: $input) {\n    result {\n      position {\n        internalID\n        saleArtwork {\n          sale {\n            registrationStatus {\n              internalID\n              qualifiedForBidding\n              id\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n      status\n      messageHeader\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '1ed3f093df63d0401ed964616a1597d6';
+(node as any).hash = 'b68f3811be758bcc79f4bba38bd57d91';
 export default node;


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-465

It adds the `<OnSubmitValidationError>` component to rack validation errors from Formik.

@dblandin @erikdstock I'm not sure if I'm using it right, but let me know if there's anything I should update.

## Tracking validation errors

<img width="2032" alt="Screen Shot 2019-11-21 at 2 27 59 PM" src="https://user-images.githubusercontent.com/386234/69373448-cf7af100-0c71-11ea-8158-13395f961126.png">

## Tracking `registration submitted`

<img width="2032" alt="Screen Shot 2019-11-21 at 3 08 32 PM" src="https://user-images.githubusercontent.com/386234/69373460-d3a70e80-0c71-11ea-81cb-01af12232235.png">
