### PR TITLE
[GROW-1681] adds analytics events to the navbar notification menu

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -254,6 +254,8 @@ export enum Subject {
    * Header
    */
   NotificationBell = "Notification Bell",
+  Notification = "Notification",
+  ViewAll = "View All",
   Login = "Log In",
   Signup = "Sign Up",
   SmallScreenMenuSandwichIcon = "Small Screen Menu Sandwich Icon",
@@ -273,6 +275,7 @@ export enum ContextModule {
   RecentlyViewedArtworks = "recently_viewed_artworks",
   HeaderMoreDropdown = "HeaderMoreDropdown",
   HeaderUserDropdown = "HeaderUserDropdown",
+  HeaderActivityDropdown = "HeaderActivityDropdown",
 
   /**
    * Artist page

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -1,5 +1,7 @@
+import { AnalyticsSchema } from "Artsy/Analytics"
 import React, { useContext } from "react"
 import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 import { SystemContext } from "Artsy"
 import { get } from "Utils/get"
@@ -36,12 +38,29 @@ export const NotificationMenuItems: React.FC<NotificationsMenuQueryResponse> = p
     []
   )
 
+  const { trackEvent } = useTracking()
+
+  const handleClick = (href: string, subject: string) => {
+    trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
+      context_module: AnalyticsSchema.ContextModule.HeaderActivityDropdown,
+      destination_path: href,
+      subject,
+    })
+  }
+
   return (
     <>
       {notifications.map(({ node }, index) => {
         const { artists, href, image, summary } = node
         return (
-          <MenuItem href={href} key={index}>
+          <MenuItem
+            href={href}
+            key={index}
+            onClick={() => {
+              handleClick(href, AnalyticsSchema.Subject.Notification)
+            }}
+          >
             <Flex alignItems="center">
               <Box width={40} height={40} bg="black5" mr={1}>
                 <Image
@@ -80,7 +99,14 @@ export const NotificationMenuItems: React.FC<NotificationsMenuQueryResponse> = p
 
           <Box pt={2}>
             <Sans size="2">
-              <Link href="/works-for-you">View all</Link>
+              <Link
+                href="/works-for-you"
+                onClick={() => {
+                  handleClick("/works-for-you", AnalyticsSchema.Subject.ViewAll)
+                }}
+              >
+                View all
+              </Link>
             </Sans>
           </Box>
         </>

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -1,7 +1,7 @@
 import { AnalyticsSchema } from "Artsy/Analytics"
+import { useTracking } from "Artsy/Analytics/useTracking"
 import React, { useContext } from "react"
 import { graphql } from "react-relay"
-import { useTracking } from "react-tracking"
 
 import { SystemContext } from "Artsy"
 import { get } from "Utils/get"

--- a/src/Components/NavBar/Menus/__tests__/NotificationsMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NotificationsMenu.test.tsx
@@ -1,8 +1,21 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount } from "enzyme"
 import React from "react"
 import { NotificationMenuItems } from "../NotificationsMenu"
 
+jest.mock("Artsy/Analytics/useTracking")
+
 describe("NotificationsMenu", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
   const getWrapper = (props = NotificationMenuFixture) => {
     return mount(<NotificationMenuItems {...props} />)
   }


### PR DESCRIPTION
Addresses: [GROW-1681](https://artsyproduct.atlassian.net/browse/GROW-1681)

This adds missing analytics coverage for the notification dropdown bar in preparation for the navigation a/b test.

**View All**
![Screen Shot 2019-12-09 at 2 57 06 PM](https://user-images.githubusercontent.com/5201004/70467999-44cd2b00-1a94-11ea-83eb-6acef14bef76.png)

**Alert items**
![Screen Shot 2019-12-09 at 2 57 23 PM](https://user-images.githubusercontent.com/5201004/70467993-4139a400-1a94-11ea-95e7-9899bfe9bebc.png)


