### PR TITLE
Remove showing follower numbers twice on mobile

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -258,11 +258,6 @@ export class SmallArtistHeader extends Component<Props> {
                   </Serif>
                 </H2>
               </Box>
-              {props.artist.counts.follows > 50 && (
-                <Serif size="2">
-                  {props.artist.counts.follows.toLocaleString()} followers
-                </Serif>
-              )}
             </Flex>
           </Flex>
         </Box>


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1705
We show number of followers twice on the artist page on mobile.

![image](https://user-images.githubusercontent.com/1230819/71589521-2ab2c580-2af3-11ea-8518-cd68c08e6363.png)


# Selfie
![image](https://user-images.githubusercontent.com/1230819/71589443-ea534780-2af2-11ea-9cb8-4e3b003599c3.png)
