### PR TITLE
Fix artwork grid preloading too many images

### DIFF
--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -117,7 +117,7 @@ export class ArtworkGridContainer extends React.Component<
             artwork={artwork}
             key={artwork.id}
             mediator={this.props.mediator}
-            lazyLoad={i + j >= preloadImageCount}
+            lazyLoad={i * columnCount + j >= preloadImageCount}
             onClick={() => {
               if (this.props.onBrickClick) {
                 this.props.onBrickClick(artwork)

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -108,16 +108,24 @@ export class ArtworkGridContainer extends React.Component<
     }
     const sections = []
 
-    for (let i = 0; i < columnCount; i++) {
+    for (let column = 0; column < columnCount; column++) {
       const artworkComponents = []
-      for (let j = 0; j < sectionedArtworks[i].length; j++) {
-        const artwork = sectionedArtworks[i][j]
+      for (let row = 0; row < sectionedArtworks[column].length; row++) {
+        /**
+         * The position of the image in the grid represented
+         * by counting left to right, top to bottom.
+         *
+         * Here's a stackoverflow explaining the math: https://stackoverflow.com/questions/1730961/convert-a-2d-array-index-into-a-1d-index
+         */
+        const artworkIndex = column * columnCount + row
+
+        const artwork = sectionedArtworks[column][row]
         artworkComponents.push(
           <GridItem
             artwork={artwork}
             key={artwork.id}
             mediator={this.props.mediator}
-            lazyLoad={i * columnCount + j >= preloadImageCount}
+            lazyLoad={artworkIndex >= preloadImageCount}
             onClick={() => {
               if (this.props.onBrickClick) {
                 this.props.onBrickClick(artwork)
@@ -126,9 +134,9 @@ export class ArtworkGridContainer extends React.Component<
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
-        if (j < sectionedArtworks[i].length - 1) {
+        if (row < sectionedArtworks[column].length - 1) {
           artworkComponents.push(
-            <div style={spacerStyle} key={"spacer-" + j + "-" + artwork.id} />
+            <div style={spacerStyle} key={"spacer-" + row + "-" + artwork.id} />
           )
         }
       }
@@ -136,11 +144,11 @@ export class ArtworkGridContainer extends React.Component<
       const sectionSpecificStyle = {
         flex: 1,
         minWidth: 0,
-        marginRight: i === columnCount - 1 ? 0 : this.props.sectionMargin,
+        marginRight: column === columnCount - 1 ? 0 : this.props.sectionMargin,
       }
 
       sections.push(
-        <div style={sectionSpecificStyle} key={i}>
+        <div style={sectionSpecificStyle} key={column}>
           {artworkComponents}
         </div>
       )

--- a/src/Components/ArtworkGrid/__tests__/ArtworkGrid.test.tsx
+++ b/src/Components/ArtworkGrid/__tests__/ArtworkGrid.test.tsx
@@ -6,7 +6,7 @@ import { cloneDeep } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ExtractProps } from "Utils/ExtractProps"
-import { ArtworkGridItem } from "../../Artwork/GridItem"
+import GridItem, { ArtworkGridItem } from "../../Artwork/GridItem"
 import { ArtworkGridFixture } from "../__stories__/ArtworkGridFixture"
 import ArtworkGrid, {
   ArtworkGridContainer,
@@ -197,6 +197,19 @@ describe("ArtworkGrid", () => {
       const wrapper = (await getRelayWrapper(props)).find(ArtworkGridContainer)
       expect(wrapper.text()).toMatch(ArtworkGridFixture.edges[0].node.title)
       expect(wrapper.find(ArtworkGridItem).length).toBe(4)
+    })
+
+    it("Should preload same number of images as specified in preloadImageCount", async () => {
+      const wrapper = await getRelayWrapper({
+        preloadImageCount: 2,
+        columnCount: 2,
+        ...props,
+      })
+      const gridItems = wrapper.find(GridItem)
+      expect(gridItems.get(0).props.lazyLoad).toBeFalsy()
+      expect(gridItems.get(1).props.lazyLoad).toBeFalsy()
+      expect(gridItems.get(2).props.lazyLoad).toBeTruthy()
+      expect(gridItems.get(3).props.lazyLoad).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
In digging more into [PURCHASE-1658](https://artsyproduct.atlassian.net/browse/PURCHASE-1658) I noticed something very strange. Many more images were being  preloaded than what was specified via the top level artwork grid. We usually default to 6, but I was seeing 11 (on mobile). 

Was scratching my head trying to figure out what prop was being passed down improperly, but then I realized I just goofed up the math. 

## Visualization

![ll-example](https://user-images.githubusercontent.com/3087225/71751523-d3418c00-2e49-11ea-9c39-6e0a714f0440.png)


