### PR TITLE
Remove linking artifact

### DIFF
--- a/2
+++ b/2
@@ -1,1 +1,0 @@
-"./scripts/quicklink-to-project.sh"


### PR DESCRIPTION
Checked the history and it looks like this might be an artifact from the `yarn integrate reaction` process in force-- shouldn't be here!