### PR TITLE
@pepopowitz => [RouterLink] Tweak check to decide whether to route

### DIFF
--- a/src/Artsy/Router/RouterLink.tsx
+++ b/src/Artsy/Router/RouterLink.tsx
@@ -1,6 +1,7 @@
 import { Link, LinkProps, LinkPropsSimple, RouterContext } from "found"
 import { pick } from "lodash"
 import React, { useContext } from "react"
+import { get } from "Utils/get"
 
 /**
  * Wrapper component around found's <Link> component with a fallback to a normal
@@ -14,7 +15,11 @@ import React, { useContext } from "react"
  */
 
 export const RouterLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
-  const isRouterContext = !!useContext(RouterContext)
+  const context = useContext(RouterContext)
+  const routes = get(context, c => c.router.matcher.routeConfig, [])
+  const isSupportedInRouter = !!get(context, c =>
+    c.router.matcher.matchRoutes(routes, to)
+  )
 
   // Only pass found-router specific props across, props that conform to the
   // link API found here: https://github.com/4Catalyzer/found#links
@@ -25,7 +30,7 @@ export const RouterLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
     return acc
   }, [])
 
-  if (isRouterContext) {
+  if (isSupportedInRouter) {
     const allowedProps = pick(props, [
       "Component",
       "activeClassName",

--- a/src/Artsy/Router/__tests__/RouterLink.test.tsx
+++ b/src/Artsy/Router/__tests__/RouterLink.test.tsx
@@ -10,7 +10,7 @@ describe("RouterLink", () => {
       <MockRouter
         routes={[
           {
-            path: "/",
+            path: "/*",
             Component: () => {
               return (
                 <RouterLink to="/foo" {...props}>


### PR DESCRIPTION
We use this component in several collect related places. This enables client-side routing on the collect suite of pages, for instance (since all of those are mounted in the same router), as well as when navigating from a non-collect page, with full client side routing enabled.

However, when navigating from a non-collect page, such as when linked to from a rail on the artist page, and _without_ global client side routing enabled, this component incorrectly checks whether you're in a router context, whereas it should be checking that you're in a router context _and it's a supported route_.

cc @damassi as a sanity check. This should keep all the existing behavior (client-side routing is enabled in collect pages), while restoring the full reload when linked to from outside the collect suite. Additionally, when global client side routing is turned back on, those links from outside that can be routed client-side will be.
