### PR TITLE
Updates to display ad tracking

### DIFF
--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -1,10 +1,10 @@
 import { Box, color, Flex, FlexProps, Sans } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
 import * as AnalyticsSchema from "Artsy/Analytics/Schema"
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { is300x50AdUnit } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
-import { once } from "lodash"
-import React from "react"
+import React, { useState } from "react"
 import { Bling as GPT } from "react-gpt"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -37,93 +37,87 @@ export interface DisplayAdContainerProps extends FlexProps {
 
 GPT.syncCorrelator(true)
 
-@track(null, {
-  dispatch: data => Events.postEvent(data),
+export const DisplayAd = track(
+  {
+    context_page: AnalyticsSchema.PageName.ArticlePage,
+    context_module: AnalyticsSchema.ContextModule.AdServer,
+    context_page_owner_type: AnalyticsSchema.OwnerType.Article,
+  },
+  { dispatch: data => Events.postEvent(data) }
+)((props: DisplayAdProps) => {
+  const { trackEvent } = useTracking()
+  const [isAdEmpty, setIsAdEmpty] = useState<boolean | null>(null)
+
+  const {
+    adDimension,
+    adUnit,
+    targetingData,
+    articleSlug,
+    ...otherProps
+  } = props
+
+  function trackImpression() {
+    trackEvent({
+      context_page_owner_id: targetingData.post_id,
+      context_page_owner_slug: articleSlug,
+      action_type: AnalyticsSchema.ActionType.Impression,
+    })
+  }
+
+  function trackClick() {
+    trackEvent({
+      context_page_owner_id: targetingData.post_id,
+      context_page_owner_slug: articleSlug,
+      action_type: AnalyticsSchema.ActionType.Click,
+    })
+  }
+
+  const [width, height] = adDimension.split("x").map(a => parseInt(a))
+  const isMobileLeaderboardAd = is300x50AdUnit(adDimension)
+
+  const ad = (
+    <GPT
+      collapseEmptyDiv
+      adUnitPath={`/21805539690/${adUnit}`}
+      targeting={targetingData}
+      slotSize={[width, height]}
+      onSlotRenderEnded={event => {
+        setIsAdEmpty(event.isEmpty)
+      }}
+    />
+  )
+
+  if (isAdEmpty) {
+    return null
+  }
+  return (
+    <>
+      <Waypoint onEnter={() => trackImpression()} bottomOffset="100px" />
+      <DisplayAdContainer
+        onClick={() => trackClick()}
+        flexDirection="column"
+        pt={isMobileLeaderboardAd ? 2 : 4}
+        pb={isMobileLeaderboardAd ? 2 : 1}
+        height={
+          isAdEmpty || isAdEmpty === null
+            ? "1px" // on initial render OR when no ad content returned from Google, set 1px height to ad container to prevent jarring UX effect
+            : isMobileLeaderboardAd
+            ? "100px" // on mobile 300x50 ads reduce ad container height to 100px
+            : "334px"
+        }
+        isAdEmpty={isAdEmpty}
+        {...otherProps}
+      >
+        <Box m="auto">
+          {ad}
+          <Sans size="1" color="black30" m={1}>
+            Advertisement
+          </Sans>
+        </Box>
+      </DisplayAdContainer>
+    </>
+  )
 })
-@track<DisplayAdProps>(props => ({
-  context_page: AnalyticsSchema.PageName.ArticlePage,
-  context_module: AnalyticsSchema.ContextModule.AdServer,
-  context_page_owner_type: AnalyticsSchema.OwnerType.Article,
-  context_page_owner_id: props.targetingData.post_id,
-  context_page_owner_slug: props.articleSlug,
-}))
-export class DisplayAd extends React.Component<DisplayAdProps> {
-  state = {
-    isAdEmpty: null,
-  }
-  @track({
-    action_type: AnalyticsSchema.ActionType.Impression,
-  })
-  trackImpression() {
-    // noop
-  }
-
-  @track({
-    action_type: AnalyticsSchema.ActionType.Click,
-  })
-  trackImpressionClick() {
-    // noop
-  }
-
-  render() {
-    const {
-      adDimension,
-      adUnit,
-      targetingData,
-      articleSlug,
-      ...otherProps
-    } = this.props
-    const { isAdEmpty } = this.state
-    const [width, height] = adDimension.split("x").map(a => parseInt(a))
-    const isMobileLeaderboardAd = is300x50AdUnit(adDimension)
-
-    const ad = (
-      <GPT
-        collapseEmptyDiv
-        adUnitPath={`/21805539690/${adUnit}`}
-        targeting={targetingData}
-        slotSize={[width, height]}
-        onSlotRenderEnded={event => {
-          this.setState({ isAdEmpty: event.isEmpty })
-        }}
-      />
-    )
-
-    if (isAdEmpty) {
-      return null
-    }
-    return (
-      <>
-        <Waypoint
-          onLeave={once(this.trackImpression.bind(this))}
-          bottomOffset="10%"
-        />
-        <DisplayAdContainer
-          onClick={this.trackImpressionClick.bind(this)}
-          flexDirection="column"
-          pt={isMobileLeaderboardAd ? 2 : 4}
-          pb={isMobileLeaderboardAd ? 2 : 1}
-          height={
-            isAdEmpty || isAdEmpty === null
-              ? "1px" // on initial render OR when no ad content returned from Google, set 1px height to ad container to prevent jarring UX effect
-              : isMobileLeaderboardAd
-              ? "100px" // on mobile 300x50 ads reduce ad container height to 100px
-              : "334px"
-          }
-          isAdEmpty={isAdEmpty}
-          {...otherProps}
-        >
-          <Box m="auto">
-            {ad}
-            <Sans size="1" color="black30" m={1}>
-              Advertisement
-            </Sans>
-          </Box>
-        </DisplayAdContainer>
-      </>
-    )
-  }
-}
 
 export const DisplayAdContainer = styled(Flex)<DisplayAdContainerProps>`
   margin: ${p => (p.isStandard ? "0" : "0 auto")};

--- a/src/Components/Publishing/Display/DisplayAd.tsx
+++ b/src/Components/Publishing/Display/DisplayAd.tsx
@@ -6,7 +6,6 @@ import { is300x50AdUnit } from "Components/Publishing/Display/DisplayTargeting"
 import { AdDimension, AdUnit } from "Components/Publishing/Typings"
 import React, { useState } from "react"
 import { Bling as GPT } from "react-gpt"
-import Waypoint from "react-waypoint"
 import styled from "styled-components"
 import Events from "Utils/Events"
 
@@ -84,6 +83,9 @@ export const DisplayAd = track(
       onSlotRenderEnded={event => {
         setIsAdEmpty(event.isEmpty)
       }}
+      onImpressionViewable={() => {
+        trackImpression()
+      }}
     />
   )
 
@@ -92,7 +94,6 @@ export const DisplayAd = track(
   }
   return (
     <>
-      <Waypoint onEnter={() => trackImpression()} bottomOffset="100px" />
       <DisplayAdContainer
         onClick={() => trackClick()}
         flexDirection="column"

--- a/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
+++ b/src/Components/Publishing/Display/__tests__/DisplayAd.test.tsx
@@ -11,7 +11,6 @@ import "jest-styled-components"
 import React from "react"
 import { Bling as GPT } from "react-gpt"
 import renderer from "react-test-renderer"
-import Waypoint from "react-waypoint"
 import { ArticleDisplayAdProps as AdData } from "../../Fixtures/Components"
 jest.unmock("react-tracking")
 
@@ -54,15 +53,17 @@ describe("Display Ad", () => {
     expect(gptProps.slotSize).toEqual([970, 250])
   })
 
-  it("Tracks display ad impression", () => {
+  it("Tracks display ad impression after ad is viewed", () => {
     const { Component, dispatch } = mockTracking(DisplayAd)
 
     const component = mount(<Component {...displayAdProps} />)
 
-    component
-      .find(Waypoint)
-      .getElement()
-      .props.onLeave()
+      // onImpressionViewable fires when the user scrolls to an ad long enough to view it:
+      //   https://support.google.com/admanager/answer/4524488?hl=en&visit_id=637116147923101672-4119934528&rd=1
+    ;(component
+      .find(GPT)
+      .at(0)
+      .props() as any).onImpressionViewable()
 
     expect(dispatch).toBeCalledWith({
       action_type: "Impression",

--- a/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
+++ b/src/Components/Publishing/Display/__tests__/__snapshots__/DisplayAd.test.tsx.snap
@@ -1,15 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Display Ad renders the new canvas in standard layout 1`] = `
-Array [
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />,
-  .c1 {
+.c1 {
   margin: auto;
 }
 
@@ -41,30 +33,29 @@ Array [
 }
 
 <div
-    className="c0"
-    height="1px"
-    onClick={[Function]}
+  className="c0"
+  height="1px"
+  onClick={[Function]}
+>
+  <div
+    className="c1"
   >
     <div
-      className="c1"
-    >
-      <div
-        style={
-          Object {
-            "height": 250,
-            "width": 970,
-          }
+      style={
+        Object {
+          "height": 250,
+          "width": 970,
         }
-      />
-      <div
-        className="c2"
-        color="black30"
-        fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
-        fontSize="10px"
-      >
-        Advertisement
-      </div>
+      }
+    />
+    <div
+      className="c2"
+      color="black30"
+      fontFamily="Unica77LLWebRegular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+      fontSize="10px"
+    >
+      Advertisement
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -2863,13 +2863,6 @@ exports[`News Layout with display ads renders the news layout properly with disp
       Expand
     </button>
   </div>
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />
   <div
     className="c23"
     height="1px"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1574,13 +1574,6 @@ exports[`series layout renders a series 1`] = `
       </div>
     </div>
   </div>
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />
   <div
     className="c42"
     height="1px"
@@ -3356,13 +3349,6 @@ exports[`series layout renders a sponsored series 1`] = `
       </div>
     </div>
   </div>
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />
   <div
     className="c50"
     height="1px"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1621,13 +1621,6 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
       </div>
     </div>
   </div>
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />
   <div
     className="c56"
     height="1px"
@@ -4310,13 +4303,6 @@ exports[`Video Layout matches the snapshot 1`] = `
       </div>
     </div>
   </div>
-  <span
-    style={
-      Object {
-        "fontSize": 0,
-      }
-    }
-  />
   <div
     className="c83"
     height="1px"


### PR DESCRIPTION
This PR corrects the impression tracking of display ads.

Impressions of ads will only be tracked once, when the user first views them.

I accomplished this by removing our use of waypoints, and relying on Google to manage when the ad is viewed, with the `onImpressionViewable` event. The rules Google uses to identify if an ad is viewable are [in their docs](https://support.google.com/admanager/answer/4524488?hl=en&visit_id=637116147923101672-4119934528&rd=1). 

If a user scrolls very quickly past an ad, it is possible that we *won't* track an impression for it, but that seems correct to me, since they didn't truly look at it.

Along the way, I refactored the DisplayAd component to be a functional component instead of a class, as I found that easier to work with. 

~Tests are also broken; I'll fix those before this PR is ready for merge.~ Tests are fixed now!

Note: Support for tracking *clicks* on ads will be covered in a future PR.