### PR TITLE
Add lazy loading to collections rail

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -140,6 +140,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
                 <RelatedCollectionsRail
                   collections={collection.relatedCollections}
                   title={collection.title}
+                  lazyLoadImages
                 />
               </Box>
             </>

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -1,4 +1,13 @@
-import { Box, color, Flex, Link, Sans, Serif } from "@artsy/palette"
+import {
+  Box,
+  color,
+  Flex,
+  Image,
+  Link,
+  Sans,
+  Serif,
+  WebImageProps,
+} from "@artsy/palette"
 import { RelatedCollectionEntity_collection } from "__generated__/RelatedCollectionEntity_collection.graphql"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -12,6 +21,7 @@ import { get } from "Utils/get"
 
 export interface CollectionProps {
   collection: RelatedCollectionEntity_collection
+  lazyLoad?: boolean
 }
 
 @track()
@@ -28,6 +38,7 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
   }
 
   render() {
+    const { lazyLoad } = this.props
     const {
       artworksConnection,
       headerImage,
@@ -63,6 +74,7 @@ export class RelatedCollectionEntity extends React.Component<CollectionProps> {
                       src={url}
                       width={imageSize}
                       alt={alt}
+                      lazyLoad={lazyLoad}
                     />
                   </SingleImgContainer>
                 )
@@ -123,8 +135,7 @@ const ImgOverlay = styled(Box)<{ width: number }>`
   z-index: 7;
 `
 
-export const ArtworkImage = styled.img<{ width: number }>`
-  width: ${({ width }) => width}px;
+export const ArtworkImage = styled(Image)<WebImageProps>`
   height: 125px;
   background-color: ${color("black10")};
   object-fit: cover;

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionsRail.tsx
@@ -15,6 +15,7 @@ import { RelatedCollectionEntityFragmentContainer as RelatedCollectionEntity } f
 interface RelatedCollectionsRailProps {
   collections: RelatedCollectionsRail_collections
   title?: string
+  lazyLoadImages?: boolean
 }
 
 @track(null, {
@@ -45,7 +46,7 @@ export class RelatedCollectionsRail extends React.Component<
 
   render() {
     const { collections } = this.props
-    const { title } = this.props
+    const { title, lazyLoadImages } = this.props
     if (collections.length > 3) {
       return (
         <Box>
@@ -68,7 +69,12 @@ export class RelatedCollectionsRail extends React.Component<
             onArrowClick={this.trackCarouselNav.bind(this)}
             data={take(collections, 16)}
             render={slide => {
-              return <RelatedCollectionEntity collection={slide} />
+              return (
+                <RelatedCollectionEntity
+                  lazyLoad={lazyLoadImages}
+                  collection={slide}
+                />
+              )
             }}
             renderLeftArrow={({ Arrow }) => {
               return (


### PR DESCRIPTION
While investigating image lazy loading issues on the collection page I noticed that the `RelatedCollectionRail` didn't have its images lazy loaded. I went ahead and implemented that while I was here. 

Note that until https://github.com/artsy/reaction/pull/2985 is deployed, lazy-loading won't work in prod. (That's a known bug that I'm working through)