### PR TITLE
Fix scrolling issue after modal is closed

### DIFF
--- a/src/Components/Modal/ModalWrapper.tsx
+++ b/src/Components/Modal/ModalWrapper.tsx
@@ -64,17 +64,23 @@ export class ModalWrapper extends React.Component<
   }
 
   componentDidMount() {
-    this.updateBodyScrollBlock()
-    this.updateEscapeKeyListener()
+    const isOpen = this.props.show
+    this.updateBodyScrollBlock(isOpen)
+    this.updateEscapeKeyListener(isOpen)
   }
 
-  componentDidUpdate() {
-    this.updateBodyScrollBlock()
-    this.updateEscapeKeyListener()
+  componentDidUpdate(prevProps) {
+    const isOpen = this.props.show
+    if (prevProps.show !== isOpen) {
+      this.updateBodyScrollBlock(isOpen)
+      this.updateEscapeKeyListener(isOpen)
+    }
   }
 
   componentWillUnmount() {
     this.removeBlurToContainers()
+    this.updateBodyScrollBlock(false)
+    this.updateEscapeKeyListener(false)
   }
 
   close = () => {
@@ -94,8 +100,8 @@ export class ModalWrapper extends React.Component<
     }
   }
 
-  updateBodyScrollBlock() {
-    if (this.props.show) {
+  updateBodyScrollBlock(isOpen) {
+    if (isOpen) {
       document.body.style.overflowY = "hidden"
     } else {
       document.body.style.overflowY = "visible"
@@ -108,8 +114,8 @@ export class ModalWrapper extends React.Component<
     }
   }
 
-  updateEscapeKeyListener() {
-    if (this.props.show) {
+  updateEscapeKeyListener(isOpen) {
+    if (isOpen) {
       document.addEventListener(KEYBOARD_EVENT, this.handleEscapeKey, true)
     } else {
       document.removeEventListener(KEYBOARD_EVENT, this.handleEscapeKey, true)


### PR DESCRIPTION
fixes [PURCHASE-1686](https://artsyproduct.atlassian.net/browse/PURCHASE-1686)

**Problem:**

Closing modal leaves the `overflow-y: hidden` on `Body` tag:

![Screen Shot 2019-12-06 at 2 18 38 PM](https://user-images.githubusercontent.com/687513/71045241-40db8180-2102-11ea-8d97-6e9456bf3eac.png)

**Solution:**

It turned out the component is unmounted before `this.prop.show` (coming from `state.ts`) is being set to false when closing the modal
In general it is not a bad idea to clean up side effects so added the functions cleaning up to `componentWillUnmount`

Also add a check to avoid setting multiple key event listeners when other props change