### PR TITLE
PURCHASE-1656: Add phone number field to Address for pickup

### DIFF
--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -39,6 +39,7 @@ export interface AddressFormProps {
   domesticOnly?: boolean
   showPhoneNumberInput?: boolean
   shippingCountry?: string
+  phoneNumberOnly?: boolean
   errors: AddressErrors
   touched: AddressTouched
 }
@@ -85,7 +86,9 @@ export class AddressForm extends React.Component<
   }
 
   phoneNumberInputDescription = (): string | null => {
-    if (this.props.billing && this.props.showPhoneNumberInput) {
+    if (this.props.phoneNumberOnly) {
+      return "After your order is confirmed, a specialist will contact you within 2 business days to coordinate pickup."
+    } else if (this.props.billing && this.props.showPhoneNumberInput) {
       return null
     } else {
       return "Required for shipping logistics"
@@ -96,132 +99,137 @@ export class AddressForm extends React.Component<
     const lockCountryToOrigin = !this.props.billing && this.props.domesticOnly
     return (
       <Join separator={<Spacer mb={2} />}>
-        <Flex flexDirection="column">
-          <Input
-            id="AddressForm_name"
-            placeholder="Add full name"
-            title={this.props.billing ? "Name on card" : "Full name"}
-            autoCapitalize="words"
-            autoCorrect="off"
-            value={this.props.value.name}
-            onChange={this.changeEventHandler("name")}
-            error={this.getError("name")}
-            block
-          />
-        </Flex>
-
-        <TwoColumnSplit>
-          <Flex flexDirection="column" pb={1}>
-            <Serif mb={1} size="3t" color="black100" lineHeight="1.1em">
-              Country
-            </Serif>
-            <CountrySelect
-              selected={
-                lockCountryToOrigin
-                  ? this.props.shippingCountry
-                  : this.state.address.country
-              }
-              onSelect={this.changeValueHandler("country")}
-              disabled={lockCountryToOrigin}
-            />
-            {lockCountryToOrigin && (
-              <>
-                <Spacer m={0.5} />
-                <Sans size="2" color="black60">
-                  Domestic shipping only.
-                </Sans>
-              </>
-            )}
-          </Flex>
-
-          <Flex flexDirection="column">
-            <Input
-              id="AddressForm_postalCode"
-              placeholder="Add postal code"
-              title="Postal code"
-              autoCapitalize="characters"
-              autoCorrect="off"
-              value={this.props.value.postalCode}
-              onChange={this.changeEventHandler("postalCode")}
-              error={this.getError("postalCode")}
-              block
-            />
-          </Flex>
-        </TwoColumnSplit>
-        <TwoColumnSplit>
-          <Flex flexDirection="column">
-            <Input
-              id="AddressForm_addressLine1"
-              placeholder="Add street address"
-              title="Address line 1"
-              autoCapitalize="words"
-              value={this.props.value.addressLine1}
-              onChange={this.changeEventHandler("addressLine1")}
-              error={this.getError("addressLine1")}
-              block
-            />
-          </Flex>
-
-          <Flex flexDirection="column">
-            <Input
-              id="AddressForm_addressLine2"
-              placeholder="Add apt, floor, suite, etc."
-              title="Address line 2 (optional)"
-              autoCapitalize="words"
-              value={this.props.value.addressLine2}
-              onChange={this.changeEventHandler("addressLine2")}
-              error={this.getError("addressLine2")}
-              block
-            />
-          </Flex>
-        </TwoColumnSplit>
-        <TwoColumnSplit>
-          <Flex flexDirection="column">
-            <Input
-              id="AddressForm_city"
-              placeholder="Add city"
-              title="City"
-              autoCapitalize="words"
-              value={this.props.value.city}
-              onChange={this.changeEventHandler("city")}
-              error={this.getError("city")}
-              block
-            />
-          </Flex>
-
-          <Flex flexDirection="column">
-            <Input
-              id="AddressForm_region"
-              placeholder="Add State, province, or region"
-              title="State, province, or region"
-              autoCapitalize="words"
-              autoCorrect="off"
-              value={this.props.value.region}
-              onChange={this.changeEventHandler("region")}
-              error={this.getError("region")}
-              block
-            />
-          </Flex>
-        </TwoColumnSplit>
-        {(!this.props.billing || this.props.showPhoneNumberInput) && (
+        {!this.props.phoneNumberOnly && (
           <>
             <Flex flexDirection="column">
               <Input
-                id="AddressForm_phoneNumber"
-                title="Phone number"
-                type="tel"
-                description={this.phoneNumberInputDescription()}
-                placeholder="Add phone"
-                pattern="[^a-z]+"
-                value={this.props.value.phoneNumber}
-                onChange={this.changeEventHandler("phoneNumber")}
-                error={this.getError("phoneNumber")}
+                id="AddressForm_name"
+                placeholder="Add full name"
+                title={this.props.billing ? "Name on card" : "Full name"}
+                autoCapitalize="words"
+                autoCorrect="off"
+                value={this.props.value.name}
+                onChange={this.changeEventHandler("name")}
+                error={this.getError("name")}
                 block
               />
             </Flex>
-            <Spacer mb={2} />
+
+            <TwoColumnSplit>
+              <Flex flexDirection="column" pb={1}>
+                <Serif mb={1} size="3t" color="black100" lineHeight="1.1em">
+                  Country
+                </Serif>
+                <CountrySelect
+                  selected={
+                    lockCountryToOrigin
+                      ? this.props.shippingCountry
+                      : this.state.address.country
+                  }
+                  onSelect={this.changeValueHandler("country")}
+                  disabled={lockCountryToOrigin}
+                />
+                {lockCountryToOrigin && (
+                  <>
+                    <Spacer m={0.5} />
+                    <Sans size="2" color="black60">
+                      Domestic shipping only.
+                    </Sans>
+                  </>
+                )}
+              </Flex>
+
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_postalCode"
+                  placeholder="Add postal code"
+                  title="Postal code"
+                  autoCapitalize="characters"
+                  autoCorrect="off"
+                  value={this.props.value.postalCode}
+                  onChange={this.changeEventHandler("postalCode")}
+                  error={this.getError("postalCode")}
+                  block
+                />
+              </Flex>
+            </TwoColumnSplit>
+            <TwoColumnSplit>
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_addressLine1"
+                  placeholder="Add street address"
+                  title="Address line 1"
+                  autoCapitalize="words"
+                  value={this.props.value.addressLine1}
+                  onChange={this.changeEventHandler("addressLine1")}
+                  error={this.getError("addressLine1")}
+                  block
+                />
+              </Flex>
+
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_addressLine2"
+                  placeholder="Add apt, floor, suite, etc."
+                  title="Address line 2 (optional)"
+                  autoCapitalize="words"
+                  value={this.props.value.addressLine2}
+                  onChange={this.changeEventHandler("addressLine2")}
+                  error={this.getError("addressLine2")}
+                  block
+                />
+              </Flex>
+            </TwoColumnSplit>
+            <TwoColumnSplit>
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_city"
+                  placeholder="Add city"
+                  title="City"
+                  autoCapitalize="words"
+                  value={this.props.value.city}
+                  onChange={this.changeEventHandler("city")}
+                  error={this.getError("city")}
+                  block
+                />
+              </Flex>
+
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_region"
+                  placeholder="Add State, province, or region"
+                  title="State, province, or region"
+                  autoCapitalize="words"
+                  autoCorrect="off"
+                  value={this.props.value.region}
+                  onChange={this.changeEventHandler("region")}
+                  error={this.getError("region")}
+                  block
+                />
+              </Flex>
+            </TwoColumnSplit>
           </>
         )}
+        {this.props.phoneNumberOnly ||
+          ((!this.props.billing || this.props.showPhoneNumberInput) && (
+            <>
+              <Flex flexDirection="column">
+                <Input
+                  id="AddressForm_phoneNumber"
+                  title="Phone number"
+                  type="tel"
+                  description={this.phoneNumberInputDescription()}
+                  placeholder="Add phone"
+                  pattern="[^a-z]+"
+                  value={this.props.value.phoneNumber}
+                  onChange={this.changeEventHandler("phoneNumber")}
+                  error={this.getError("phoneNumber")}
+                  block
+                />
+              </Flex>
+              <Spacer mb={2} />
+            </>
+          ))}
       </Join>
     )
   }

--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -87,7 +87,7 @@ export class AddressForm extends React.Component<
 
   phoneNumberInputDescription = (): string | null => {
     if (this.props.phoneNumberOnly) {
-      return "After your order is confirmed, a specialist will contact you within 2 business days to coordinate pickup."
+      return "Number to contact for pickup logistics"
     } else if (this.props.billing && this.props.showPhoneNumberInput) {
       return null
     } else {
@@ -97,10 +97,16 @@ export class AddressForm extends React.Component<
 
   render() {
     const lockCountryToOrigin = !this.props.billing && this.props.domesticOnly
+
+    const showPhoneNumber =
+      this.props.phoneNumberOnly ||
+      !this.props.billing ||
+      this.props.showPhoneNumberInput
+
     return (
-      <Join separator={<Spacer mb={2} />}>
+      <>
         {!this.props.phoneNumberOnly && (
-          <>
+          <Join separator={<Spacer mb={2} />}>
             <Flex flexDirection="column">
               <Input
                 id="AddressForm_name"
@@ -208,29 +214,29 @@ export class AddressForm extends React.Component<
                 />
               </Flex>
             </TwoColumnSplit>
+          </Join>
+        )}
+        {showPhoneNumber && (
+          <>
+            <Flex flexDirection="column">
+              {!this.props.phoneNumberOnly && <Spacer mb={2} />}
+              <Input
+                id="AddressForm_phoneNumber"
+                title="Phone number"
+                type="tel"
+                description={this.phoneNumberInputDescription()}
+                placeholder="Add phone"
+                pattern="[^a-z]+"
+                value={this.props.value.phoneNumber}
+                onChange={this.changeEventHandler("phoneNumber")}
+                error={this.getError("phoneNumber")}
+                block
+              />
+            </Flex>
+            <Spacer mb={2} />
           </>
         )}
-        {this.props.phoneNumberOnly ||
-          ((!this.props.billing || this.props.showPhoneNumberInput) && (
-            <>
-              <Flex flexDirection="column">
-                <Input
-                  id="AddressForm_phoneNumber"
-                  title="Phone number"
-                  type="tel"
-                  description={this.phoneNumberInputDescription()}
-                  placeholder="Add phone"
-                  pattern="[^a-z]+"
-                  value={this.props.value.phoneNumber}
-                  onChange={this.changeEventHandler("phoneNumber")}
-                  error={this.getError("phoneNumber")}
-                  block
-                />
-              </Flex>
-              <Spacer mb={2} />
-            </>
-          ))}
-      </Join>
+      </>
     )
   }
 }

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -153,6 +153,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       this.state.address,
       shippingOption === "PICKUP"
     )
+
     if (hasErrors) {
       this.setState({
         addressErrors: errors,
@@ -160,22 +161,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       })
       return
     }
-
-    // if (shippingOption === "SHIP") {
-    //   const { errors, hasErrors } = this.validateAddress(this.state.address)
-    // } else if (shippingOption === "PICKUP") {
-    //   const { errors, hasErrors } = this.validatePhoneNumber(
-    //     this.state.address.phoneNumber
-    //   )
-    // }
-
-    // if (hasErrors) {
-    //   this.setState({
-    //     addressErrors: errors,
-    //     addressTouched: this.touchedAddress,
-    //   })
-    //   return
-    // }
 
     try {
       const orderOrError = (

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -150,10 +150,17 @@ Object {
   it("commits the mutation with pickup option", async () => {
     const page = await buildPage()
     await page.selectPickupOption()
+    fillIn(page.root, {
+      title: "Phone number",
+      value: validAddress.phoneNumber,
+    })
     expect(mutations.mockFetch).not.toHaveBeenCalled()
     await page.clickSubmit()
     expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
     expect(mutations.lastFetchVariables.input.fulfillmentType).toBe("PICKUP")
+    expect(mutations.lastFetchVariables.input.shipping.phoneNumber).toBe(
+      "8475937743"
+    )
   })
 
   describe("mutation", () => {
@@ -347,6 +354,10 @@ Object {
 
     it("does submit the mutation with a non-ship order", async () => {
       await page.selectPickupOption()
+      fillIn(page.root, {
+        title: "Phone number",
+        value: validAddress.phoneNumber,
+      })
       await page.clickSubmit()
       expect(mutations.mockFetch).toBeCalled()
     })

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -150,10 +150,14 @@ Object {
   it("commits the mutation with pickup option", async () => {
     const page = await buildPage()
     await page.selectPickupOption()
-    fillIn(page.root, {
-      title: "Phone number",
-      value: validAddress.phoneNumber,
-    })
+    fillIn(
+      page.root,
+      {
+        title: "Phone number",
+        value: validAddress.phoneNumber,
+      },
+      1
+    )
     expect(mutations.mockFetch).not.toHaveBeenCalled()
     await page.clickSubmit()
     expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
@@ -354,10 +358,14 @@ Object {
 
     it("does submit the mutation with a non-ship order", async () => {
       await page.selectPickupOption()
-      fillIn(page.root, {
-        title: "Phone number",
-        value: validAddress.phoneNumber,
-      })
+      fillIn(
+        page.root,
+        {
+          title: "Phone number",
+          value: validAddress.phoneNumber,
+        },
+        1
+      )
       await page.clickSubmit()
       expect(mutations.mockFetch).toBeCalled()
     })

--- a/src/Apps/Order/Routes/__tests__/Utils/addressForm.ts
+++ b/src/Apps/Order/Routes/__tests__/Utils/addressForm.ts
@@ -15,11 +15,14 @@ export const validAddress: Address = {
 
 export const fillIn = (
   component: any,
-  inputData: { title: string; value: string }
+  inputData: { title: string; value: string },
+  index?: number
 ) => {
   const input = component
     .find(Input)
     .filterWhere(wrapper => wrapper.props().title === inputData.title)
+    .at(index ? index : 0)
+
   input.props().onChange({ currentTarget: { value: inputData.value } } as any)
 }
 


### PR DESCRIPTION
# [PURCHASE-1656] Add phone number field to Address for pickup
https://www.figma.com/file/LieDNuIuKAfhDeEPkjan4p/Checkout-Flow?node-id=0%3A1

This field should be required.

This is a refactor of [this PR](https://github.com/artsy/reaction/compare/master...lilyfromseattle:new_phone_number_field?expand=1) as was suggested in the comments

__Before:__
<img width="536" alt="Screen Shot 2020-01-02 at 11 49 45 AM" src="https://user-images.githubusercontent.com/5643895/71679895-a6f91300-2d56-11ea-809e-52f7a187a913.png">

__After:__
<img width="542" alt="Screen Shot 2020-01-02 at 11 49 30 AM" src="https://user-images.githubusercontent.com/5643895/71679873-9ea0d800-2d56-11ea-8937-465f2dad271f.png">


[PURCHASE-1656]: https://artsyproduct.atlassian.net/browse/PURCHASE-1656