### PR TITLE
User should not be able to advance to the payment page without entering a phone number with their shipping address

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -169,10 +169,27 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 
     if (shippingOption === "SHIP") {
       const { errors, hasErrors } = this.validateAddress(this.state.address)
-      if (hasErrors) {
+      const { error, hasError } = this.validatePhoneNumber(
+        this.state.phoneNumber
+      )
+      if (hasErrors && hasError) {
         this.setState({
           addressErrors: errors,
           addressTouched: this.touchedAddress,
+          phoneNumberError: error,
+          phoneNumberTouched: true,
+        })
+        return
+      } else if (hasErrors) {
+        this.setState({
+          addressErrors: errors,
+          addressTouched: this.touchedAddress,
+        })
+        return
+      } else if (hasError) {
+        this.setState({
+          phoneNumberError: error,
+          phoneNumberTouched: true,
         })
         return
       }

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -334,6 +334,22 @@ describe("Shipping", () => {
         expect(cityInput.props().error).toBeTruthy()
       })
 
+      it("does not submit the mutation without a phone number", async () => {
+        const address = {
+          name: "Erik David",
+          addressLine1: "401 Broadway",
+          addressLine2: "",
+          city: "New York",
+          region: "",
+          postalCode: "7Z",
+          phoneNumber: "",
+          country: "AQ",
+        }
+        fillAddressForm(page.root, address)
+        await page.clickSubmit()
+        expect(mutations.mockFetch).not.toBeCalled()
+      })
+
       it("allows a missing state/province if the selected country is not US or Canada", async () => {
         const address = {
           name: "Erik David",


### PR DESCRIPTION
# [PURCHASE-1757] User should not be able to advance to the payment page without entering a phone number with their shipping address

This is a follow up to fix a regression that I accidentally caused with my phone number field PR.

When I place an order
if I select shipping
and enter a shipping address
I should be required to enter a phone number

Currently, I'm able to advance without entering my phone number.

__After:__
<img width="747" alt="Screen Shot 2020-01-30 at 9 47 39 AM" src="https://user-images.githubusercontent.com/5643895/73461824-c92b8400-4348-11ea-8141-35e84d17a525.png">
