### PR TITLE
Only render one breakpoint for mobile googlebot

### DIFF
--- a/src/Artsy/Router/Utils/matchingMediaQueriesForUserAgent.ts
+++ b/src/Artsy/Router/Utils/matchingMediaQueriesForUserAgent.ts
@@ -11,6 +11,12 @@ import {
 export function matchingMediaQueriesForUserAgent(
   userAgent: string
 ): MatchingMediaQueries {
+  // Only return xs breakpoint for mobile googlebot
+  const ua = userAgent.toLowerCase()
+  if (ua.includes("googlebot") && ua.includes("mobile")) {
+    return ["notHover", "xs"]
+  }
+
   const device = findDevice(userAgent)
   if (!device) {
     return undefined


### PR DESCRIPTION
Fixes [PURCHASE-1712](https://artsyproduct.atlassian.net/browse/PURCHASE-1712).

This updates our device detection to check for googlebot's UA. If the mobile UA is present it only sends one breakpoint down the wire.

It's only detecting mobile because we've been switched over to mobile first indexing by Google. Also, the UA isn't _exact_ so there's potential that some device or service that's spoofing or using a partial of Google's UA gets swept up in this. We have access to what the full UA would be [here](https://support.google.com/webmasters/answer/1061943?hl=en). 

I'm fine with it being loose, but I'm interested to hear other's thoughts. 