### PR TITLE
[FX-1692] Reorder mobile nav items to match desktop

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -35,15 +35,14 @@ export const MobileNavMenu: React.FC = () => {
 
   return (
     <MobileNavContainer py={[1, 4]} flexDirection="column" onClick={trackClick}>
-      <MobileLink href="/">Home</MobileLink>
       <MobileLink href="/collect">Artworks</MobileLink>
+      <MobileLink href="/auctions">Auctions</MobileLink>
+      <MobileLink href="/galleries">Galleries</MobileLink>
+      <MobileLink href="/fairs">Fairs</MobileLink>
+      <MobileLink href="/articles">Editorial</MobileLink>
       <MobileLink href="/artists">Artists</MobileLink>
       <MobileLink href="/shows">Shows</MobileLink>
-      <MobileLink href="/galleries">Galleries</MobileLink>
       <MobileLink href="/institutions">Museums</MobileLink>
-      <MobileLink href="/fairs">Fairs</MobileLink>
-      <MobileLink href="/auctions">Auctions</MobileLink>
-      <MobileLink href="/articles">Editorial</MobileLink>
 
       <Box px={2}>
         <Separator my={[1, 4]} />

--- a/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MobileNavMenu.test.tsx
@@ -23,15 +23,14 @@ describe("MobileNavMenu", () => {
   }
 
   const defaultLinks = [
-    ["/", "Home"],
     ["/collect", "Artworks"],
+    ["/auctions", "Auctions"],
+    ["/galleries", "Galleries"],
+    ["/fairs", "Fairs"],
+    ["/articles", "Editorial"],
     ["/artists", "Artists"],
     ["/shows", "Shows"],
-    ["/galleries", "Galleries"],
     ["/institutions", "Museums"],
-    ["/fairs", "Fairs"],
-    ["/auctions", "Auctions"],
-    ["/articles", "Editorial"],
   ]
 
   describe("nav structure", () => {

--- a/src/Components/NavBarTest/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBarTest/Menus/MobileNavMenu.tsx
@@ -35,14 +35,14 @@ export const MobileNavMenu: React.FC = () => {
 
   return (
     <MobileNavContainer py={[1, 4]} flexDirection="column" onClick={trackClick}>
-      <MobileLink href="/">Home</MobileLink>
+      <MobileLink href="/collect">Artworks</MobileLink>
       <MobileLink href="/artists">Artists</MobileLink>
-      <MobileLink href="/shows">Shows</MobileLink>
-      <MobileLink href="/galleries">Galleries</MobileLink>
-      <MobileLink href="/institutions">Museums</MobileLink>
-      <MobileLink href="/fairs">Fairs</MobileLink>
       <MobileLink href="/auctions">Auctions</MobileLink>
       <MobileLink href="/articles">Editorial</MobileLink>
+      <MobileLink href="/galleries">Galleries</MobileLink>
+      <MobileLink href="/fairs">Fairs</MobileLink>
+      <MobileLink href="/shows">Shows</MobileLink>
+      <MobileLink href="/institutions">Museums</MobileLink>
 
       <Box px={2}>
         <Separator my={[1, 4]} />

--- a/src/Components/NavBarTest/Menus/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBarTest/Menus/__tests__/MobileNavMenu.test.tsx
@@ -23,14 +23,14 @@ describe("MobileNavMenu", () => {
   }
 
   const defaultLinks = [
-    ["/", "Home"],
+    ["/collect", "Artworks"],
     ["/artists", "Artists"],
-    ["/shows", "Shows"],
-    ["/galleries", "Galleries"],
-    ["/institutions", "Museums"],
-    ["/fairs", "Fairs"],
     ["/auctions", "Auctions"],
     ["/articles", "Editorial"],
+    ["/galleries", "Galleries"],
+    ["/fairs", "Fairs"],
+    ["/shows", "Shows"],
+    ["/institutions", "Museums"],
   ]
 
   describe("nav structure", () => {

--- a/src/Components/__stories__/NavBar.story.tsx
+++ b/src/Components/__stories__/NavBar.story.tsx
@@ -1,8 +1,7 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
-import styled from "styled-components"
 
-import { Box, Sans } from "@artsy/palette"
+import { Box, Sans, Spacer } from "@artsy/palette"
 import { SystemContextProvider } from "Artsy"
 import { NavBar } from "Components/NavBar"
 import * as Menus from "Components/NavBar/Menus"
@@ -27,18 +26,11 @@ storiesOf("Components/NavBar", module)
             {isLoggedIn ? "Logged in • " : "Logged out • "}
             {isExperiment ? "Experiment" : "Control"}
           </Sans>
-          <ShowOutlines>
-            {isExperiment ? <NavBarTest /> : <NavBar />}
-          </ShowOutlines>
+          {isExperiment ? <NavBarTest /> : <NavBar />}
+          <Spacer height={180} />
         </Box>
       </SystemContextProvider>
     )
-
-    const ShowOutlines = styled.div`
-      * {
-        outline: solid 0px hsla(180, 100%, 50%, 0.5);
-      }
-    `
 
     return (
       <>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1692

This brings the mobile web nav menu inline with the desktop nav, so that they have the same items in the same order:

![comp](https://user-images.githubusercontent.com/140521/73277485-39ef6680-41b8-11ea-90ea-8f9e604b6414.png)

This also similarly updates the A/B experiment version of the nav bar — which is currently disabled but not definitively retired yet.