### PR TITLE
Handle missing partner on artwork page

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkBanner/index.tsx
@@ -25,12 +25,14 @@ export const ArtworkBanner: React.SFC<ArtworkBannerProps> = props => {
       return (
         <Banner
           imageUrl={auctionImage}
-          initials={partner.initials}
+          initials={partner && partner.initials}
           meta="In auction"
           name={context.name}
           // Do not display partner name for benefit or gallery auctions
           subHeadline={
-            sale.isBenefit || sale.isGalleryAuction ? null : partner.name
+            sale.isBenefit || sale.isGalleryAuction
+              ? null
+              : partner && partner.name
           }
           href={context.href}
         />
@@ -45,7 +47,7 @@ export const ArtworkBanner: React.SFC<ArtworkBannerProps> = props => {
           initials={initials}
           meta="At fair"
           name={context.name}
-          subHeadline={partner.name}
+          subHeadline={partner && partner.name}
           href={context.href}
         />
       )
@@ -61,10 +63,10 @@ export const ArtworkBanner: React.SFC<ArtworkBannerProps> = props => {
       return (
         <Banner
           imageUrl={showImage}
-          initials={partner.initials}
+          initials={partner && partner.initials}
           meta={showLine}
           name={context.name}
-          subHeadline={partner.name}
+          subHeadline={partner && partner.name}
           href={context.href}
         />
       )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -152,9 +152,10 @@ export class ArtworkActions extends React.Component<
 
   renderEditButton() {
     const { artwork } = this.props
-    const editUrl = `${sd.CMS_URL}/artworks/${artwork.slug}/edit?current_partner_id=${artwork.partner.slug}` // prettier-ignore
-
-    return <UtilButton name="edit" href={editUrl} label="Edit" />
+    if (artwork.partner) {
+      const editUrl = `${sd.CMS_URL}/artworks/${artwork.slug}/edit?current_partner_id=${artwork.partner.slug}` // prettier-ignore
+      return <UtilButton name="edit" href={editUrl} label="Edit" />
+    }
   }
 
   renderGenomeButton() {


### PR DESCRIPTION
Noticed while looking into Google Search Console issues that we were throwing a 500 on a few pages due to this error: https://sentry.io/organizations/artsynet/issues/1247032632/?project=28316&query=is%3Aunresolved&statsPeriod=14d

This should fix! (So would null checks cc @zephraph 😄)