### PR TITLE
Bump down threshold for lazy-loading on artist artwork grid

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilterArtworkGrid2.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterArtworkGrid2.tsx
@@ -63,7 +63,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
         <ArtworkGrid
           artworks={props.filtered_artworks}
           columnCount={columnCount}
-          preloadImageCount={9}
+          preloadImageCount={6}
           itemMargin={40}
           user={user}
           mediator={mediator}


### PR DESCRIPTION
Small change to adjust lazy loading threshold on artwork grid from 9 to 6. 