### PR TITLE
Remove react-responsive-media and add fresnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,8 +171,8 @@
   },
   "dependencies": {
     "@artsy/detect-responsive-traits": "^0.0.5",
+    "@artsy/fresnel": "^1.0.13",
     "@artsy/react-html-parser": "^3.0.2",
-    "@artsy/react-responsive-media": "^2.0.0-beta.5",
     "@types/luxon": "^1.15.1",
     "autosuggest-highlight": "^3.1.1",
     "cheerio": "^1.0.0-rc.2",

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="sc-ifAKCX Nav__Title-cd3j7j-1 dlWCPx sc-htpNat gcRkdF"
@@ -50,7 +51,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
     />
   </div>
   <div
-    className="rrm-container rrm-at-xs"
+    className="fresnel-container fresnel-at-xs"
+    suppressHydrationWarning={false}
   >
     <div
       className="sc-bwzfXH FrameText__MobileFrame-sc-8olftt-3 gbUxui"
@@ -79,7 +81,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
     </div>
   </div>
   <div
-    className="rrm-container rrm-greaterThan-xs"
+    className="fresnel-container fresnel-greaterThan-xs"
+    suppressHydrationWarning={false}
   >
     <div
       className="sc-bxivhb FrameText-sc-8olftt-0 FrameText__FrameTextLeft-sc-8olftt-1 jeAhdw sc-htpNat bbRNyO"
@@ -149,7 +152,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
         </div>
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="sc-bxivhb Introduction__HeaderText-acx5fk-0 MoUBM sc-htpNat FZqZl"
@@ -177,7 +181,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
           className="sc-bwzfXH eZcrdQ"
         >
           <div
-            className="rrm-container rrm-greaterThanOrEqual-xl"
+            className="fresnel-container fresnel-greaterThanOrEqual-xl"
+            suppressHydrationWarning={false}
           >
             <h1
               className="sc-ifAKCX Introduction__Title-acx5fk-2 Introduction__LargeTitle-acx5fk-3 dwpeyH sc-htpNat dSCwbf"
@@ -188,7 +193,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             </h1>
           </div>
           <div
-            className="rrm-container rrm-lessThan-xl"
+            className="fresnel-container fresnel-lessThan-xl"
+            suppressHydrationWarning={false}
           >
             <h1
               className="sc-ifAKCX Introduction__Title-acx5fk-2 fpoUpA sc-htpNat XcbTY"
@@ -751,7 +757,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -762,7 +769,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -1174,7 +1182,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -1185,7 +1194,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -1597,7 +1607,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -1608,7 +1619,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -2020,7 +2032,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -2031,7 +2044,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -2415,7 +2429,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -2426,7 +2441,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -2838,7 +2854,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -2849,7 +2866,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -3233,7 +3251,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -3244,7 +3263,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -3656,7 +3676,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -3667,7 +3688,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -4079,7 +4101,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -4090,7 +4113,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -4502,7 +4526,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -4513,7 +4538,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -4897,7 +4923,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -4908,7 +4935,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -5292,7 +5320,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -5303,7 +5332,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -5715,7 +5745,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -5726,7 +5757,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -6138,7 +6170,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -6149,7 +6182,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -6533,7 +6567,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -6544,7 +6579,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -6928,7 +6964,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -6939,7 +6976,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -7351,7 +7389,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -7362,7 +7401,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -7746,7 +7786,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -7757,7 +7798,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -8169,7 +8211,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -8180,7 +8223,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -8564,7 +8608,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -8575,7 +8620,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -9130,7 +9176,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -9141,7 +9188,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -9553,7 +9601,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -9564,7 +9613,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -9976,7 +10026,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -9987,7 +10038,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -10371,7 +10423,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -10382,7 +10435,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -10766,7 +10820,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -10777,7 +10832,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -11189,7 +11245,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -11200,7 +11257,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -11584,7 +11642,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -11595,7 +11654,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -12007,7 +12067,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -12018,7 +12079,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -12402,7 +12464,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -12413,7 +12476,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -12825,7 +12889,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -12836,7 +12901,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -13220,7 +13286,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -13231,7 +13298,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -13643,7 +13711,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -13654,7 +13723,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -14066,7 +14136,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -14077,7 +14148,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -14489,7 +14561,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -14500,7 +14573,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -14884,7 +14958,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -14895,7 +14970,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -15450,7 +15526,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -15461,7 +15538,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -15845,7 +15923,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -15856,7 +15935,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -16268,7 +16348,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -16279,7 +16360,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -16691,7 +16773,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -16702,7 +16785,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -17086,7 +17170,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -17097,7 +17182,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -17481,7 +17567,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -17492,7 +17579,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -17876,7 +17964,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -17887,7 +17976,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -18271,7 +18361,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -18282,7 +18373,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -18694,7 +18786,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -18705,7 +18798,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -19117,7 +19211,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -19128,7 +19223,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -19512,7 +19608,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -19523,7 +19620,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -19935,7 +20033,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -19946,7 +20045,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -20358,7 +20458,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -20369,7 +20470,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -20781,7 +20883,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -20792,7 +20895,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"
@@ -21176,7 +21280,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="sc-bdVaJa jTeONE"
           >
             <div
-              className="rrm-container rrm-greaterThanOrEqual-xl"
+              className="fresnel-container fresnel-greaterThanOrEqual-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 ArtistWrapper__ArtistTitle-sc-1bsuwlh-2 czHZFM sc-htpNat bMBRul"
@@ -21187,7 +21292,8 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
               </h3>
             </div>
             <div
-              className="rrm-container rrm-lessThan-xl"
+              className="fresnel-container fresnel-lessThan-xl"
+              suppressHydrationWarning={false}
             >
               <h3
                 className="sc-ifAKCX ArtistWrapper__InvertedSerif-sc-1bsuwlh-0 jeUPk sc-htpNat gbAHCR"

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -2087,7 +2087,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c6 c7"
@@ -2126,14 +2127,16 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
       className="c10"
     >
       <div
-        className="rrm-container rrm-at-xs"
+        className="fresnel-container fresnel-at-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c11"
         />
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c11"
@@ -2153,7 +2156,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           Influential 
         </span>
         <div
-          className="rrm-container rrm-lessThan-md"
+          className="fresnel-container fresnel-lessThan-md"
+          suppressHydrationWarning={false}
         >
           <span
             className="c13"
@@ -2162,7 +2166,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           </span>
         </div>
         <div
-          className="rrm-container rrm-lessThan-md"
+          className="fresnel-container fresnel-lessThan-md"
+          suppressHydrationWarning={false}
         >
           <span
             className="c14"
@@ -2171,7 +2176,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
           </span>
         </div>
         <div
-          className="rrm-container rrm-greaterThan-sm"
+          className="fresnel-container fresnel-greaterThan-sm"
+          suppressHydrationWarning={false}
         >
           <span
             className="c13"
@@ -2451,7 +2457,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -2652,7 +2659,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -2853,7 +2861,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -3054,7 +3063,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -3255,7 +3265,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -3456,7 +3467,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -3657,7 +3669,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -3858,7 +3871,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -4059,7 +4073,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -4260,7 +4275,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -4461,7 +4477,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -4662,7 +4679,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -4863,7 +4881,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -5064,7 +5083,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -5265,7 +5285,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -5466,7 +5487,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -5667,7 +5689,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -5868,7 +5891,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -6069,7 +6093,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -6270,7 +6295,8 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-sm"
+                className="fresnel-container fresnel-greaterThanOrEqual-sm"
+                suppressHydrationWarning={false}
               >
                 <div
                   className="c48"
@@ -8011,7 +8037,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c6 c7"
@@ -8457,7 +8484,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -8755,7 +8783,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -9053,7 +9082,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -9351,7 +9381,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -9649,7 +9680,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -9947,7 +9979,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -10245,7 +10278,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -10734,7 +10768,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -11223,7 +11258,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -11715,7 +11751,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -12210,7 +12247,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -12508,7 +12546,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -12806,7 +12845,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -13295,7 +13335,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -13593,7 +13634,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -13891,7 +13933,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -14380,7 +14423,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -14678,7 +14722,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"
@@ -14976,7 +15021,8 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              className="rrm-container rrm-greaterThanOrEqual-sm"
+              className="fresnel-container fresnel-greaterThanOrEqual-sm"
+              suppressHydrationWarning={false}
             >
               <div
                 className="c56"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1094,7 +1094,8 @@ exports[`series layout renders a series 1`] = `
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c5 c6"
@@ -1537,7 +1538,8 @@ exports[`series layout renders a series 1`] = `
             </div>
           </div>
           <div
-            className="rrm-container rrm-greaterThanOrEqual-md"
+            className="fresnel-container fresnel-greaterThanOrEqual-md"
+            suppressHydrationWarning={false}
           />
         </div>
         <div
@@ -1568,7 +1570,8 @@ exports[`series layout renders a series 1`] = `
             </div>
           </div>
           <div
-            className="rrm-container rrm-lessThan-md"
+            className="fresnel-container fresnel-lessThan-md"
+            suppressHydrationWarning={false}
           />
         </div>
       </div>
@@ -2793,7 +2796,8 @@ exports[`series layout renders a sponsored series 1`] = `
         </a>
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c7 c8"
@@ -3258,7 +3262,8 @@ exports[`series layout renders a sponsored series 1`] = `
             </div>
           </div>
           <div
-            className="rrm-container rrm-greaterThanOrEqual-md"
+            className="fresnel-container fresnel-greaterThanOrEqual-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c46"
@@ -3316,7 +3321,8 @@ exports[`series layout renders a sponsored series 1`] = `
             </div>
           </div>
           <div
-            className="rrm-container rrm-lessThan-md"
+            className="fresnel-container fresnel-lessThan-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c49"

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1020,7 +1020,8 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c6 c7"
@@ -1342,7 +1343,8 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
             />
           </div>
           <div
-            className="rrm-container rrm-greaterThanOrEqual-md"
+            className="fresnel-container fresnel-greaterThanOrEqual-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c47"
@@ -1496,7 +1498,8 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
             />
           </div>
           <div
-            className="rrm-container rrm-lessThan-md"
+            className="fresnel-container fresnel-lessThan-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c47"
@@ -3248,7 +3251,8 @@ exports[`Video Layout matches the snapshot 1`] = `
         
       </div>
       <div
-        className="rrm-container rrm-greaterThan-xs"
+        className="fresnel-container fresnel-greaterThan-xs"
+        suppressHydrationWarning={false}
       >
         <div
           className="c6 c7"
@@ -3574,7 +3578,8 @@ exports[`Video Layout matches the snapshot 1`] = `
             />
           </div>
           <div
-            className="rrm-container rrm-greaterThanOrEqual-md"
+            className="fresnel-container fresnel-greaterThanOrEqual-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c47"
@@ -3728,7 +3733,8 @@ exports[`Video Layout matches the snapshot 1`] = `
             />
           </div>
           <div
-            className="rrm-container rrm-lessThan-md"
+            className="fresnel-container fresnel-lessThan-md"
+            suppressHydrationWarning={false}
           >
             <div
               className="c47"
@@ -4264,7 +4270,8 @@ exports[`Video Layout matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-greaterThanOrEqual-md"
+                className="fresnel-container fresnel-greaterThanOrEqual-md"
+                suppressHydrationWarning={false}
               />
             </div>
             <div
@@ -4295,7 +4302,8 @@ exports[`Video Layout matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="rrm-container rrm-lessThan-md"
+                className="fresnel-container fresnel-lessThan-md"
+                suppressHydrationWarning={false}
               />
             </div>
           </div>

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -128,7 +128,8 @@ exports[`Nav renders a Nav 1`] = `
       
     </div>
     <div
-      className="rrm-container rrm-greaterThan-xs"
+      className="fresnel-container fresnel-greaterThan-xs"
+      suppressHydrationWarning={false}
     >
       <div
         className="c4 c5"
@@ -343,7 +344,8 @@ exports[`Nav renders a sponsored nav 1`] = `
       </a>
     </div>
     <div
-      className="rrm-container rrm-greaterThan-xs"
+      className="fresnel-container fresnel-greaterThan-xs"
+      suppressHydrationWarning={false}
     >
       <div
         className="c6 c7"
@@ -504,7 +506,8 @@ exports[`Nav renders a transparent nav 1`] = `
       
     </div>
     <div
-      className="rrm-container rrm-greaterThan-xs"
+      className="fresnel-container fresnel-greaterThan-xs"
+      suppressHydrationWarning={false}
     >
       <div
         className="c4 c5"

--- a/src/Components/Publishing/Sections/ImageSetPreview/__tests__/__snapshots__/ImageSetPreview.test.tsx.snap
+++ b/src/Components/Publishing/Sections/ImageSetPreview/__tests__/__snapshots__/ImageSetPreview.test.tsx.snap
@@ -206,7 +206,8 @@ exports[`renders a full image set properly 1`] = `
         </div>
       </div>
       <div
-        className="rrm-container rrm-greaterThanOrEqual-sm"
+        className="fresnel-container fresnel-greaterThanOrEqual-sm"
+        suppressHydrationWarning={false}
       >
         <div
           className="c8"
@@ -454,7 +455,8 @@ exports[`renders a mini image set properly 1`] = `
         </div>
       </div>
       <div
-        className="rrm-container rrm-greaterThanOrEqual-sm"
+        className="fresnel-container fresnel-greaterThanOrEqual-sm"
+        suppressHydrationWarning={false}
       >
         <div
           className="c10"

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -2137,7 +2137,8 @@ exports[`Sections snapshots tests renders properly 1`] = `
             </div>
           </div>
           <div
-            className="rrm-container rrm-greaterThanOrEqual-sm"
+            className="fresnel-container fresnel-greaterThanOrEqual-sm"
+            suppressHydrationWarning={false}
           >
             <div
               className="c36"

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -547,7 +547,8 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     />
   </div>
   <div
@@ -578,7 +579,8 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -1131,7 +1133,8 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     />
   </div>
   <div
@@ -1155,7 +1158,8 @@ exports[`SeriesAbout snapshots Renders with editDescription 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -1711,7 +1715,8 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     />
   </div>
   <div
@@ -1742,7 +1747,8 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     />
   </div>
 </div>
@@ -2331,7 +2337,8 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c6"
@@ -2389,7 +2396,8 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c12"

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -465,7 +465,8 @@ exports[`Video About matches the snapshot 1`] = `
       />
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c5"
@@ -619,7 +620,8 @@ exports[`Video About matches the snapshot 1`] = `
       />
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c5"
@@ -1206,7 +1208,8 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-greaterThanOrEqual-md"
+      className="fresnel-container fresnel-greaterThanOrEqual-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c5"
@@ -1357,7 +1360,8 @@ exports[`Video About matches the snapshot with editable props 1`] = `
       </div>
     </div>
     <div
-      className="rrm-container rrm-lessThan-md"
+      className="fresnel-container fresnel-lessThan-md"
+      suppressHydrationWarning={false}
     >
       <div
         className="c5"

--- a/src/Utils/Responsive/DeprecatedResponsive.tsx
+++ b/src/Utils/Responsive/DeprecatedResponsive.tsx
@@ -1,9 +1,9 @@
-import { themeProps } from "@artsy/palette"
 import {
   createResponsiveComponents,
   MediaQueryMatches,
   ResponsiveProviderProps as _ResponsiveProviderProps,
-} from "@artsy/react-responsive-media/dist/DynamicResponsive"
+} from "@artsy/fresnel/dist/DynamicResponsive"
+import { themeProps } from "@artsy/palette"
 import React from "react"
 import * as sharify from "sharify"
 

--- a/src/Utils/Responsive/index.tsx
+++ b/src/Utils/Responsive/index.tsx
@@ -1,5 +1,5 @@
 export * from "./DeprecatedResponsive"
-import { createMedia } from "@artsy/react-responsive-media"
+import { createMedia } from "@artsy/fresnel"
 
 // TODO: We need this to be 0-based, whereas currently in palette xs is defined
 //       as 767. We should move this up to palette, but we need to give the

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.0.5.tgz#abf85959f8567816babec6f582b744f58c98b726"
   integrity sha512-axgW5YuqSpPzHb27yo2jmPHz/N9eN2hh2E+Mub5BKuu/jHZI+iDTdw0OZ3I+z7Z9WKBh+FPVx4gpza5w7slJNA==
 
+"@artsy/fresnel@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-1.0.13.tgz#4bbbda274e74e0d63b471a36d72360d33d571598"
+  integrity sha512-Gg/43i30aIqkryVE6eLhNe4j9G1fk41qIJqYfj/b+mv3bYCl8H9HSaedcM7exuh0RlexZGLMD2aYnugiobrpxQ==
+
 "@artsy/palette@5.1.13":
   version "5.1.13"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-5.1.13.tgz#1f7c055d2d1fea074b00a409811680fae48785de"
@@ -34,11 +39,6 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
-
-"@artsy/react-responsive-media@^2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
-  integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
 "@babel/cli@7.0.0":
   version "7.0.0"


### PR DESCRIPTION
Turns out reaction was still using react-responsive-media! Whoops. This updates it to use fresnel (which is the same library, just renamed).