### PR TITLE
@damassi => [PageView Tracking] Correct for over-tracking on tabbed routes

### DIFF
--- a/src/Apps/Artist/Components/NavigationTabs.tsx
+++ b/src/Apps/Artist/Components/NavigationTabs.tsx
@@ -1,7 +1,7 @@
 import { Flex } from "@artsy/palette"
 import { NavigationTabs_artist } from "__generated__/NavigationTabs_artist.graphql"
 import { SystemContextProps, withSystemContext } from "Artsy"
-import { track } from "Artsy/Analytics"
+import { track, trackPageView } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RouteTab, RouteTabs } from "Components/v2"
 import React from "react"
@@ -21,7 +21,7 @@ export class NavigationTabs extends React.Component<Props> {
     destination_path,
   }))
   handleClick(tab: string, destination_path: string) {
-    // no-op
+    trackPageView({ path: destination_path })
   }
 
   renderTab(
@@ -29,19 +29,15 @@ export class NavigationTabs extends React.Component<Props> {
     to: string,
     options: {
       exact?: boolean
-      mediator: {
-        trigger: (action: string, config: object) => void
-      }
-    }
+    } = {}
   ) {
-    const { exact, mediator } = options
+    const { exact } = options
 
     return (
       <RouteTab
         to={to}
         exact={exact}
         onClick={() => {
-          mediator && mediator.trigger("artist:tabclick", { to })
           this.handleClick(text, to)
         }}
       >
@@ -53,7 +49,6 @@ export class NavigationTabs extends React.Component<Props> {
   renderTabs() {
     const {
       artist: { slug, statuses },
-      mediator,
     } = this.props
 
     const route = path => `/artist/${slug}${path}`
@@ -62,19 +57,12 @@ export class NavigationTabs extends React.Component<Props> {
       <>
         {this.renderTab("Overview", route(""), {
           exact: true,
-          mediator,
         })}
-        {statuses.cv && this.renderTab("CV", route("/cv"), { mediator })}
-        {statuses.articles &&
-          this.renderTab("Articles", route("/articles"), {
-            mediator,
-          })}
-        {statuses.shows &&
-          this.renderTab("Shows", route("/shows"), { mediator })}
+        {statuses.cv && this.renderTab("CV", route("/cv"))}
+        {statuses.articles && this.renderTab("Articles", route("/articles"))}
+        {statuses.shows && this.renderTab("Shows", route("/shows"))}
         {statuses.auction_lots &&
-          this.renderTab("Auction results", route("/auction-results"), {
-            mediator,
-          })}
+          this.renderTab("Auction results", route("/auction-results"))}
       </>
     )
   }

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -47,11 +47,6 @@ export class ArtworkApp extends React.Component<Props> {
     this.trackProductView()
   }
 
-  componentDidUpdate() {
-    this.trackPageview()
-    this.trackProductView()
-  }
-
   trackProductView() {
     const {
       tracking,

--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -1,6 +1,6 @@
 import { Flex, Sans } from "@artsy/palette"
 import { NavigationTabs_searchableConnection } from "__generated__/NavigationTabs_searchableConnection.graphql"
-import { track } from "Artsy/Analytics"
+import { track, trackPageView } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RouteTab, TabCarousel } from "Components/v2"
 import React from "react"
@@ -38,7 +38,7 @@ export class NavigationTabs extends React.Component<Props> {
     destination_path,
   }))
   trackClick(tab: string, destination_path: string) {
-    // no-op
+    trackPageView({ path: destination_path })
   }
 
   shouldComponentUpdate = prevProps => {

--- a/src/Artsy/Analytics/trackPageView.ts
+++ b/src/Artsy/Analytics/trackPageView.ts
@@ -1,9 +1,10 @@
 declare const window: any
 
-export function trackPageView(): void {
+export function trackPageView(options: { path?: string } = {}): void {
+  const { path } = options
   if (typeof window.analytics !== "undefined") {
     window.analytics.page(
-      { path: window.location.pathname },
+      { path: path || window.location.pathname },
       { integrations: { Marketo: false } }
     )
     // Reset timers that track time on page since we're tracking each order

--- a/src/Artsy/Analytics/trackPageViewWrapper.tsx
+++ b/src/Artsy/Analytics/trackPageViewWrapper.tsx
@@ -11,9 +11,6 @@ export function trackPageViewWrapper<T>(
     componentDidMount() {
       trackPageView()
     }
-    componentDidUpdate() {
-      trackPageView()
-    }
     render() {
       return <Component {...this.props} />
     }

--- a/src/Artsy/Router/__tests__/RouterLink.test.tsx
+++ b/src/Artsy/Router/__tests__/RouterLink.test.tsx
@@ -4,10 +4,17 @@ import { Link } from "found"
 import React from "react"
 import { RouterLink } from "../RouterLink"
 
+jest.mock("Artsy/Analytics/trackPageView", () => ({
+  trackPageView: jest.fn(),
+}))
+const mockTrackPageView = require("Artsy/Analytics/trackPageView")
+  .trackPageView as jest.Mock
+
 describe("RouterLink", () => {
-  const getWrapper = async (props = {}) => {
+  const getWrapper = async (props: any = {}) => {
     return await mount(
       <MockRouter
+        initialRoute={props.initialRoute}
         routes={[
           {
             path: "/*",
@@ -30,6 +37,10 @@ describe("RouterLink", () => {
     })
   }
 
+  beforeEach(() => {
+    mockTrackPageView.mockClear()
+  })
+
   it("uses the <Link> component if within a router context", async () => {
     const wrapper = await getWrapper()
     expect(wrapper.find(Link).length).toEqual(1)
@@ -44,5 +55,25 @@ describe("RouterLink", () => {
   it("prunes invalid props from being passed to dom", async () => {
     const wrapper = await getWrapper({ hey: true, you: true })
     expect(Object.keys(wrapper.find("a").props())).not.toContain(["hey", "you"])
+  })
+
+  it("tracks a pageview and calls onclick when navigating to the same page type", async () => {
+    const onClick = jest.fn()
+    const wrapper = await getWrapper({
+      onClick,
+      initialRoute: "/foo/23",
+      to: "/foo/45",
+    })
+    wrapper.find("a").simulate("click")
+    expect(mockTrackPageView).toHaveBeenCalledTimes(1)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("doesnt track a pageview and calls onclick when navigating to a different page type", async () => {
+    const onClick = jest.fn()
+    const wrapper = await getWrapper({ onClick })
+    wrapper.find("a").simulate("click")
+    expect(mockTrackPageView).not.toHaveBeenCalled()
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
You called it in https://github.com/artsy/reaction/pull/3076#discussion_r362671969 .

This wound up overtriggering on tabbed pages.

This additional tweaked check seemed to work as desired in my local testing, but now I'm wondering if we should revert this approach entirely (and leave things on `componentDidMount`).

That would definitely remove over-triggering, but it puts us back in the position we were for the A/B test, where we were dropping all those subsequent calls. My gut tells me we have to get these lifecycle/hook calls correct in order to capture all those analytics properly.