### PR TITLE
Prevent right click on auction results images

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionDetailsModal.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionDetailsModal.tsx
@@ -89,7 +89,7 @@ const LotDetails: SFC<Props> = props => {
         <Spacer mr={2} />
 
         <Box height="auto">
-          <Image width="100px" src={imageUrl} />
+          <Image width="100px" src={imageUrl} preventRightClick />
         </Box>
       </Flex>
 

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -94,7 +94,7 @@ const LargeAuctionItem: SFC<Props> = props => {
           <>
             <Col sm={1}>
               <Box height="auto" pr={2}>
-                <Image width="70px" src={imageUrl} />
+                <Image width="70px" src={imageUrl} preventRightClick />
               </Box>
             </Col>
             <Col sm={4}>
@@ -153,7 +153,7 @@ const SmallAuctionItem: SFC<Props> = props => {
       <Col sm={6}>
         <Flex>
           <Box height="auto">
-            <Image width="70px" src={imageUrl} />
+            <Image width="70px" src={imageUrl} preventRightClick />
           </Box>
 
           <Spacer mr={2} />
@@ -204,7 +204,7 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
       <Col>
         <Flex>
           <Box height="auto">
-            <Image width="70px" src={imageUrl} />
+            <Image width="70px" src={imageUrl} preventRightClick />
           </Box>
 
           <Spacer mr={2} />


### PR DESCRIPTION
We want to prevent users from right-clicking on images in the auction results section of the artist page.