### PR TITLE
Rename 'repcaptcha' to 'recaptcha', add new types

### DIFF
--- a/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
@@ -8,7 +8,7 @@ import {
   SubmitButton,
 } from "Components/Authentication/commonElements"
 import QuickInput from "Components/QuickInput"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 import { FormProps, InputValues, ModalType } from "../Types"
 import { ForgotPasswordValidator } from "../Validators"
 
@@ -25,7 +25,7 @@ export class ForgotPasswordForm extends Component<
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("forgot_submit")
+    recaptcha("forgot_submit")
     this.props.handleSubmit(values, formikBag)
   }
 

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -16,7 +16,7 @@ import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React, { Component } from "react"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 
 export interface LoginFormState {
   error: string
@@ -28,7 +28,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("login_submit")
+    recaptcha("login_submit")
     this.props.handleSubmit(values, formikBag)
   }
 

--- a/src/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/Components/Authentication/Desktop/SignUpForm.tsx
@@ -15,7 +15,7 @@ import PasswordInput from "Components/PasswordInput"
 import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React, { Component } from "react"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 
 export interface SignUpFormState {
   error?: string
@@ -27,7 +27,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("signup_submit", recaptcha_token => {
+    recaptcha("signup_submit", recaptcha_token => {
       const valuesWithToken = {
         ...values,
         recaptcha_token,

--- a/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
@@ -10,13 +10,13 @@ import {
 import QuickInput from "Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React from "react"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 import { FormProps, InputValues, ModalType } from "../Types"
 import { ForgotPasswordValidator } from "../Validators"
 
 export class MobileForgotPasswordForm extends React.Component<FormProps> {
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("forgot_submit")
+    recaptcha("forgot_submit")
     this.props.handleSubmit(values, formikBag)
   }
 

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -9,7 +9,7 @@ import { Step, Wizard } from "Components/Wizard"
 import { FormikProps } from "formik"
 import React, { Component, Fragment } from "react"
 import { Environment } from "relay-runtime"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 import {
   BackButton,
   Error,
@@ -42,7 +42,7 @@ class MobileLoginFormWithSystemContext extends Component<
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("login_submit")
+    recaptcha("login_submit")
     this.props.handleSubmit(values, formikBag)
   }
 

--- a/src/Components/Authentication/Mobile/SignUpForm.tsx
+++ b/src/Components/Authentication/Mobile/SignUpForm.tsx
@@ -26,7 +26,7 @@ import { Step, Wizard } from "Components/Wizard"
 import { FormikProps } from "formik"
 import React, { Component, Fragment } from "react"
 import { Environment } from "relay-runtime"
-import { repcaptcha } from "Utils/repcaptcha"
+import { recaptcha } from "Utils/recaptcha"
 
 export interface MobileSignUpFormState {
   isSocialSignUp: boolean
@@ -74,7 +74,7 @@ class TrackedMobileSignUpForm extends Component<
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
-    repcaptcha("signup_submit", recaptcha_token => {
+    recaptcha("signup_submit", recaptcha_token => {
       const valuesWithToken = {
         ...values,
         recaptcha_token,

--- a/src/Utils/__tests__/recaptcha.test.ts
+++ b/src/Utils/__tests__/recaptcha.test.ts
@@ -1,4 +1,4 @@
-import { repcaptcha } from "../repcaptcha"
+import { recaptcha } from "../recaptcha"
 jest.mock("sharify", () => ({ data: jest.fn() }))
 const sd = require("sharify").data
 
@@ -10,7 +10,7 @@ describe("repcaptcha", () => {
   })
 
   it("fires an action", () => {
-    repcaptcha("login_submit")
+    recaptcha("login_submit")
     expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
       action: "login_submit",
     })
@@ -24,7 +24,7 @@ describe("repcaptcha", () => {
       done()
     })
 
-    repcaptcha("signup_submit", callback)
+    recaptcha("signup_submit", callback)
     expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
       action: "signup_submit",
     })
@@ -39,7 +39,7 @@ describe("repcaptcha", () => {
       done()
     })
 
-    repcaptcha("signup_submit", callback)
+    recaptcha("signup_submit", callback)
     expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
       action: "signup_submit",
     })
@@ -54,7 +54,7 @@ describe("repcaptcha", () => {
       done()
     })
 
-    repcaptcha("signup_submit", callback)
+    recaptcha("signup_submit", callback)
     expect(window.grecaptcha.ready).not.toBeCalled()
     expect(window.grecaptcha.execute).not.toBeCalled()
   })

--- a/src/Utils/recaptcha.ts
+++ b/src/Utils/recaptcha.ts
@@ -1,6 +1,6 @@
 import { data as sd } from "sharify"
 
-export const repcaptcha = (action: RepcaptchaAction, cb?: any) => {
+export const recaptcha = (action: RecaptchaAction, cb?: any) => {
   if (sd.RECAPTCHA_KEY) {
     window.grecaptcha.ready(async () => {
       try {
@@ -18,8 +18,12 @@ export const repcaptcha = (action: RepcaptchaAction, cb?: any) => {
   }
 }
 
-export type RepcaptchaAction =
-  | "home"
+export type RecaptchaAction =
   | "forgot_submit"
+  | "home"
+  | "inquiry_forgot_impression"
+  | "inquiry_impression"
+  | "inquiry_login_impression"
+  | "inquiry_register_impression"
   | "login_submit"
   | "signup_submit"


### PR DESCRIPTION
- Renames misspelled `repcaptcha` instances
- Adds new impression types to `recaptcha`