### PR TITLE
@joeyAghion => [Analytics] Correctly trigger pageviews using componentDidUpdate

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -11,11 +11,9 @@ import {
   Footer,
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
-import React, { useEffect } from "react"
+import React from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useTracking } from "react-tracking"
-import { data as sd } from "sharify"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 
 export interface ArtistAppProps {
@@ -27,23 +25,6 @@ export interface ArtistAppProps {
 
 export const ArtistApp: React.FC<ArtistAppProps> = props => {
   const { artist, children } = props
-  const { trackEvent } = useTracking()
-
-  // TODO: Remove after AB test ends.
-  useEffect(() => {
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
-  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -25,7 +25,6 @@ import {
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
 import { TrackingProp } from "react-tracking"
-import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
@@ -46,23 +45,11 @@ export class ArtworkApp extends React.Component<Props> {
   componentDidMount() {
     this.trackPageview()
     this.trackProductView()
-    this.trackABTest() // TODO: Remove after AB test
   }
 
-  trackABTest() {
-    const { tracking } = this.props
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    tracking.trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
+  componentDidUpdate() {
+    this.trackPageview()
+    this.trackProductView()
   }
 
   trackProductView() {

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { Match, Router } from "found"
-import React, { useEffect } from "react"
+import React from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -54,22 +54,6 @@ export const CollectApp = track({
       name: breadcrumbTitle,
     })
   }
-
-  // TODO: Remove after AB test ends.
-  useEffect(() => {
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
-  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -50,23 +50,6 @@ export class CollectionApp extends Component<CollectionAppProps> {
     this.collectionNotFound(this.props.collection)
   }
 
-  // TODO: Remove after AB test ends.
-  componentDidMount() {
-    const { tracking } = this.props
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    tracking.trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
-  }
-
   render() {
     const {
       collection,

--- a/src/Apps/Collect2/Routes/Collections/index.tsx
+++ b/src/Apps/Collect2/Routes/Collections/index.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
 import { Collections_marketingCategories } from "__generated__/Collections_marketingCategories.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { trackPageViewWrapper, withSystemContext } from "Artsy"
-import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "Components/v2/Seo"
 import { Link, Router } from "found"
@@ -26,22 +25,6 @@ const META_DESCRIPTION =
 const isServer = typeof window === "undefined"
 
 export class CollectionsApp extends Component<CollectionsAppProps> {
-  // TODO: Remove after AB Test ends.
-  componentDidMount() {
-    const { tracking } = this.props
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    tracking.trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
-  }
   render() {
     const { marketingCategories, router } = this.props
 

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -15,7 +15,6 @@ import { RouterState, withRouter } from "found"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { TrackingProp } from "react-tracking"
-import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { ZeroState } from "./Components/ZeroState"
 
@@ -37,23 +36,6 @@ const TotalResults: React.SFC<{ count: number; term: string }> = ({
   context_page: Schema.PageName.SearchPage,
 })
 export class SearchApp extends React.Component<Props> {
-  // TODO: Remove after AB test ends.
-  componentDidMount() {
-    const { tracking } = this.props
-    const { CLIENT_NAVIGATION } = sd
-
-    const experiment = "client_navigation"
-    const variation = CLIENT_NAVIGATION
-    tracking.trackEvent({
-      action_type: Schema.ActionType.ExperimentViewed,
-      experiment_id: experiment,
-      experiment_name: experiment,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
-  }
-
   renderResults(count: number, artworkCount: number) {
     const {
       viewer,

--- a/src/Artsy/Analytics/trackPageViewWrapper.tsx
+++ b/src/Artsy/Analytics/trackPageViewWrapper.tsx
@@ -11,6 +11,9 @@ export function trackPageViewWrapper<T>(
     componentDidMount() {
       trackPageView()
     }
+    componentDidUpdate() {
+      trackPageView()
+    }
     render() {
       return <Component {...this.props} />
     }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -24,7 +24,6 @@ import styled from "styled-components"
 import request from "superagent"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 import { SearchInputContainer } from "./SearchInputContainer"
@@ -151,13 +150,6 @@ export class SearchBar extends Component<Props, State> {
         this.trackSearch(term, edges.length > 0)
       }
     )
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.enableExperimentalAppShell =
-      sd.CLIENT_NAVIGATION === "experiment" && getENV("EXPERIMENTAL_APP_SHELL")
   }
 
   componentDidMount() {

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,7 +20,6 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
-      readonly CLIENT_NAVIGATION: string // TODO: remove after AB test
       readonly CMS_URL: string
       readonly ENABLE_PRICE_TRANSPARENCY: string
       readonly FACEBOOK_APP_NAMESPACE: string


### PR DESCRIPTION
First, a brief story about pageview tracking. Initially, this code all lived in Force, and upon page load, would fire. As we moved UI code into Reaction, this was less than ideal since this analytics code still lived in Force, but it was ok. We were doing full page reloads, and everything still worked.

We discovered, when wanting to trigger these while doing client side navigation, that it made sense to move analytics out of Force, and into Reaction. Additionally, since we only want the analytics call to fire on the client, we used `componentDidMount`. This was in https://github.com/artsy/reaction/pull/3067. So far so good, everything was checked and seemed to work fine.

However, consider the case of navigating from an artist page, to a related artist. Or from a collection, to a different collection via a hub rail, etc. All of these are the same route as the previous page, just a different argument. And so, the component doesn't need to be re-mounted, it's already rendered!

We tested navigating from an artist page, to an artwork page, to a different artist page, etc. but we missed checking on our pageview tracking when navigating to the same 'type' of page.

The fix here would be to add the same analytics calls to `componentDidUpdate` as well. This will not fire on the initial render (`componentDidMount` does), yet it will fire on subsequent renders with different props (which would be the case when doing client-side navigation, within the same route).