### PR TITLE
Fixes a bug where your max bid is not pre-selected on the new confirm bid page

### DIFF
--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -1,4 +1,6 @@
 import { Box, Separator, Serif } from "@artsy/palette"
+import { Location, Match } from "found"
+
 import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
 import { ConfirmBid_me } from "__generated__/ConfirmBid_me.graphql"
 import {
@@ -21,7 +23,6 @@ import * as Schema from "Artsy/Analytics/Schema"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { FormikActions } from "formik"
 import { isEmpty } from "lodash"
-import qs from "qs"
 import React, { useEffect, useState } from "react"
 import { Title } from "react-head"
 import {
@@ -44,11 +45,15 @@ const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
 type BidFormActions = FormikActions<FormValues>
 
+interface OptionalQueryStrings {
+  bid?: string
+}
+
 interface ConfirmBidProps extends ReactStripeElements.InjectedStripeProps {
   artwork: routes_ConfirmBidQueryResponse["artwork"]
   me: ConfirmBid_me
   relay: RelayProp
-  location: Location
+  match: Match
 }
 
 const MAX_POLL_ATTEMPTS = 20
@@ -289,7 +294,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
         <BidForm
           artworkSlug={artwork.slug}
-          initialSelectedBid={getInitialSelectedBid(props.location)}
+          initialSelectedBid={getInitialSelectedBid(props.match.location)}
           saleArtwork={saleArtwork}
           onSubmit={handleSubmit}
           me={me as any}
@@ -304,8 +309,8 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
 const getInitialSelectedBid = (location: Location): string | undefined => {
   return get(
-    qs,
-    querystring => querystring.parse(location.search.slice(1)).bid,
+    location,
+    ({ query }) => (query as OptionalQueryStrings).bid,
     undefined
   )
 }

--- a/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
+++ b/src/Apps/Auction/Routes/__tests__/ConfirmBid.test.tsx
@@ -26,6 +26,7 @@ jest.mock("react-stripe-elements", () => {
 
 import deepMerge from "deepmerge"
 import { createTestEnv } from "DevTools/createTestEnv"
+import { Location, Match } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 
@@ -70,7 +71,9 @@ jest.mock("sharify", () => ({
 }))
 
 const mockLocation: Partial<Location> = {
-  search: "",
+  query: {
+    bid: null,
+  },
 }
 
 const setupTestEnv = ({
@@ -84,7 +87,7 @@ const setupTestEnv = ({
       props: routes_ConfirmBidQueryResponse & { tracking: TrackingProp }
     ) => (
       <ConfirmBidRouteFragmentContainer
-        location={location as Location}
+        match={{ location } as Match}
         {...props}
       />
     ),
@@ -861,8 +864,10 @@ describe("Routes/ConfirmBid", () => {
   describe("preselected bid amounts", () => {
     it("pre-fills the bid select box with a value from the query string that is available in increments", async () => {
       const specialSelectedBidAmount = "7000000"
-      const search = `?bid=${specialSelectedBidAmount}`
-      const env = setupTestEnv({ location: { search } })
+
+      const env = setupTestEnv({
+        location: { query: { bid: specialSelectedBidAmount } },
+      })
       const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe(
@@ -872,8 +877,10 @@ describe("Routes/ConfirmBid", () => {
 
     it("pre-fills the bid select box with the highest increment if the value is higher than what is available", async () => {
       const specialSelectedBidAmount = "42000000"
-      const search = `?bid=${specialSelectedBidAmount}`
-      const env = setupTestEnv({ location: { search } })
+
+      const env = setupTestEnv({
+        location: { query: { bid: specialSelectedBidAmount } },
+      })
       const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
@@ -881,8 +888,10 @@ describe("Routes/ConfirmBid", () => {
 
     it("pre-fills the bid select box with the lowest increment if the value is lower than what is available", async () => {
       const specialSelectedBidAmount = "420000"
-      const search = `?bid=${specialSelectedBidAmount}`
-      const env = setupTestEnv({ location: { search } })
+
+      const env = setupTestEnv({
+        location: { query: { bid: specialSelectedBidAmount } },
+      })
       const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe("5000000")
@@ -890,8 +899,10 @@ describe("Routes/ConfirmBid", () => {
 
     it("pre-fills the bid select box with the lowest increment if the value is not a number", async () => {
       const specialSelectedBidAmount = "50 thousand and 00/100 dollars"
-      const search = `?bid=${specialSelectedBidAmount}`
-      const env = setupTestEnv({ location: { search } })
+
+      const env = setupTestEnv({
+        location: { query: { bid: specialSelectedBidAmount } },
+      })
       const page = await env.buildPage()
 
       expect(page.selectBidAmountInput.props().value).toBe("5000000")


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-774

It seems like the actual prop in [`found`](https://github.com/4Catalyzer/found) looks like `props.match.location` instead of `props.location`. The test was passing because it was injecting to `props.location`, but in the actual browser it was actually missing. I updated it to properly confirm the interface. I also dropped the `qs` dependency since `found` already does this and we don't need to parse it out by ourselves.