### PR TITLE
@joeyAghion => [Analytics] More explicitly track AB test events

### DIFF
--- a/src/Artsy/Analytics/trackExperimentViewed.tsx
+++ b/src/Artsy/Analytics/trackExperimentViewed.tsx
@@ -1,0 +1,20 @@
+import * as Schema from "Artsy/Analytics"
+import { data as sd } from "sharify"
+
+declare const window: any
+export const trackExperimentViewed = (name: string) => {
+  if (typeof window.analytics !== "undefined") {
+    const variation = sd[name.toUpperCase()]
+    if (!Boolean(variation))
+      return console.warn(`experiment value for ${name} not found, skipping`)
+
+    window.analytics.track({
+      action_type: Schema.ActionType.ExperimentViewed,
+      experiment_id: name,
+      experiment_name: name,
+      variation_id: variation,
+      variation_name: variation,
+      nonInteraction: 1,
+    })
+  }
+}

--- a/src/Artsy/Router/RouterLink.tsx
+++ b/src/Artsy/Router/RouterLink.tsx
@@ -1,8 +1,10 @@
+import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import { trackPageView } from "Artsy/Analytics/trackPageView"
 import { Link, LinkProps, LinkPropsSimple, Match, RouterContext } from "found"
 import { pick } from "lodash"
 import React, { useContext } from "react"
 import { get } from "Utils/get"
+import { getENV } from "Utils/getENV"
 
 /**
  * Wrapper component around found's <Link> component with a fallback to a normal
@@ -54,6 +56,8 @@ export const RouterLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
       const toPageType = toPath.split("/")[1]
       if (currentPageType === toPageType) {
         trackPageView({ path: toPath })
+        if (getENV("EXPERIMENTAL_APP_SHELL"))
+          trackExperimentViewed("client_navigation_v2")
       }
 
       if (props.onClick) {

--- a/src/Artsy/Router/makeAppRoutes.tsx
+++ b/src/Artsy/Router/makeAppRoutes.tsx
@@ -4,8 +4,10 @@ import React, { useEffect } from "react"
 
 import { AppShell } from "Apps/Components/AppShell"
 import { trackPageView } from "Artsy"
+import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import { useSystemContext } from "Artsy/SystemContext"
 import { catchLinks } from "Utils/catchLinks"
+import { getENV } from "Utils/getENV"
 
 const ROUTE_NAMESPACE = ""
 
@@ -71,6 +73,8 @@ export function makeAppRoutes(routeList: RouteList[]): RouteConfig[] {
           const toPageType = toPath.split("/")[1]
           if (currentPageType === toPageType && toPageType !== "collection") {
             trackPageView({ path: toPath })
+            if (getENV("EXPERIMENTAL_APP_SHELL"))
+              trackExperimentViewed("client_navigation_v2")
           }
           props.router.push(url)
         } else {


### PR DESCRIPTION
This _might_ work if needed (still playing around locally).

Basically, we weren't always triggering a subsequent experiment viewed event (generally on subsequent navigation of the same 'type'). Very akin to the pageview triggering.

So, this adds explicit experiment viewed events alongside the places we had to specially handle the pageview triggering. Logical, right?

I attempted reconfiguring in various ways in order to try to properly use our `tracking` functionality, using hooks, using React lifecycle methods, rewriting a class to a functional component, etc.

None of them worked! So this winds up just reaching into `window.analytics`, etc. 