### PR TITLE
Fix double image load issue by updating lazy load library

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "react-css-transition-replace": "^3.0.2",
     "react-gpt": "^2.0.1",
     "react-head": "^3.0.0",
-    "react-lazy-load-image-component": "^1.4.0",
+    "react-lazy-load-image-component": "^1.4.1-beta.0",
     "react-lines-ellipsis": "^0.14.0",
     "react-markdown": "^2.5.0",
     "react-oembed-container": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12960,14 +12960,6 @@ react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
-react-lazy-load-image-component@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.0.tgz#10c73ca46afc039864b395191d6b54a46a673b60"
-  integrity sha512-o/L93CyJVvXPuA2P/ouUZI7ZXJRrdE/eqP45AH5/SakOU0bzAk2ZP6qNT/WaaXhf+JtE7hhjXxMr7KGsLNX64w==
-  dependencies:
-    lodash.debounce "^4.0.8"
-    lodash.throttle "^4.1.1"
-
 react-lazy-load-image-component@^1.4.1-beta.0:
   version "1.4.1-beta.0"
   resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.1-beta.0.tgz#4b47fcda23b40412bc03f66442e419a23e5cae9d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12968,6 +12968,14 @@ react-lazy-load-image-component@^1.4.0:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
 
+react-lazy-load-image-component@^1.4.1-beta.0:
+  version "1.4.1-beta.0"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.1-beta.0.tgz#4b47fcda23b40412bc03f66442e419a23e5cae9d"
+  integrity sha512-SFYu44wAMRpN9afyoeerlSprjl3K/aokueZgTW/qbqmxkEbRLUSWubr5dM1cXEAcLxFruqGdjswzB8YI3KaPBQ==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
See https://github.com/artsy/palette/pull/628 for more context. 

TL;DR sometimes (esp on chrome) images were downloading twice when lazy loading. Updating the library resolves that issue. 