### PR TITLE
Maintain proper aspect ratio for image on confirm bid

### DIFF
--- a/src/Apps/Auction/Components/LotInfo.tsx
+++ b/src/Apps/Auction/Components/LotInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, Image, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, ResponsiveImage, Sans, Serif } from "@artsy/palette"
 import { LotInfo_artwork } from "__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "__generated__/LotInfo_saleArtwork.graphql"
 import React from "react"
@@ -16,9 +16,9 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
   } = saleArtwork
   return (
     <Flex py={4}>
-      <Flex maxWidth="150px">
-        <Image width="100%" src={artwork.imageUrl} />
-      </Flex>
+      <Box maxWidth="150px" width="100%" height="auto" p={0}>
+        <ResponsiveImage src={artwork.imageUrl} />
+      </Box>
       <Flex pl={3} pt={1} flexDirection="column">
         <Sans size="3" weight="medium" color="black100">
           Lot {saleArtwork.lotLabel}

--- a/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
+++ b/src/Apps/Auction/Routes/__stories__/ConfirmBid.story.tsx
@@ -4,14 +4,18 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 
 /**
- * These stories need updating (in their initialRoute props) each week as they are tied to staging data.
- * Required: /auction/:auctionId/bid2/:artworkid
- * The `bid` query param, if present, must match the cents in an available increment on the artwork.
+ * The `artworkId` needs to be changed on a weekly basis due to the re-creation
+ * of the `shared-live-mocktion` auction. The sale slug should stay consistent
+ * from week to week.
+ *
+ * When in doubt, you can always create a new mocktion
+ * (https://joe.artsy.net/job/gravity-staging-create-auction-on-demand/) and
+ * set these values to the sale and an artwork created in the auction
  */
 
-const auctionId = "seoul-auction-31st-hong-kong-sale"
-const artworkId = "yoshitomo-nara-untitled-65"
-const confirmBidRoute = `/auction/${auctionId}/bid2/${artworkId}`
+const auctionId = "shared-live-mocktion"
+const artworkId = "joseph-lorusso-transcendence"
+const confirmBidRoute = `/auction/${auctionId}/bid/${artworkId}`
 
 storiesOf("Apps/Auction/Routes/Confirm Bid", module)
   .add("Plain", () => {


### PR DESCRIPTION
Before

![sb-artwork-mweb-new-confirm-bid-bug](https://user-images.githubusercontent.com/1561546/70189874-788a0880-16c2-11ea-8ca4-1b56649e503f.jpeg)

After

![sb-artwork-mweb-new-confirm-bid-fix](https://user-images.githubusercontent.com/1561546/70190762-d4ee2780-16c4-11ea-8b2f-4eff9ee717f6.jpeg)

---

Also references more static auction information in the stories for ConfirmBid
Jira: https://artsyproduct.atlassian.net/browse/AUCT-718
