### PR TITLE
[FX-1684] use resizer for featured collection image

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.test.tsx
@@ -115,8 +115,8 @@ describe("FeaturedCollectionEntity", () => {
     expect(firstEntity.text()).toMatch("From SpongeBob SquarePants to Snoopy")
     expect(firstEntity.text()).toMatch("From $60")
     const featuredImage = component.find(FeaturedImage).at(0)
-    expect(featuredImage.getElement().props.src).toBe(
-      "http://files.artsy.net/images/cartoons_thumbnail.png"
+    expect(featuredImage.getElement().props.src).toContain(
+      "cartoons_thumbnail.png&width=500&height=500&quality=80"
     )
   })
 

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -18,6 +18,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
+import { resize } from "Utils/resizer"
 import { Media } from "Utils/Responsive"
 
 interface Props {
@@ -136,7 +137,13 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
     <Container p={2} m={1} width={["261px", "261px", "355px", "355px"]}>
       <StyledLink to={`/collection/${slug}`} onClick={handleClick}>
         <Flex height={["190px", "190px", "280px", "280px"]}>
-          <FeaturedImage src={thumbnail} />
+          <FeaturedImage
+            src={resize(thumbnail, {
+              width: 500,
+              height: 500,
+              quality: 80,
+            })}
+          />
         </Flex>
         <Serif size="4" mt={1} maxWidth={["246px", "100%"]}>
           <Truncator maxLineCount={1}>{title}</Truncator>


### PR DESCRIPTION
Addresses: [FX-1684](https://artsyproduct.atlassian.net/browse/FX-1684)

After investigating the performance on the collection page, we identified that the featured collections rail used an image that was larger than necessary (over 900px). This PR use the resize util to pull in a smaller images (500px) as a means of improving the page's performance. 

**Featured Collections Rail**
<img width="1174" alt="Screen Shot 2020-01-31 at 10 25 31 AM" src="https://user-images.githubusercontent.com/5201004/73551265-1163a880-4414-11ea-943e-44d61babe12b.png">
