### PR TITLE
@mzikherman => [Analytics] Proper structure for experiment viewed event

### DIFF
--- a/src/Artsy/Analytics/trackExperimentViewed.tsx
+++ b/src/Artsy/Analytics/trackExperimentViewed.tsx
@@ -8,8 +8,7 @@ export const trackExperimentViewed = (name: string) => {
     if (!Boolean(variation))
       return console.warn(`experiment value for ${name} not found, skipping`)
 
-    window.analytics.track({
-      action_type: Schema.ActionType.ExperimentViewed,
+    window.analytics.track(Schema.ActionType.ExperimentViewed, {
       experiment_id: name,
       experiment_name: name,
       variation_id: variation,


### PR DESCRIPTION
Since this is using `window.analytics` directly, the format of the argument is slightly different (+ no typing to help...)