### PR TITLE
Add user agents to buildClientApp and SystemContext

### DIFF
--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -45,6 +45,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         createRelaySSREnvironment({
           cache: JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}"),
           user,
+          userAgent: (navigator && navigator.userAgent) || undefined,
         })
 
       const getHistoryProtocol = () => {

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -45,7 +45,9 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         createRelaySSREnvironment({
           cache: JSON.parse(window.__RELAY_BOOTSTRAP__ || "{}"),
           user,
-          userAgent: (navigator && navigator.userAgent) || undefined,
+          userAgent:
+            (typeof navigator !== "undefined" && navigator.userAgent) ||
+            undefined,
         })
 
       const getHistoryProtocol = () => {

--- a/src/Artsy/SystemContext.tsx
+++ b/src/Artsy/SystemContext.tsx
@@ -60,6 +60,7 @@ export interface SystemContextProps {
    * and `USER_ACCESS_TOKEN` environment variables if available.
    */
   user?: User
+  userAgent?: string
 }
 
 export const SystemContext = React.createContext<SystemContextProps>({})
@@ -75,8 +76,10 @@ export const SystemContextProvider: SFC<SystemContextProps> = ({
   const [isFetching, setIsFetching] = useState(false)
   const [router, setRouter] = useState(null)
   const user = getUser(props.user)
+  const { userAgent } = props
+
   const relayEnvironment =
-    props.relayEnvironment || createRelaySSREnvironment({ user })
+    props.relayEnvironment || createRelaySSREnvironment({ user, userAgent })
 
   const providerValues = {
     ...props,

--- a/src/Artsy/SystemContext.tsx
+++ b/src/Artsy/SystemContext.tsx
@@ -79,7 +79,14 @@ export const SystemContextProvider: SFC<SystemContextProps> = ({
   const { userAgent } = props
 
   const relayEnvironment =
-    props.relayEnvironment || createRelaySSREnvironment({ user, userAgent })
+    props.relayEnvironment ||
+    createRelaySSREnvironment({
+      user,
+      userAgent:
+        userAgent ||
+        (typeof navigator !== "undefined" && navigator.userAgent) ||
+        undefined,
+    })
 
   const providerValues = {
     ...props,


### PR DESCRIPTION
This is a minor update to add more hooks for passing user agents to the relay connection constructor. It will _not_ completely fixed PURCHASE-1140, but it should ensure client side relay requests have the proper UA. 

To completely fix PURCHASE-1140, we need to make sure that all usages of `SystemContextProvider` eventually get the correct prop when called in force. 