### PR TITLE
@mzikherman => [CatchLinks] Dont attempt to handle empty anchor tags

### DIFF
--- a/src/Utils/catchLinks.tsx
+++ b/src/Utils/catchLinks.tsx
@@ -124,6 +124,12 @@ export const routeThroughBrowserOrApp = hrefHandler => event => {
     return true
   }
 
+  // Empty anchor tags should be skipped. Those either won't navigate
+  // anywhere, or may have custom click handlers.
+  if (clickedAnchor.href === "") {
+    return false
+  }
+
   if (authorIsForcingNavigation(clickedAnchor)) {
     return true
   }


### PR DESCRIPTION
There were some bug reports about wonky behavior with the 'Next' button in pagination.

Turns out, Prev/Next are [implemented](https://github.com/artsy/palette/blob/eab9b059edade3cc2ff918ff8285596e46e7258b/packages/palette/src/elements/Pagination/Pagination.tsx#L176) as empty anchor tags with custom `onClick` handlers. This just seems to be an oversight from early development of pagination. That doesn't work well with our link interception strategy for client side routing.

For that particular component, it should most likely be a valid anchor tag with href. However, since there might be other examples of these (we've found and fixed a few during work on the client side router in Reaction), plus Palette work and fixes deserves a lot of care, let's just go with this fix for now.