### PR TITLE
@joeyAghion => [Analytics] Fire AB test events for client side routing

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -11,9 +11,11 @@ import {
   Footer,
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
-import React from "react"
+import React, { useEffect } from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+import { data as sd } from "sharify"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 
 export interface ArtistAppProps {
@@ -25,6 +27,23 @@ export interface ArtistAppProps {
 
 export const ArtistApp: React.FC<ArtistAppProps> = props => {
   const { artist, children } = props
+  const { trackEvent } = useTracking()
+
+  // TODO: Remove after AB test ends.
+  useEffect(() => {
+    const { CLIENT_NAVIGATION } = sd
+
+    const experiment = "client_navigation"
+    const variation = CLIENT_NAVIGATION
+    trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -25,6 +25,7 @@ import {
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
 import { TrackingProp } from "react-tracking"
+import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
@@ -45,6 +46,23 @@ export class ArtworkApp extends React.Component<Props> {
   componentDidMount() {
     this.trackPageview()
     this.trackProductView()
+    this.trackABTest() // TODO: Remove after AB test
+  }
+
+  trackABTest() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION } = sd
+
+    const experiment = "client_navigation"
+    const variation = CLIENT_NAVIGATION
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
   }
 
   trackProductView() {

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { Match, Router } from "found"
-import React from "react"
+import React, { useEffect } from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -54,6 +54,22 @@ export const CollectApp = track({
       name: breadcrumbTitle,
     })
   }
+
+  // TODO: Remove after AB test ends.
+  useEffect(() => {
+    const { CLIENT_NAVIGATION } = sd
+
+    const experiment = "client_navigation"
+    const variation = CLIENT_NAVIGATION
+    trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -50,6 +50,23 @@ export class CollectionApp extends Component<CollectionAppProps> {
     this.collectionNotFound(this.props.collection)
   }
 
+  // TODO: Remove after AB test ends.
+  componentDidMount() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION } = sd
+
+    const experiment = "client_navigation"
+    const variation = CLIENT_NAVIGATION
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
+
   render() {
     const {
       collection,

--- a/src/Apps/Collect2/Routes/Collections/__tests__/CollectionsApp.test.tsx
+++ b/src/Apps/Collect2/Routes/Collections/__tests__/CollectionsApp.test.tsx
@@ -17,8 +17,11 @@ jest.mock("found", () => ({
 describe("CollectionApp", () => {
   it("renders a relay tree correctly", async () => {
     const getRelayWrapper = async () => {
+      const trackEvent = jest.fn()
+      const tracking = { trackEvent }
       return await renderRelayTree({
         Component: CollectionsApp,
+        componentProps: { tracking },
         query: graphql`
           query CollectionsAppTestQuery @raw_response_type {
             marketingCategories {

--- a/src/Apps/Collect2/Routes/Collections/index.tsx
+++ b/src/Apps/Collect2/Routes/Collections/index.tsx
@@ -1,19 +1,22 @@
 import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
 import { Collections_marketingCategories } from "__generated__/Collections_marketingCategories.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { trackPageViewWrapper } from "Artsy"
+import { trackPageViewWrapper, withSystemContext } from "Artsy"
+import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "Components/v2/Seo"
 import { Link, Router } from "found"
 import React, { Component, useState } from "react"
 import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
+import { TrackingProp } from "react-tracking"
 import { data as sd } from "sharify"
 import { CollectionEntity, CollectionsGrid } from "./Components/CollectionsGrid"
 
 interface CollectionsAppProps {
   marketingCategories: Collections_marketingCategories
   router: Router
+  tracking: TrackingProp
 }
 
 const META_DESCRIPTION =
@@ -23,6 +26,22 @@ const META_DESCRIPTION =
 const isServer = typeof window === "undefined"
 
 export class CollectionsApp extends Component<CollectionsAppProps> {
+  // TODO: Remove after AB Test ends.
+  componentDidMount() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION } = sd
+
+    const experiment = "client_navigation"
+    const variation = CLIENT_NAVIGATION
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
   render() {
     const { marketingCategories, router } = this.props
 
@@ -104,7 +123,7 @@ const CategoryItem = props => {
 }
 
 export const CollectionsAppFragmentContainer = createFragmentContainer(
-  trackPageViewWrapper(CollectionsApp),
+  withSystemContext(trackPageViewWrapper(CollectionsApp)),
   {
     marketingCategories: graphql`
       fragment Collections_marketingCategories on MarketingCollectionCategory

--- a/src/Apps/Search/__tests__/SearchApp.test.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.test.tsx
@@ -11,10 +11,12 @@ jest.mock("Components/v2/RouteTabs", () => ({
 
 describe("SearchApp", () => {
   const getWrapper = (searchProps: any) => {
+    const trackEvent = jest.fn()
+    const tracking = { trackEvent }
     return mount(
       <MockBoot breakpoint="lg">
         <SystemContextProvider>
-          <SearchApp {...searchProps} />
+          <SearchApp {...searchProps} tracking={tracking} />
         </SystemContextProvider>
       </MockBoot>
     )

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -157,8 +157,7 @@ export class SearchBar extends Component<Props, State> {
     super(props)
 
     this.enableExperimentalAppShell =
-      sd.CLIENT_SIDE_ROUTING === "experiment" &&
-      getENV("EXPERIMENTAL_APP_SHELL")
+      sd.CLIENT_NAVIGATION === "experiment" && getENV("EXPERIMENTAL_APP_SHELL")
   }
 
   componentDidMount() {

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,7 +20,7 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
-      readonly CLIENT_SIDE_ROUTING: string // TODO: remove after AB test
+      readonly CLIENT_NAVIGATION: string // TODO: remove after AB test
       readonly CMS_URL: string
       readonly ENABLE_PRICE_TRANSPARENCY: string
       readonly FACEBOOK_APP_NAMESPACE: string


### PR DESCRIPTION
This moves the AB test events out of Force, and into Reaction. The enables them to fire whenever any Reaction page is rendered, no matter 'how' the client navigated to that page.

Places where the app was already functional went with `useEffect`, and in places where the app was a class went with `componentDidMount` (we want this analytics call to be fired when mounted).

The Force PR that ingests this will be pretty trivial, just removing the AB test events. 

**This still needs an updated experiment name.**