### PR TITLE
PURCHASE-1649: Adds data-test attribute to the sale message on artwork view

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -77,7 +77,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
 
   renderSaleMessage(saleMessage: string) {
     return (
-      <Serif size="5t" weight="semibold">
+      <Serif size="5t" weight="semibold" data-test="SaleMessage">
         {saleMessage}
       </Serif>
     )
@@ -90,7 +90,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     const editionFragment = (
       <>
         <SizeInfo piece={editionSet} />
-        <Serif ml="auto" size="2">
+        <Serif ml="auto" size="2" data-test="SaleMessage">
           {editionSet.sale_message}
         </Serif>
       </>


### PR DESCRIPTION
Adds a specific identifier to this element so we can select it in our integrity tests!

![image](https://user-images.githubusercontent.com/2081340/69999852-a4bd5200-1527-11ea-9f52-2b47d1584eaa.png)
