### PR TITLE
Use open:auth with redirectTo option to skip signup onboarding

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -19,11 +19,9 @@ import {
 } from "Artsy"
 import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { ErrorModal } from "Components/Modal/ErrorModal"
-import * as authentication from "Components/NavBar/Utils/authentication"
 import createLogger from "Utils/logger"
 
 import { RequestConditionReport_artwork } from "__generated__/RequestConditionReport_artwork.graphql"
-
 import { RequestConditionReport_me } from "__generated__/RequestConditionReport_me.graphql"
 import {
   RequestConditionReportMutation,
@@ -101,7 +99,10 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
       sale_artwork_id: artwork.saleArtwork.internalID,
     })
 
-    return authentication.login(mediator)
+    mediator.trigger("open:auth", {
+      mode: "login",
+      redirectTo: location.href,
+    })
   }
 
   const handleRequestConditionReportClick = () => {

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.test.tsx
@@ -65,7 +65,7 @@ describe("RequestConditionReport ", () => {
 
     await page.clickRequestConditionReportButton()
 
-    expect(mockPostEvent).toBeCalledWith({
+    expect(mockPostEvent).toHaveBeenCalledWith({
       action_type: Schema.ActionType.ClickedRequestConditionReport,
       subject: Schema.Subject.RequestConditionReport,
       context_page: Schema.PageName.ArtworkPage,
@@ -93,7 +93,7 @@ describe("RequestConditionReport ", () => {
   })
 
   describe("when unauthenticated", () => {
-    it("redirects to login flows and tracks a login analytic event", async () => {
+    it("redirects to login/signup flow and tracks click event", async () => {
       const env = setupTestEnv()
 
       const page = await env.buildPage({
@@ -104,9 +104,12 @@ describe("RequestConditionReport ", () => {
 
       await page.clickLogInButton()
 
-      expect(mediator.trigger).toHaveBeenCalledTimes(1)
+      expect(mediator.trigger).toHaveBeenCalledWith("open:auth", {
+        mode: "login",
+        redirectTo: "http://localhost/",
+      })
 
-      expect(mockPostEvent).toBeCalledWith({
+      expect(mockPostEvent).toHaveBeenCalledWith({
         action_type: Schema.ActionType.Click,
         context_module: Schema.ContextModule.AboutTheWorkCondition,
         context_page: Schema.PageName.ArtworkPage,


### PR DESCRIPTION
When creating a new account for a user via a request for a condition report on an artwork in a sale, skip the onboarding flow so that the user can quickly return to the artwork page to complete their condition report request.