### PR TITLE
@joeyAghion => [Client Side Routing] Reenable AB test

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -4,16 +4,17 @@ import { ArtistMetaFragmentContainer as ArtistMeta } from "Apps/Artist/Component
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Artist/Components/NavigationTabs"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { trackPageViewWrapper } from "Artsy"
+import { trackPageViewWrapper, useTracking } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import {
   Footer,
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
-import React from "react"
+import React, { useEffect } from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
+import { data as sd } from "sharify"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 
 export interface ArtistAppProps {
@@ -25,6 +26,24 @@ export interface ArtistAppProps {
 
 export const ArtistApp: React.FC<ArtistAppProps> = props => {
   const { artist, children } = props
+
+  const { trackEvent } = useTracking()
+
+  // TODO: Remove after AB test ends.
+  useEffect(() => {
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -25,6 +25,7 @@ import {
   RecentlyViewedQueryRenderer as RecentlyViewed,
 } from "Components/v2"
 import { TrackingProp } from "react-tracking"
+import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
@@ -45,6 +46,24 @@ export class ArtworkApp extends React.Component<Props> {
   componentDidMount() {
     this.trackPageview()
     this.trackProductView()
+    this.trackABTest()
+  }
+
+  // TODO: Remove after AB test ends.
+  trackABTest() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
   }
 
   trackProductView() {

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator, Serif, Spacer } from "@artsy/palette"
 import { Match, Router } from "found"
-import React from "react"
+import React, { useEffect } from "react"
 import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
@@ -54,6 +54,22 @@ export const CollectApp = track({
       name: breadcrumbTitle,
     })
   }
+
+  // TODO: Remove after AB test ends.
+  useEffect(() => {
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }, [])
 
   return (
     <AppContainer>

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -51,6 +51,23 @@ export class CollectionApp extends Component<CollectionAppProps> {
     this.collectionNotFound(this.props.collection)
   }
 
+  // TODO: Remove after AB test ends.
+  componentDidMount() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
+
   render() {
     const {
       collection,

--- a/src/Apps/Collect2/Routes/Collections/index.tsx
+++ b/src/Apps/Collect2/Routes/Collections/index.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
 import { Collections_marketingCategories } from "__generated__/Collections_marketingCategories.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { trackPageViewWrapper, withSystemContext } from "Artsy"
+import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "Components/v2/Seo"
 import { Link, Router } from "found"
@@ -25,6 +26,23 @@ const META_DESCRIPTION =
 const isServer = typeof window === "undefined"
 
 export class CollectionsApp extends Component<CollectionsAppProps> {
+  // TODO: Remove after AB Test ends.
+  componentDidMount() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
+
   render() {
     const { marketingCategories, router } = this.props
 

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -15,6 +15,7 @@ import { RouterState, withRouter } from "found"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { TrackingProp } from "react-tracking"
+import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { ZeroState } from "./Components/ZeroState"
 
@@ -36,6 +37,23 @@ const TotalResults: React.SFC<{ count: number; term: string }> = ({
   context_page: Schema.PageName.SearchPage,
 })
 export class SearchApp extends React.Component<Props> {
+  // TODO: Remove after AB test ends.
+  componentDidMount() {
+    const { tracking } = this.props
+    const { CLIENT_NAVIGATION_V2 } = sd
+
+    const experiment = "client_navigation_v2"
+    const variation = CLIENT_NAVIGATION_V2
+    tracking.trackEvent({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: experiment,
+      experiment_name: experiment,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
+
   renderResults(count: number, artworkCount: number) {
     const {
       viewer,

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -24,6 +24,7 @@ import styled from "styled-components"
 import request from "superagent"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
+import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 import { SearchInputContainer } from "./SearchInputContainer"
@@ -150,6 +151,14 @@ export class SearchBar extends Component<Props, State> {
         this.trackSearch(term, edges.length > 0)
       }
     )
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.enableExperimentalAppShell =
+      sd.CLIENT_NAVIGATION_V2 === "experiment" &&
+      getENV("EXPERIMENTAL_APP_SHELL")
   }
 
   componentDidMount() {

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,6 +20,7 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
+      readonly CLIENT_NAVIGATION_V2: string // TODO: Remove after AB test.
       readonly CMS_URL: string
       readonly ENABLE_PRICE_TRANSPARENCY: string
       readonly FACEBOOK_APP_NAMESPACE: string


### PR DESCRIPTION
This is a draft until the NAV AB test is closed. This relaunches the test w/ experiment viewed events under a new test name. The analytics around pageview tracking should hopefully be resolved 🤞 .

Take 53!