### PR TITLE
Reset pagination on artwork filter updates

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -256,7 +256,9 @@ const artworkFilterReducer = (
     case "SET": {
       const { name, value } = action.payload
 
-      let filterState: ArtworkFilters = {}
+      let filterState: ArtworkFilters = {
+        page: 1,
+      }
 
       if (name === "majorPeriods") {
         filterState = {
@@ -311,7 +313,9 @@ const artworkFilterReducer = (
     case "UNSET": {
       const { name } = action.payload as { name: keyof ArtworkFilters }
 
-      let filterState: ArtworkFilters = {}
+      let filterState: ArtworkFilters = {
+        page: 1,
+      }
 
       if (name === "majorPeriods") {
         filterState = {

--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
@@ -86,6 +86,22 @@ describe("ArtworkFilterContext", () => {
       })
     })
 
+    it("#setFilter resets pagination", done => {
+      getWrapper({
+        filters: {
+          page: 10,
+        },
+      })
+      act(() => {
+        expect(context.filters.page).toEqual(10)
+        context.setFilter("sort", "relevant")
+        setTimeout(() => {
+          expect(context.filters.page).toEqual(1)
+          done()
+        })
+      })
+    })
+
     it("#unsetFilter", done => {
       getWrapper()
       act(() => {
@@ -99,6 +115,23 @@ describe("ArtworkFilterContext", () => {
               done()
             })
           })
+        })
+      })
+    })
+
+    it("#unsetFilter resets pagination", done => {
+      getWrapper({
+        filters: {
+          page: 10,
+          sort: "relevant",
+        },
+      })
+      act(() => {
+        expect(context.filters.page).toEqual(10)
+        context.unsetFilter("sort", "relevant")
+        setTimeout(() => {
+          expect(context.filters.page).toEqual(1)
+          done()
         })
       })
     })

--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterContext.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "../ArtworkFilterContext"
 
 describe("ArtworkFilterContext", () => {
-  let context
+  let context: ReturnType<typeof useArtworkFilterContext>
 
   const getWrapper = (props = {}) => {
     return mount(
@@ -38,7 +38,7 @@ describe("ArtworkFilterContext", () => {
     it("#onArtworkBrickClick", () => {
       const spy = jest.fn()
       getWrapper({ onArtworkBrickClick: spy })
-      context.onArtworkBrickClick()
+      context.onArtworkBrickClick(null, null)
       expect(spy).toHaveBeenCalled()
     })
 
@@ -109,7 +109,7 @@ describe("ArtworkFilterContext", () => {
         setTimeout(() => {
           expect(context.filters.page).toEqual(10)
           act(() => {
-            context.unsetFilter("page", 10)
+            context.unsetFilter("page")
             setTimeout(() => {
               expect(context.filters.page).toEqual(1)
               done()
@@ -128,7 +128,7 @@ describe("ArtworkFilterContext", () => {
       })
       act(() => {
         expect(context.filters.page).toEqual(10)
-        context.unsetFilter("sort", "relevant")
+        context.unsetFilter("sort")
         setTimeout(() => {
           expect(context.filters.page).toEqual(1)
           done()


### PR DESCRIPTION
Fixes [1692](https://artsyproduct.atlassian.net/browse/PURCHASE-1692)

If a user paginates in the artwork grid then applies a filter it preserved the paginated state and could sometimes show no results. This update resets the pagination whenever a filter is set or unset. 