### PR TITLE
Add "no-switch-case-fall-through" tslint rule

### DIFF
--- a/src/Apps/Collect2/Routes/Collect/Components/CollectMediumMetadata.ts
+++ b/src/Apps/Collect2/Routes/Collect/Components/CollectMediumMetadata.ts
@@ -46,6 +46,7 @@ export function getMetadataForMedium(medium) {
     case "performance-art":
       title = "Performance Art Works"
       mediumDescription = "3,000 performance art works"
+      break
     default:
       null
   }

--- a/tslint.json
+++ b/tslint.json
@@ -17,6 +17,7 @@
     "no-console": false,
     "no-import-un-mocked": true,
     "no-namespace": [true, "allow-declarations"],
+    "no-switch-case-fall-through": true,
     "no-unused-expression": false,
     "no-var-requires": false,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
While working on #3007, I ran into a tricky bug that was a result of accidentally falling through the `case` of a `switch`. It makes sense to me to disallow fall-through, as it has only ever caused me headaches. I'm PR'ing this change instead of making it directly in master, to allow others to speak up against disallowing fall-through.

There was only one place (CollectMediumMetadata) that was taking advantage of fall-through, and it might have been an accident. 