### PR TITLE
[GROW-1698] Fix whitespace in global nav

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -76,7 +76,7 @@ export const NavBar: React.FC = track(
           </Box>
         </NavSection>
 
-        <Spacer mr={3} />
+        <Spacer mr={2} />
 
         {/*
           Desktop. Collapses into mobile at `sm` breakpoint.


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1698

Minor pre-existing Q/A issue that turned up while developing the [soon-to-be launched a/b test](https://github.com/artsy/force/pull/4860)

### Before

![before](https://user-images.githubusercontent.com/140521/71034070-943fd680-20e6-11ea-94f1-ef3fa9d82e25.png)

### After

![after](https://user-images.githubusercontent.com/140521/71034071-94d86d00-20e6-11ea-8b26-38b33abb1ccc.png)

(Pretty subtle — check the spacing to the left of Artworks and to the right of More 🔍 )