### PR TITLE
Modifies waypoint method call

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -94,7 +94,10 @@ export class DisplayAd extends React.Component<DisplayAdProps> {
     }
     return (
       <>
-        <Waypoint onEnter={once(this.trackImpression.bind(this))} />
+        <Waypoint
+          onLeave={once(this.trackImpression.bind(this))}
+          bottomOffset="10%"
+        />
         <DisplayAdContainer
           onClick={this.trackImpressionClick.bind(this)}
           flexDirection="column"

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -62,7 +62,7 @@ describe("Display Ad", () => {
     component
       .find(Waypoint)
       .getElement()
-      .props.onEnter()
+      .props.onLeave()
 
     expect(dispatch).toBeCalledWith({
       action_type: "Impression",


### PR DESCRIPTION
Ad server analytics tracking still wasn't firing as expected. This PR modifies the tracking event to fire as the waypoint leaves the viewport, rather than on entering, with an offset added to push the waypoint's boundaries up now that the event is firing on leave.

[Links to GROW-1678](https://artsyproduct.atlassian.net/browse/GROW-1678)


Firing Events Before Fix:
![Kapture 2019-12-03 at 14 52 15](https://user-images.githubusercontent.com/10385964/70056932-967d3d80-15dc-11ea-9258-a04e663765bb.gif)


Firing Events After Fix:
![Kapture 2019-12-03 at 14 47 58](https://user-images.githubusercontent.com/10385964/70056620-122aba80-15dc-11ea-82b8-feb0c225b5c8.gif)
