### PR TITLE
Add `data-test` attribute to Order code so we can use it in integrity

### DIFF
--- a/src/Apps/Order/Routes/Status/index.tsx
+++ b/src/Apps/Order/Routes/Status/index.tsx
@@ -246,7 +246,7 @@ export class StatusRoute extends Component<StatusProps> {
             {title}
           </Serif>
           <Sans size="2" weight="regular" color="black60" mb={[2, 3]}>
-            {flowName} #{order.code}
+            {flowName} <span data-test="OrderCode">#{order.code}</span>
           </Sans>
           <TwoColumnLayout
             Content={


### PR DESCRIPTION
# Problem
We want to be able to find the newly created order's `code` in Integrity so we can test proper emails.

# Solution
Wrap code around a `span` and add `data-test` for it so we can find this element in the UI during integrity.