### PR TITLE
Wrap main page header in header tags

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -60,7 +60,7 @@ export const NavBar: React.FC = track(
   }, [isMobile])
 
   return (
-    <>
+    <header>
       <NavBarContainer px={1}>
         <NavSection>
           <Link href="/" style={{ display: "flex" }}>
@@ -232,7 +232,7 @@ export const NavBar: React.FC = track(
           <MobileNavMenu />
         </>
       )}
-    </>
+    </header>
   )
 })
 


### PR DESCRIPTION
Noticed that the new react header doesn't use a `<header>` html tag -- this caused some issues with Integrity's login tests, where we couldn't find the 'log in' button on fully react pages. 

Adding header will have effects on accessibility, making nav clearer/more semantic for screen readers.