### PR TITLE
[FX-1773] Adjust default jpeg quality for cropped images

### DIFF
--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -6514,7 +6514,7 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               >
                 <img
                   className="c86 c87"
-                  src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fr3TUoJ9u8QhxGeWdjR4ccQ%252FVC-email-final.jpg&width=680&height=450&quality=95"
+                  src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2Fr3TUoJ9u8QhxGeWdjR4ccQ%252FVC-email-final.jpg&width=680&height=450&quality=80"
                 />
               </div>
             </div>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1254,7 +1254,7 @@ exports[`series layout renders a series 1`] = `
             >
               <img
                 className="c26 c27"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
               />
               <div
                 className="c28"
@@ -1413,7 +1413,7 @@ exports[`series layout renders a series 1`] = `
             >
               <img
                 className="c26 c27"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
               />
             </div>
           </div>
@@ -2978,7 +2978,7 @@ exports[`series layout renders a sponsored series 1`] = `
             >
               <img
                 className="c32 c33"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
               />
               <div
                 className="c34"
@@ -3137,7 +3137,7 @@ exports[`series layout renders a sponsored series 1`] = `
             >
               <img
                 className="c32 c33"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
               />
             </div>
           </div>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -3985,7 +3985,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                   >
                     <img
                       className="c71 c72"
-                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
                     />
                     <div
                       className="c73"
@@ -4144,7 +4144,7 @@ exports[`Video Layout matches the snapshot 1`] = `
                   >
                     <img
                       className="c71 c72"
-                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                      src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
                     />
                   </div>
                 </div>

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCard.test.tsx.snap
@@ -431,7 +431,7 @@ exports[`ArticleCard renders an article properly 1`] = `
     >
       <img
         className="c11 c12"
-        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
       />
     </div>
   </div>
@@ -1313,7 +1313,7 @@ exports[`ArticleCard renders an article with unpublished media properly 1`] = `
     >
       <img
         className="c9 c10"
-        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
       />
       <div
         className="c11"

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/ArticleCards.test.tsx.snap
@@ -468,7 +468,7 @@ exports[`ArticleCard renders properly 1`] = `
         >
           <img
             className="c11 c12"
-            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
           />
         </div>
       </div>
@@ -557,7 +557,7 @@ exports[`ArticleCard renders properly 1`] = `
         >
           <img
             className="c11 c12"
-            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+            src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
           />
           <div
             className="c13"

--- a/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/ArticleCards/__tests__/__snapshots__/Block.test.tsx.snap
@@ -533,7 +533,7 @@ exports[`ArticleCard renders properly 1`] = `
             >
               <img
                 className="c17 c18"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F7lsxxsw0qPAuKl37jEYitw%252Farticle%2Basset%2B1-hig%2Bres%2Bcopy.jpg&width=680&height=450&quality=80"
               />
             </div>
           </div>
@@ -622,7 +622,7 @@ exports[`ArticleCard renders properly 1`] = `
             >
               <img
                 className="c17 c18"
-                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=95"
+                src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FwHFgQlrTrHav5O6bQRJ0dg%252FUntitled%2BSuspended_30x67x33%2B%25282%2529_sm%2Bcropped.jpg&width=680&height=450&quality=80"
               />
               <div
                 className="c19"

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         <img
           alt="The 15 Top Art Schools in the United States"
           className="c7"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=510&height=340&quality=95"
+          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=510&height=340&quality=80"
         />
         <div
           className="c8"
@@ -296,7 +296,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         <img
           alt="Four Years after Walter De Maria’s Death, His Final Work Is Complete"
           className="c7"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=510&height=340&quality=95"
+          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=510&height=340&quality=80"
         />
         <div
           className="c8"
@@ -356,7 +356,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         <img
           alt="French Art History in a Nutshell"
           className="c7"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=510&height=340&quality=95"
+          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=510&height=340&quality=80"
         />
         <div
           className="c8"
@@ -416,7 +416,7 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
         <img
           alt="Miami Artists and Museums Brace for Hurricane Irma"
           className="c7"
-          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FjAu4NaKnr_m53OnnMaDe_w%252Fmag.jpg&width=510&height=340&quality=95"
+          src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FjAu4NaKnr_m53OnnMaDe_w%252Fmag.jpg&width=510&height=340&quality=80"
         />
         <div
           className="c8"

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     >
       <img
         className="c5"
-        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=160&height=110&quality=95"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4Tq-iYkN8dOpshFoKRXyYw%252Fcustom-Custom_Size___PoetterHall_Exterior%2Bcopy.jpg&width=160&height=110&quality=80"
       />
       <div
         className="c6"
@@ -103,7 +103,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     >
       <img
         className="c5"
-        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=160&height=110&quality=95"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F6IqxBTQCkExip2auQ7ZWCA%252FDEMAR-2011.0006-B.jpg&width=160&height=110&quality=80"
       />
       <div
         className="c6"
@@ -121,7 +121,7 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     >
       <img
         className="c5"
-        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=160&height=110&quality=95"
+        src="https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlEcCm2XbfZ7bPAVgLlM21w%252Flarger-21.jpg&width=160&height=110&quality=80"
       />
       <div
         className="c6"

--- a/src/Components/Publishing/__tests__/ArticleMeta.test.tsx
+++ b/src/Components/Publishing/__tests__/ArticleMeta.test.tsx
@@ -180,7 +180,7 @@ describe("ArticleMeta", () => {
       expect(
         component.find("[name='sailthru.image.full']").props().content
       ).toContain(
-        "?resize_to=fill&src=email_image.jpg&width=1200&height=800&quality=95"
+        "?resize_to=fill&src=email_image.jpg&width=1200&height=800&quality=80"
       )
     })
 
@@ -189,7 +189,7 @@ describe("ArticleMeta", () => {
       expect(
         component.find("[name='sailthru.image.thumb']").props().content
       ).toContain(
-        "?resize_to=fill&src=email_image.jpg&width=600&height=400&quality=95"
+        "?resize_to=fill&src=email_image.jpg&width=600&height=400&quality=80"
       )
     })
 

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -36,7 +36,7 @@ export const crop = (
     src,
     width,
     height,
-    quality: quality || 95,
+    quality: quality || 80,
   }
 
   return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1773

We have multiple approaches for requesting on-the-fly resized images. One of them is to use these `resize`  and `crop` utility functions from within Reaction code.

While working on image optimizations related to collections, I noticed that the `crop` default was still set to 95, even though [we had settled on 80 a while back](https://github.com/artsy/force/pull/2226), and even though `resize` in this file itself had been [similarly updated previously](https://github.com/artsy/reaction/pull/1491).

This just carries that change through to `crop` as well.