### PR TITLE
PURCHASE-1700: Artist Page Tweaks

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -5,7 +5,6 @@ import { Mediator, SystemContextConsumer } from "Artsy"
 import { track, Track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
-import { CATEGORIES } from "Components/v2/ArtistMarketInsights"
 import { Carousel } from "Components/v2/Carousel"
 import React, { Component, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -42,6 +41,12 @@ interface Props {
   artist: ArtistHeader_artist
   user?: User
   mediator?: Mediator
+}
+
+const Categories = {
+  "blue-chip": "Blue Chip",
+  "top-established": "Established",
+  "top-emerging": "Emerging",
 }
 
 type Image = Props["artist"]["carousel"]["images"][0]
@@ -152,8 +157,8 @@ export class LargeArtistHeader extends Component<Props> {
             </Box>
             <Flex justifyContent="space-between">
               {props.artist.counts.follows > 50 && (
-                <Flex flexDirection="column">
-                  <Sans size="4" weight="medium">
+                <Flex flexDirection="column" alignItems="center">
+                  <Sans size="5t" weight="medium">
                     {props.artist.counts.follows.toLocaleString()}
                   </Sans>
                   <Sans size="2" color="black60" weight="medium">
@@ -176,10 +181,10 @@ export class LargeArtistHeader extends Component<Props> {
           </Flex>
         </Box>
         <Flex flexDirection="row">
-          {renderAuctionHighlight(props.artist)}
+          {renderRepresentationStatus(props.artist)}
           {renderAuctionHighlight(props.artist) &&
             renderRepresentationStatus(props.artist) && <Spacer mr={5} />}
-          {renderRepresentationStatus(props.artist)}
+          {renderAuctionHighlight(props.artist)}
         </Flex>
       </HorizontalPadding>
     )
@@ -303,10 +308,10 @@ export class SmallArtistHeader extends Component<Props> {
           </Flex>
         </Flex>
         <Flex flexDirection="row" justifyContent="center">
-          {renderAuctionHighlight(props.artist)}
+          {renderRepresentationStatus(props.artist)}
           {renderAuctionHighlight(props.artist) &&
             renderRepresentationStatus(props.artist) && <Spacer mr={5} />}
-          {renderRepresentationStatus(props.artist)}
+          {renderAuctionHighlight(props.artist)}
         </Flex>
       </Flex>
     )
@@ -343,7 +348,10 @@ const renderRepresentationStatus = artist => {
     const highCategory = highestCategory(partnersConnection.edges)
 
     return (
-      <ArtistIndicator label={CATEGORIES[highCategory]} type={highCategory} />
+      <ArtistIndicator
+        label={Categories[highCategory] + " Representation"}
+        type={highCategory}
+      />
     )
   }
 }

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -43,10 +43,10 @@ interface Props {
   mediator?: Mediator
 }
 
-const Categories = {
-  "blue-chip": "Blue Chip",
-  "top-established": "Established",
-  "top-emerging": "Emerging",
+const CATEGORIES = {
+  "blue-chip": "Blue Chip Representation",
+  "top-established": "Established Representation",
+  "top-emerging": "Emerging Representation",
 }
 
 type Image = Props["artist"]["carousel"]["images"][0]
@@ -348,10 +348,7 @@ const renderRepresentationStatus = artist => {
     const highCategory = highestCategory(partnersConnection.edges)
 
     return (
-      <ArtistIndicator
-        label={Categories[highCategory] + " Representation"}
-        type={highCategory}
-      />
+      <ArtistIndicator label={CATEGORIES[highCategory]} type={highCategory} />
     )
   }
 }

--- a/src/Apps/Artist/Components/ArtistIndicator.tsx
+++ b/src/Apps/Artist/Components/ArtistIndicator.tsx
@@ -29,7 +29,7 @@ export class ArtistIndicator extends React.Component<ArtistIndicatorProps> {
   renderIcon(insightType) {
     const Component = ICON_MAPPING[insightType]
 
-    return <Component pr={5} />
+    return <Component size="20px" pr={5} />
   }
 
   render() {
@@ -44,7 +44,9 @@ export class ArtistIndicator extends React.Component<ArtistIndicatorProps> {
         mt={1}
       >
         {this.renderIcon(type)}
-        <Sans size="2">{label}</Sans>
+        <Sans pt="2px" size="2">
+          {label}
+        </Sans>
       </RoundedFlex>
     )
   }

--- a/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
@@ -43,7 +43,7 @@ describe("ArtistHeader", () => {
   it("renders blue chip indicator when data is present", async () => {
     const wrapper = await getWrapper()
     const html = wrapper.html()
-    expect(html).toContain("Blue chip")
+    expect(html).toContain("Blue Chip")
   })
 
   it("renders auction record indicator when data is present", async () => {
@@ -69,6 +69,6 @@ describe("ArtistHeader", () => {
     }
     const wrapper = await getWrapper(artist)
     const html = wrapper.html()
-    expect(html).not.toContain("Blue chip")
+    expect(html).not.toContain("Blue Chip")
   })
 })

--- a/src/Components/v2/SelectedCareerAchievements.tsx
+++ b/src/Components/v2/SelectedCareerAchievements.tsx
@@ -68,12 +68,13 @@ export class SelectedCareerAchievements extends React.Component<
     ) {
       const highCategory = highestCategory(partnersConnection.edges)
       const type = highCategory.toUpperCase().replace("-", "_")
+      const label = CATEGORIES[highCategory] + " representation"
 
       return (
         <ArtistInsight
           key={type}
           type={type}
-          label={CATEGORIES[highCategory]}
+          label={label}
           value={CATEGORY_LABEL_MAP[highCategory]}
         />
       )

--- a/src/Components/v2/SelectedCareerAchievements.tsx
+++ b/src/Components/v2/SelectedCareerAchievements.tsx
@@ -17,9 +17,9 @@ export interface SelectedCareerAchievementsProps {
 }
 
 const CATEGORIES = {
-  "blue-chip": "Blue chip",
-  "top-established": "Established",
-  "top-emerging": "Emerging",
+  "blue-chip": "Blue chip representation",
+  "top-established": "Established representation",
+  "top-emerging": "Emerging representation",
 }
 const CATEGORY_LABEL_MAP = {
   "blue-chip": "Represented by internationally reputable galleries.",
@@ -68,7 +68,7 @@ export class SelectedCareerAchievements extends React.Component<
     ) {
       const highCategory = highestCategory(partnersConnection.edges)
       const type = highCategory.toUpperCase().replace("-", "_")
-      const label = CATEGORIES[highCategory] + " representation"
+      const label = CATEGORIES[highCategory]
 
       return (
         <ArtistInsight


### PR DESCRIPTION
[PURCHASE-1700] Artist Page Tweaks

Center-align the number of followers with the label

Blue chip / emerging / established badge should always come before the auction record badge

Add “Representation” after Blue chip / established / emerging on both the top level badges and in career achievements

i.e. “Blue Chip Representation” (Title case on the badge)

“Blue chip representation” (sentence case in career achievements)

Adjust the icon size from 18px to 20px in badges

Add padding-top: 2px to text within badge to better align with the icon

<img width="880" alt="Screen Shot 2019-12-18 at 3 56 27 PM" src="https://user-images.githubusercontent.com/5643895/71123278-48f1fa80-21b0-11ea-826d-8b01d9137595.png">
<img width="883" alt="Screen Shot 2019-12-18 at 3 56 15 PM" src="https://user-images.githubusercontent.com/5643895/71123290-4d1e1800-21b0-11ea-8875-6c8a769956d4.png">


[PURCHASE-1700]: https://artsyproduct.atlassian.net/browse/PURCHASE-1700