### PR TITLE
Track "selected max bid" events on the confirm bid page

### DIFF
--- a/src/Apps/Auction/Components/BidForm.tsx
+++ b/src/Apps/Auction/Components/BidForm.tsx
@@ -28,6 +28,7 @@ interface Props {
   initialSelectedBid?: string
   me: BidForm_me
   onSubmit: (values: FormikValues, actions: FormikActions<object>) => void
+  onMaxBidSelect?: (values: string) => void
   relay: RelayProp
   saleArtwork: BidForm_saleArtwork
   trackSubmissionErrors: TrackErrors
@@ -117,6 +118,7 @@ export const BidForm: React.FC<Props> = ({
   initialSelectedBid,
   me,
   onSubmit,
+  onMaxBidSelect,
   relay,
   saleArtwork,
   trackSubmissionErrors,
@@ -190,6 +192,7 @@ export const BidForm: React.FC<Props> = ({
                   <LargeSelect
                     selected={values.selectedBid}
                     onSelect={value => {
+                      onMaxBidSelect && onMaxBidSelect(value)
                       setFieldValue("selectedBid", value)
                       setFieldTouched("selectedBid")
                     }}

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -147,6 +147,15 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     })
   }
 
+  function trackMaxBidSelected(maxBid: string) {
+    trackEvent({
+      action_type: Schema.ActionType.SelectedMaxBid,
+      bidder_id: bidderId,
+      order_id: bidderId,
+      selected_max_bid_minor: maxBid,
+    })
+  }
+
   const createTokenFromAddress = async (address: stripe.TokenOptions) => {
     const { error, token } = await stripe.createToken(address)
 
@@ -292,6 +301,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
           initialSelectedBid={getInitialSelectedBid(props.location)}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
+          onMaxBidSelect={trackMaxBidSelected}
           me={me as any}
           trackSubmissionErrors={errors =>
             !isEmpty(errors) && trackConfirmBidFailed(errors)

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -315,6 +315,26 @@ describe("Routes/ConfirmBid", () => {
       })
     })
 
+    it("tracks a max bid selected event to Segment", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage()
+
+      await page.selectBidAmount("6000000")
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toHaveBeenCalledWith({
+        action_type: AnalyticsSchema.ActionType.SelectedMaxBid,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: "existing-bidder-id",
+        sale_id: "saleid",
+        selected_max_bid_minor: "6000000",
+        user_id: "my-user-id",
+        order_id: "existing-bidder-id",
+      })
+    })
+
     it("displays an error message when the mutation returns a GraphQL error", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage()

--- a/src/Artsy/Analytics/Schema/AuctionInfo.ts
+++ b/src/Artsy/Analytics/Schema/AuctionInfo.ts
@@ -12,10 +12,19 @@ export interface AuctionInfo {
    * but occasionally it is a fixed bid amount.
    */
   bidder_position_id: string
+
   /**
    * List of reasons why there's a failure event
    *
    *  Used by the auction registration flow.
    */
   error_messages: string[]
+
+  /**
+   * The amount of max bid the user selected in cents. For example, if the user
+   * selected $5,000.00, it will be reported as 500000.
+   *
+   *  Used by the auction confirm bid flow.
+   */
+  selected_max_bid_minor: string
 }

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -93,6 +93,7 @@ export enum ActionType {
   ConfirmBidFailed = "Confirm bid failed",
   PlacedMaxBid = "Placed Max Bid",
   RegisteredToBid = "Registered To Bid",
+  SelectedMaxBid = "Selected max bid",
 
   /**
    * A tap on a UI element using a finger-like input device.


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-773

## Screenshot

<img width="2032" alt="Screen Shot 2019-11-27 at 3 36 57 PM" src="https://user-images.githubusercontent.com/386234/69758495-a48b1400-112d-11ea-80cc-e2ffb11536f9.png">
