### PR TITLE
Bump version of lazy-load lib to fix SSR issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "react-css-transition-replace": "^3.0.2",
     "react-gpt": "^2.0.1",
     "react-head": "^3.0.0",
-    "react-lazy-load-image-component": "^1.1.1",
+    "react-lazy-load-image-component": "^1.4.0-beta.1",
     "react-lines-ellipsis": "^0.14.0",
     "react-markdown": "^2.5.0",
     "react-oembed-container": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12960,14 +12960,6 @@ react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
-react-lazy-load-image-component@^1.1.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.3.2.tgz#2182d6ed864feb15c30067e04e52cbcdcfc86860"
-  integrity sha512-LLbsFQwIV4TdlObBYjlJyRSmYMadd8pMOsYmihFAI6nXBgOEYVuRJlq7T0PjT5OWzntV38VvSw+P+NJU7etH3Q==
-  dependencies:
-    lodash.debounce "^4.0.8"
-    lodash.throttle "^4.1.1"
-
 react-lazy-load-image-component@^1.4.0-beta.1:
   version "1.4.0-beta.1"
   resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.0-beta.1.tgz#9728b2de583cfee2146f4e81db60562b63fe866f"


### PR DESCRIPTION
Fixes an issue w/ `react-lazy-load-image-component` where lazy loading is broken when using intersection observers because of a faulty SSR check. 

cc @pepopowitz 