### PR TITLE
@damassi => [PageView Tracking] Ensure pageviews are counted for navigation in the same page type

### DIFF
--- a/src/Artsy/Router/makeAppRoutes.tsx
+++ b/src/Artsy/Router/makeAppRoutes.tsx
@@ -1,8 +1,9 @@
-import { RouteConfig } from "found"
+import { RouteConfig, withRouter } from "found"
 import { flatten } from "lodash"
 import React, { useEffect } from "react"
 
 import { AppShell } from "Apps/Components/AppShell"
+import { trackPageView } from "Artsy"
 import { useSystemContext } from "Artsy/SystemContext"
 import { catchLinks } from "Utils/catchLinks"
 
@@ -44,39 +45,50 @@ export function makeAppRoutes(routeList: RouteList[]): RouteConfig[] {
     createRouteConfiguration
   )
 
+  const Component = props => {
+    const { router, setRouter } = useSystemContext()
+    // Store global reference to router instance
+    useEffect(() => {
+      if (props.router !== router) {
+        setRouter(props.router)
+      }
+
+      /**
+       * Intercept <a> tags on page and if contained within router route
+       * manifest, navigate via router versus doing a hard jump between pages.
+       */
+      catchLinks(window, href => {
+        const url = ROUTE_NAMESPACE + href
+        const foundUrl = props.router.matcher.matchRoutes(routes, url)
+        // Make sure to track pageviews when staying on the same page type.
+        // Collection pages link to each other using `RouterLink` which already
+        // handles this, so just in case avoid double triggering.
+        if (foundUrl) {
+          const toPath = url.toString()
+          // TODO: Figure out why the router prop is stale.
+          // const currentPageType = props.match.location.pathname.split("/")[1]
+          const currentPageType = window.location.pathname.split("/")[1]
+          const toPageType = toPath.split("/")[1]
+          if (currentPageType === toPageType && toPageType !== "collection") {
+            trackPageView({ path: toPath })
+          }
+          props.router.push(url)
+        } else {
+          window.location.assign(url)
+        }
+      })
+    }, [])
+
+    return <AppShell {...props} />
+  }
+
   // Return a top-level "meta" route containing all global sub-routes, which is
   // then mounted into the router.
   return [
     {
       path: ROUTE_NAMESPACE,
 
-      Component: props => {
-        const { router, setRouter } = useSystemContext()
-
-        // Store global reference to router instance
-        useEffect(() => {
-          if (props.router !== router) {
-            setRouter(props.router)
-          }
-
-          /**
-           * Intercept <a> tags on page and if contained within router route
-           * manifest, navigate via router versus doing a hard jump between pages.
-           */
-          catchLinks(window, href => {
-            const url = ROUTE_NAMESPACE + href
-            const foundUrl = props.router.matcher.matchRoutes(routes, url)
-
-            if (foundUrl) {
-              props.router.push(url)
-            } else {
-              window.location.assign(url)
-            }
-          })
-        }, [])
-
-        return <AppShell {...props} />
-      },
+      Component: withRouter(Component),
       children: routes,
     },
   ]


### PR DESCRIPTION
This is a companion to https://github.com/artsy/reaction/pull/3086 , specifically the changes made in [`RouterLink`](https://github.com/artsy/reaction/blob/1ca5ca626cd744a07ff08426406187b7a0e15b1a/src/Artsy/Router/RouterLink.tsx#L51). Those were made to accommodate collection pages linking among themselves.

So, we still had the same issue that plagued our initial AB test. Namely, clicking on an artwork from an artwork page, keeps you in the same app, and we don't fire that subsequent pageview.

So this updates our global link interception to do the same thing we did in `RouterLink` for pageview tracking.

There's one sketchy thing, which I'll comment on in-line.