### PR TITLE
[FX-1675] Resize collection header artist images

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/Header.test.tsx
@@ -120,8 +120,12 @@ describe("collections header", () => {
 
       expect(artist).toMatchObject({
         name: "KAWS",
-        imageUrl:
-          "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+        image: {
+          resized: {
+            url:
+              "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWhacjFyMKlMkNVzncPjlRA%2Fsquare.jpg",
+          },
+        },
         birthday: "1974",
         nationality: "American",
       })
@@ -284,8 +288,12 @@ describe("collections header", () => {
         slug: "medicom-toy-slash-china",
         internalID: "5b9821af86c8aa21d364dde5",
         name: "Medicom Toy/China",
-        imageUrl:
-          "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
+        image: {
+          resized: {
+            url:
+              "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FnpEmyaOeaPzkfEHX5VsmQg%2Fsquare.jpg",
+          },
+        },
         birthday: "",
         nationality: "",
         " $fragmentRefs": null,

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/fixtures/artworks.ts
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/__tests__/fixtures/artworks.ts
@@ -9,8 +9,12 @@ export const collectionHeaderArtworks: Header_artworks = {
       slug: "kaws",
       internalID: "4e934002e340fa0001005336",
       name: "KAWS",
-      imageUrl:
-        "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+      image: {
+        resized: {
+          url:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWhacjFyMKlMkNVzncPjlRA%2Fsquare.jpg",
+        },
+      },
       birthday: "1974",
       nationality: "American",
       " $fragmentRefs": null,
@@ -19,8 +23,12 @@ export const collectionHeaderArtworks: Header_artworks = {
       slug: "robert-lazzarini",
       internalID: "4f5f64c23b555230ac0003ae",
       name: "Robert Lazzarini",
-      imageUrl:
-        "https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg",
+      image: {
+        resized: {
+          url:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1npk1i_Xua5q8Hv0YOq_3g%2Fsquare.jpg",
+        },
+      },
       birthday: "1965",
       nationality: "American",
       " $fragmentRefs": null,
@@ -29,8 +37,12 @@ export const collectionHeaderArtworks: Header_artworks = {
       slug: "medicom",
       internalID: "58fe85ee275b2450a0fd2b51",
       name: "Medicom",
-      imageUrl:
-        "https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg",
+      image: {
+        resized: {
+          url:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjUMOidRmCQ0RyynXM_sFzQ%2Fsquare.jpg",
+        },
+      },
       birthday: "",
       nationality: "",
       " $fragmentRefs": null,
@@ -39,8 +51,12 @@ export const collectionHeaderArtworks: Header_artworks = {
       slug: "medicom-toy-slash-china",
       internalID: "5b9821af86c8aa21d364dde5",
       name: "Medicom Toy/China",
-      imageUrl:
-        "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
+      image: {
+        resized: {
+          url:
+            "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FnpEmyaOeaPzkfEHX5VsmQg%2Fsquare.jpg",
+        },
+      },
       birthday: "",
       nationality: "",
       " $fragmentRefs": null,

--- a/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/Header/index.tsx
@@ -73,7 +73,7 @@ export const featuredArtistsEntityCollection: (
     return (
       <Box width={["100%", "33%", "33%", "25%"]} key={index} pb={20}>
         <EntityHeader
-          imageUrl={artist.imageUrl}
+          imageUrl={artist.image.resized.url}
           name={artist.name}
           meta={
             hasArtistMetaData
@@ -363,7 +363,11 @@ export const CollectionFilterFragmentContainer = createFragmentContainer(
           slug
           internalID
           name
-          imageUrl
+          image {
+            resized(width: 45, height: 45, version: "square") {
+              url
+            }
+          }
           birthday
           nationality
           ...FollowArtistButton_artist

--- a/src/__generated__/CollectionRefetch2Query.graphql.ts
+++ b/src/__generated__/CollectionRefetch2Query.graphql.ts
@@ -326,7 +326,11 @@ fragment Header_artworks on FilterArtworksConnection {
     slug
     internalID
     name
-    imageUrl
+    image {
+      resized(width: 45, height: 45, version: "square") {
+        url
+      }
+    }
     birthday
     nationality
     ...FollowArtistButton_artist
@@ -818,19 +822,22 @@ v16 = {
   "args": null,
   "storageKey": null
 },
-v17 = {
+v17 = [
+  (v16/*: any*/)
+],
+v18 = {
   "kind": "Literal",
   "name": "includeMediumFilterInAggregation",
   "value": true
 },
-v18 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v19 = [
+v20 = [
   (v16/*: any*/),
   {
     "kind": "ScalarField",
@@ -847,7 +854,7 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
@@ -860,35 +867,35 @@ v20 = {
   ],
   "storageKey": "url(version:\"larger\")"
 },
-v21 = {
+v22 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "availability",
   "args": null,
   "storageKey": null
 },
-v22 = {
+v23 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v23 = {
+v24 = {
   "kind": "ScalarField",
   "alias": "is_acquireable",
   "name": "isAcquireable",
   "args": null,
   "storageKey": null
 },
-v24 = {
+v25 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v25 = [
+v26 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -897,33 +904,33 @@ v25 = [
     "storageKey": null
   }
 ],
-v26 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v27 = {
+v28 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v28 = {
+v29 = {
   "kind": "Literal",
   "name": "size",
   "value": 1
 },
-v29 = {
+v30 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v30 = {
+v31 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "aggregations",
@@ -967,12 +974,12 @@ v30 = {
     }
   ]
 },
-v31 = {
+v32 = {
   "kind": "Literal",
   "name": "first",
   "value": 1
 },
-v32 = [
+v33 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -994,7 +1001,7 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = [
+v34 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -1014,7 +1021,7 @@ v33 = [
         "plural": false,
         "selections": [
           (v7/*: any*/),
-          (v21/*: any*/),
+          (v22/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1024,7 +1031,7 @@ v33 = [
             "concreteType": null,
             "plural": false,
             "selections": [
-              (v24/*: any*/),
+              (v25/*: any*/),
               {
                 "kind": "InlineFragment",
                 "type": "PriceRange",
@@ -1037,7 +1044,7 @@ v33 = [
                     "args": null,
                     "concreteType": "Money",
                     "plural": false,
-                    "selections": (v32/*: any*/)
+                    "selections": (v33/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1047,14 +1054,14 @@ v33 = [
                     "args": null,
                     "concreteType": "Money",
                     "plural": false,
-                    "selections": (v32/*: any*/)
+                    "selections": (v33/*: any*/)
                   }
                 ]
               },
               {
                 "kind": "InlineFragment",
                 "type": "Money",
-                "selections": (v32/*: any*/)
+                "selections": (v33/*: any*/)
               }
             ]
           }
@@ -1064,23 +1071,23 @@ v33 = [
   },
   (v7/*: any*/)
 ],
-v34 = {
+v35 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v35 = {
+v36 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v36 = [
-  (v34/*: any*/),
+v37 = [
   (v35/*: any*/),
+  (v36/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -1248,9 +1255,7 @@ return {
                                 ],
                                 "concreteType": "ResizedImageUrl",
                                 "plural": false,
-                                "selections": [
-                                  (v16/*: any*/)
-                                ]
+                                "selections": (v17/*: any*/)
                               }
                             ]
                           },
@@ -1381,7 +1386,7 @@ return {
                 "name": "first",
                 "value": 20
               },
-              (v17/*: any*/),
+              (v18/*: any*/),
               {
                 "kind": "Literal",
                 "name": "size",
@@ -1410,7 +1415,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v18/*: any*/),
+                      (v19/*: any*/),
                       (v8/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -1435,7 +1440,7 @@ return {
                             ],
                             "concreteType": "ResizedImageUrl",
                             "plural": false,
-                            "selections": (v19/*: any*/)
+                            "selections": (v20/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1451,16 +1456,16 @@ return {
                             ],
                             "concreteType": "ResizedImageUrl",
                             "plural": false,
-                            "selections": (v19/*: any*/)
+                            "selections": (v20/*: any*/)
                           },
-                          (v20/*: any*/)
+                          (v21/*: any*/)
                         ]
                       },
                       (v7/*: any*/),
-                      (v21/*: any*/),
-                      (v4/*: any*/),
                       (v22/*: any*/),
+                      (v4/*: any*/),
                       (v23/*: any*/),
+                      (v24/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "is_price_range",
@@ -1477,16 +1482,16 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v24/*: any*/),
+                          (v25/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "type": "PriceRange",
-                            "selections": (v25/*: any*/)
+                            "selections": (v26/*: any*/)
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "Money",
-                            "selections": (v25/*: any*/)
+                            "selections": (v26/*: any*/)
                           }
                         ]
                       },
@@ -1503,7 +1508,7 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v26/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": (v14/*: any*/)
@@ -1525,12 +1530,12 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v26/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v27/*: any*/),
+                          (v28/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1549,7 +1554,7 @@ return {
                                 "concreteType": "Image",
                                 "plural": false,
                                 "selections": [
-                                  (v20/*: any*/)
+                                  (v21/*: any*/)
                                 ]
                               },
                               (v7/*: any*/)
@@ -1561,7 +1566,7 @@ return {
                             "name": "locations",
                             "storageKey": "locations(size:1)",
                             "args": [
-                              (v28/*: any*/)
+                              (v29/*: any*/)
                             ],
                             "concreteType": "Location",
                             "plural": true,
@@ -1635,14 +1640,44 @@ return {
                 "plural": true,
                 "selections": [
                   (v8/*: any*/),
-                  (v29/*: any*/),
+                  (v30/*: any*/),
                   (v13/*: any*/),
                   {
-                    "kind": "ScalarField",
+                    "kind": "LinkedField",
                     "alias": null,
-                    "name": "imageUrl",
+                    "name": "image",
+                    "storageKey": null,
                     "args": null,
-                    "storageKey": null
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "resized",
+                        "storageKey": "resized(height:45,version:\"square\",width:45)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "height",
+                            "value": 45
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 45
+                          }
+                        ],
+                        "concreteType": "ResizedImageUrl",
+                        "plural": false,
+                        "selections": (v17/*: any*/)
+                      }
+                    ]
                   },
                   {
                     "kind": "ScalarField",
@@ -1686,7 +1721,7 @@ return {
                   }
                 ]
               },
-              (v30/*: any*/),
+              (v31/*: any*/),
               (v7/*: any*/)
             ]
           },
@@ -1697,9 +1732,9 @@ return {
             "storageKey": null,
             "args": [
               (v2/*: any*/),
-              (v31/*: any*/),
-              (v17/*: any*/),
-              (v28/*: any*/),
+              (v32/*: any*/),
+              (v18/*: any*/),
+              (v29/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1708,7 +1743,7 @@ return {
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
-            "selections": (v33/*: any*/)
+            "selections": (v34/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -1717,9 +1752,9 @@ return {
             "storageKey": null,
             "args": [
               (v2/*: any*/),
-              (v31/*: any*/),
-              (v17/*: any*/),
-              (v28/*: any*/),
+              (v32/*: any*/),
+              (v18/*: any*/),
+              (v29/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1728,7 +1763,7 @@ return {
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
-            "selections": (v33/*: any*/)
+            "selections": (v34/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -1740,7 +1775,7 @@ return {
             "plural": false,
             "selections": [
               (v7/*: any*/),
-              (v30/*: any*/),
+              (v31/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1783,7 +1818,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v36/*: any*/)
+                    "selections": (v37/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1793,7 +1828,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v36/*: any*/)
+                    "selections": (v37/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1803,7 +1838,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v36/*: any*/)
+                    "selections": (v37/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1814,8 +1849,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v34/*: any*/),
-                      (v35/*: any*/)
+                      (v35/*: any*/),
+                      (v36/*: any*/)
                     ]
                   }
                 ]
@@ -1840,7 +1875,7 @@ return {
                     "selections": [
                       (v7/*: any*/),
                       (v8/*: any*/),
-                      (v18/*: any*/),
+                      (v19/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1879,7 +1914,7 @@ return {
                           }
                         ]
                       },
-                      (v29/*: any*/),
+                      (v30/*: any*/),
                       (v9/*: any*/),
                       {
                         "kind": "ScalarField",
@@ -1888,7 +1923,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v22/*: any*/),
+                      (v23/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "sale_message",
@@ -1908,12 +1943,12 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v26/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
                           (v7/*: any*/),
-                          (v18/*: any*/),
+                          (v19/*: any*/),
                           (v13/*: any*/)
                         ]
                       },
@@ -1929,14 +1964,14 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v26/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v18/*: any*/),
+                          (v19/*: any*/),
                           (v7/*: any*/),
-                          (v27/*: any*/)
+                          (v28/*: any*/)
                         ]
                       },
                       {
@@ -2028,7 +2063,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v25/*: any*/)
+                            "selections": (v26/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -2038,7 +2073,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v25/*: any*/)
+                            "selections": (v26/*: any*/)
                           },
                           (v7/*: any*/)
                         ]
@@ -2064,7 +2099,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v23/*: any*/),
+                      (v24/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "is_offerable",
@@ -2087,7 +2122,7 @@ return {
     "operationKind": "query",
     "name": "CollectionRefetch2Query",
     "id": null,
-    "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    imageUrl\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query CollectionRefetch2Query(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    image {\n      resized(width: 45, height: 45, version: \"square\") {\n        url\n      }\n    }\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Header_artworks.graphql.ts
+++ b/src/__generated__/Header_artworks.graphql.ts
@@ -7,7 +7,11 @@ export type Header_artworks = {
         readonly slug: string;
         readonly internalID: string;
         readonly name: string | null;
-        readonly imageUrl: string | null;
+        readonly image: {
+            readonly resized: {
+                readonly url: string | null;
+            } | null;
+        } | null;
         readonly birthday: string | null;
         readonly nationality: string | null;
         readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
@@ -61,11 +65,49 @@ const node: ReaderFragment = {
           "storageKey": null
         },
         {
-          "kind": "ScalarField",
+          "kind": "LinkedField",
           "alias": null,
-          "name": "imageUrl",
+          "name": "image",
+          "storageKey": null,
           "args": null,
-          "storageKey": null
+          "concreteType": "Image",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "resized",
+              "storageKey": "resized(height:45,version:\"square\",width:45)",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 45
+                },
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "square"
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 45
+                }
+              ],
+              "concreteType": "ResizedImageUrl",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "url",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
         },
         {
           "kind": "ScalarField",
@@ -95,5 +137,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '7094c150ec1332c9565fc3a75995460f';
+(node as any).hash = 'ee9a91cd2dac53afe39f913787441bc3';
 export default node;


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1675

Our performance investigations a while back uncovered some potential improvements. This is a small one, but does look to reduce page weight a little.

These images — up to 12 of them — are only 45px square but were being rendered from the 230px version, and with the original, variable quality settings (some times up to quality: 100).

![entheads](https://user-images.githubusercontent.com/140521/73481812-93979280-436a-11ea-8840-1c56f4ebbe3f.png)

In this PR we use the `artist.image.resized` field to reduce these in size to match the design, and in compression quality to our recommended value of quality: 80.

## Example 

Here's a sample collection and the reduction in image weight:

https://www.artsy.net/collection/street-art-now

### Total for artist header images: 483 kb → 15 kb

(All images reduced from 230px square to 45px square)

|Img|Quality before|Bytes before|Quality after|Bytes after|
|---|---|---|---|---|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FDlabDQqoAI0CCu5TD_qNoA%2Fsquare.jpg)|89|27,153|80|1,527|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FITroKwWUgrsFlax-zrHhBQ%2Fsquare.jpg)|96|63,010|80|1,811|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FY0lGV8OyCmQpKCiWT4s_Qw%2Fsquare.jpg)|99|58,311|80|1,567|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOcYkonYKNoEIvg__2jnZCA%2Fsquare.jpg)|99|74,378|80|1,609|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWhacjFyMKlMkNVzncPjlRA%2Fsquare.jpg)|86|10,149|80|884|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=33&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FX9vVvod7QY73ZwLDSZzljw%2Fsquare.jpg)|92|17,606|80|940|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4DpIqaZPHZM-Q3qWqGa7mA%2Fsquare.jpg)|92|30,442|80|1,523|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNcQj8OI160YgfmpXhI4yjg%2Fsquare.jpg)|99|69,622|80|1,263|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=34&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEzZTt_ErG3qsVAwMh7JM2g%2Fsquare.jpg)|92|22,383|80|1,311|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGv3lvI9V6CyXIq1ZRNsAvg%2Fsquare.jpg)|93|36,395|80|1,451|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNep0duc-gEOgivQ8brPi1w%2Fsquare.jpg)|92|644|80|193|
|![img](https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=45&height=45&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fy794SO0hZELi9DAPSgcphQ%2Fsquare.jpg)|99|84,800|80|1,642|

