### PR TITLE
MX-104 - Fix double capitalized letters in iOS inputs

### DIFF
--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -94,6 +94,7 @@ export class AddressForm extends React.Component<
 
   render() {
     const lockCountryToOrigin = !this.props.billing && this.props.domesticOnly
+
     return (
       <Join separator={<Spacer mb={2} />}>
         <Flex flexDirection="column">
@@ -101,7 +102,6 @@ export class AddressForm extends React.Component<
             id="AddressForm_name"
             placeholder="Add full name"
             title={this.props.billing ? "Name on card" : "Full name"}
-            autoCapitalize="words"
             autoCorrect="off"
             value={this.props.value.name}
             onChange={this.changeEventHandler("name")}
@@ -154,7 +154,6 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine1"
               placeholder="Add street address"
               title="Address line 1"
-              autoCapitalize="words"
               value={this.props.value.addressLine1}
               onChange={this.changeEventHandler("addressLine1")}
               error={this.getError("addressLine1")}
@@ -167,7 +166,6 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine2"
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
-              autoCapitalize="words"
               value={this.props.value.addressLine2}
               onChange={this.changeEventHandler("addressLine2")}
               error={this.getError("addressLine2")}
@@ -181,7 +179,6 @@ export class AddressForm extends React.Component<
               id="AddressForm_city"
               placeholder="Add city"
               title="City"
-              autoCapitalize="words"
               value={this.props.value.city}
               onChange={this.changeEventHandler("city")}
               error={this.getError("city")}
@@ -194,7 +191,6 @@ export class AddressForm extends React.Component<
               id="AddressForm_region"
               placeholder="Add State, province, or region"
               title="State, province, or region"
-              autoCapitalize="words"
               autoCorrect="off"
               value={this.props.value.region}
               onChange={this.changeEventHandler("region")}


### PR DESCRIPTION
- There's an existing iOS bug which uppercases the first two letters when `autoCapitalization="word"` is enabled, so we are for now removing autoCapitalization on mobile
- WebKit bug report from 2016: https://bugs.webkit.org/show_bug.cgi?id=157410
- [MX-104]
- https://artsyproduct.atlassian.net/browse/MX-104

## After fix:

![2020-01-15 15 27 50](https://user-images.githubusercontent.com/21182806/72557246-5e6d4980-386e-11ea-8e1f-92624f561e5b.gif)

## Before fix:

<img width="404" alt="Screen Shot 2020-01-15 at 3 22 07 PM" src="https://user-images.githubusercontent.com/21182806/72557259-63ca9400-386e-11ea-8560-7515567c061c.png">




[MX-104]: https://artsyproduct.atlassian.net/browse/MX-104