### PR TITLE
Update the auction result layout

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -1,5 +1,6 @@
 import { Col, Row } from "@artsy/palette"
 import { ArtistAuctionResults_artist } from "__generated__/ArtistAuctionResults_artist.graphql"
+import { AuctionResultsCount_results } from "__generated__/AuctionResultsCount_results.graphql"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -8,12 +9,13 @@ import { ArtistAuctionDetailsModal } from "./ArtistAuctionDetailsModal"
 import { AuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import { AuctionResultsState } from "./state"
 import { TableColumns } from "./TableColumns"
-import { TableSidebar } from "./TableSidebar"
+// import { TableSidebar } from "./TableSidebar"
 
 import { Box, Separator, Spacer } from "@artsy/palette"
 
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import createLogger from "Utils/logger"
+import { AuctionResultsCount } from "./Components/AuctionResultsCount"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
@@ -102,47 +104,52 @@ class AuctionResultsContainer extends Component<
   }
 
   render() {
-    const auctionResultsLength = this.props.artist.auctionResultsConnection
-      .edges.length
-    const { totalCount } = this.props.artist.auctionResultsConnection
+    const { artist } = this.props
+    const auctionResultsLength = artist.auctionResultsConnection.edges.length
     return (
       <Subscribe to={[AuctionResultsState]}>
         {({ state }: AuctionResultsState) => {
           return (
             <>
               <Row>
+                {/* 
                 <Col sm={2} pr={[0, 2]}>
-                  <TableSidebar count={totalCount} />
+                   <TableSidebar count={totalCount} />
                 </Col>
+                */}
 
-                <Col sm={10}>
-                  <TableColumns />
+                {/* <Col sm={10}> */}
+                <AuctionResultsCount
+                  results={artist.auctionResultsConnection}
+                />
 
-                  <Box pt={0.5}>
-                    <Separator />
-                  </Box>
+                <TableColumns />
 
-                  <ArtistAuctionDetailsModal
-                    auctionResult={state.selectedAuction}
-                  />
+                <Box pt={0.5}>
+                  <Separator />
+                </Box>
 
-                  <Spacer mt={3} />
+                <ArtistAuctionDetailsModal
+                  auctionResult={state.selectedAuction}
+                />
 
-                  <LoadingArea isLoading={this.state.isLoading}>
-                    {this.props.artist.auctionResultsConnection.edges.map(
-                      ({ node }, index) => {
-                        return (
-                          <React.Fragment key={index}>
-                            <AuctionResultItem
-                              auctionResult={node}
-                              lastChild={index === auctionResultsLength - 1}
-                            />
-                          </React.Fragment>
-                        )
-                      }
-                    )}
-                  </LoadingArea>
-                </Col>
+                <Spacer mt={3} />
+
+                <LoadingArea isLoading={this.state.isLoading}>
+                  {this.props.artist.auctionResultsConnection.edges.map(
+                    ({ node }, index) => {
+                      return (
+                        <React.Fragment key={index}>
+                          <AuctionResultItem
+                            auctionResult={node}
+                            lastChild={index === auctionResultsLength - 1}
+                          />
+                        </React.Fragment>
+                      )
+                    }
+                  )}
+                </LoadingArea>
+                {/* </Col> */}
               </Row>
 
               <Row>
@@ -199,6 +206,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           last: $last
           sort: $sort
         ) {
+          ...AuctionResultsCount_results
           pageInfo {
             hasNextPage
             endCursor

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -1,6 +1,5 @@
-import { Col, Row } from "@artsy/palette"
+import { Col, Flex, Row } from "@artsy/palette"
 import { ArtistAuctionResults_artist } from "__generated__/ArtistAuctionResults_artist.graphql"
-import { AuctionResultsCount_results } from "__generated__/AuctionResultsCount_results.graphql"
 import { PaginationFragmentContainer as Pagination } from "Components/v2"
 import React, { Component } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -8,14 +7,15 @@ import { Subscribe } from "unstated"
 import { ArtistAuctionDetailsModal } from "./ArtistAuctionDetailsModal"
 import { AuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import { AuctionResultsState } from "./state"
-import { TableColumns } from "./TableColumns"
+// import { TableColumns } from "./TableColumns"
 // import { TableSidebar } from "./TableSidebar"
 
-import { Box, Separator, Spacer } from "@artsy/palette"
+import { Box, Spacer } from "@artsy/palette"
 
 import { LoadingArea, LoadingAreaState } from "Components/v2/LoadingArea"
 import createLogger from "Utils/logger"
-import { AuctionResultsCount } from "./Components/AuctionResultsCount"
+import { AuctionResultsCountFragmentContainer as AuctionResultsCount } from "./Components/AuctionResultsCount"
+import { SortSelect } from "./Components/SortSelect"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
@@ -119,15 +119,17 @@ class AuctionResultsContainer extends Component<
                 */}
 
                 {/* <Col sm={10}> */}
-                <AuctionResultsCount
-                  results={artist.auctionResultsConnection}
-                />
-
-                <TableColumns />
-
-                <Box pt={0.5}>
-                  <Separator />
-                </Box>
+                <Flex
+                  justifyContent="space-between"
+                  alignItems="center"
+                  width="100%"
+                  mb={2}
+                >
+                  <AuctionResultsCount
+                    results={artist.auctionResultsConnection}
+                  />
+                  <SortSelect />
+                </Flex>
 
                 <ArtistAuctionDetailsModal
                   auctionResult={state.selectedAuction}

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultsCount.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultsCount.tsx
@@ -1,0 +1,27 @@
+import { Sans } from "@artsy/palette"
+import { AuctionResultsCount_results } from "__generated__/AuctionResultsCount_results.graphql"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface AuctionResultsCountProps {
+  results: AuctionResultsCount_results
+}
+
+export const AuctionResultsCount = ({ results }: AuctionResultsCountProps) => {
+  return (
+    <Sans size="2" weight="medium">
+      {`${results.totalCount.toLocaleString()} Results`}
+    </Sans>
+  )
+}
+
+export const ResultCountFragmentContainer = createFragmentContainer(
+  AuctionResultsCount,
+  {
+    results: graphql`
+      fragment AuctionResultsCount_results on AuctionResultConnection {
+        totalCount
+      }
+    `,
+  }
+)

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultsCount.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultsCount.tsx
@@ -10,12 +10,12 @@ interface AuctionResultsCountProps {
 export const AuctionResultsCount = ({ results }: AuctionResultsCountProps) => {
   return (
     <Sans size="2" weight="medium">
-      {`${results.totalCount.toLocaleString()} Results`}
+      {`Showing ${results.totalCount.toLocaleString()} results`}
     </Sans>
   )
 }
 
-export const ResultCountFragmentContainer = createFragmentContainer(
+export const AuctionResultsCountFragmentContainer = createFragmentContainer(
   AuctionResultsCount,
   {
     results: graphql`

--- a/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
@@ -1,4 +1,4 @@
-import { LargeSelect } from "@artsy/palette"
+import { SelectSmall } from "@artsy/palette"
 import React from "react"
 import { Subscribe } from "unstated"
 import { AuctionResultsState } from "../state"
@@ -6,7 +6,7 @@ import { AuctionResultsState } from "../state"
 const SORTS = [
   {
     value: "DATE_DESC",
-    text: "Most recent",
+    text: "Sale Date (Most recent)",
   },
   {
     value: "ESTIMATE_AND_DATE_DESC",
@@ -22,7 +22,7 @@ export const SortSelect = () => {
   return (
     <Subscribe to={[AuctionResultsState]}>
       {(filters: AuctionResultsState) => (
-        <LargeSelect
+        <SelectSmall
           options={SORTS}
           selected={filters.state.sort}
           onSelect={filters.setSort}

--- a/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
@@ -1,0 +1,33 @@
+import { LargeSelect } from "@artsy/palette"
+import React from "react"
+import { Subscribe } from "unstated"
+import { AuctionResultsState } from "../state"
+
+const SORTS = [
+  {
+    value: "DATE_DESC",
+    text: "Most recent",
+  },
+  {
+    value: "ESTIMATE_AND_DATE_DESC",
+    text: "Estimate",
+  },
+  {
+    value: "PRICE_AND_DATE_DESC",
+    text: "Sale price",
+  },
+]
+
+export const SortSelect = () => {
+  return (
+    <Subscribe to={[AuctionResultsState]}>
+      {(filters: AuctionResultsState) => (
+        <LargeSelect
+          options={SORTS}
+          selected={filters.state.sort}
+          onSelect={filters.setSort}
+        />
+      )}
+    </Subscribe>
+  )
+}

--- a/src/Apps/Artist/Routes/AuctionResults/TableSidebar.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/TableSidebar.tsx
@@ -1,32 +1,8 @@
 import React from "react"
-import { Subscribe } from "unstated"
 import { Media } from "Utils/Responsive"
-import { AuctionResultsState } from "./state"
 
-import {
-  Col,
-  Flex,
-  LargeSelect,
-  Row,
-  Sans,
-  Separator,
-  Spacer,
-} from "@artsy/palette"
-
-const SORTS = [
-  {
-    value: "DATE_DESC",
-    text: "Most recent",
-  },
-  {
-    value: "ESTIMATE_AND_DATE_DESC",
-    text: "Estimate",
-  },
-  {
-    value: "PRICE_AND_DATE_DESC",
-    text: "Sale price",
-  },
-]
+import { Flex, Row, Separator, Spacer } from "@artsy/palette"
+import { SortSelect } from "./Components/SortSelect"
 
 interface Props {
   count: number
@@ -34,40 +10,18 @@ interface Props {
 
 export const TableSidebar = (props: Props) => {
   return (
-    <Subscribe to={[AuctionResultsState]}>
-      {(filters: AuctionResultsState) => {
-        return (
-          <Flex flexDirection="column">
-            <Row>
-              <Col>{renderCount(props.count)}</Col>
-            </Row>
+    <Flex flexDirection="column">
+      <Media greaterThan="xs">
+        <Row pt={0.5}>
+          <Separator />
+        </Row>
+      </Media>
 
-            <Media greaterThan="xs">
-              <Row pt={0.5}>
-                <Separator />
-              </Row>
-            </Media>
+      <Spacer mt={[2, 3]} />
 
-            <Spacer mt={[2, 3]} />
+      <SortSelect />
 
-            <LargeSelect
-              options={SORTS}
-              selected={filters.state.sort}
-              onSelect={filters.setSort}
-            />
-
-            <Spacer mb={2} />
-          </Flex>
-        )
-      }}
-    </Subscribe>
-  )
-}
-
-const renderCount = (count: number) => {
-  return (
-    <Sans size="2" weight="medium">
-      {`${count.toLocaleString()} Results`}
-    </Sans>
+      <Spacer mb={2} />
+    </Flex>
   )
 }

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -38,17 +38,17 @@ describe("AuctionResults", () => {
     })
 
     it("renders proper elements", () => {
-      expect(wrapper.find("LargeSelect").length).toBe(1)
+      expect(wrapper.find("SelectSmall").length).toBe(1)
       expect(wrapper.find("Pagination").length).toBe(1)
       expect(wrapper.find("ArtistAuctionResultItem").length).toBe(10)
     })
 
     it("renders the proper count", () => {
-      expect(wrapper.html()).toContain("830 Results")
+      expect(wrapper.html()).toContain("Showing 830 results")
     })
 
     it("renders proper select options", () => {
-      const html = wrapper.find("LargeSelect").html()
+      const html = wrapper.find("SelectSmall").html()
       expect(html).toContain("Most recent")
       expect(html).toContain("Estimate")
       expect(html).toContain("Sale price")

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -62,6 +62,7 @@ fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
 fragment ArtistAuctionResults_artist_2TjZs4 on Artist {
   slug
   auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {
+    ...AuctionResultsCount_results
     pageInfo {
       hasNextPage
       endCursor
@@ -77,6 +78,10 @@ fragment ArtistAuctionResults_artist_2TjZs4 on Artist {
       }
     }
   }
+}
+
+fragment AuctionResultsCount_results on AuctionResultConnection {
+  totalCount
 }
 
 fragment Pagination_pageCursors on PageCursors {
@@ -272,6 +277,13 @@ return {
             "plural": false,
             "selections": [
               {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
+              {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "pageInfo",
@@ -349,13 +361,6 @@ return {
                     ]
                   }
                 ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "totalCount",
-                "args": null,
-                "storageKey": null
               },
               {
                 "kind": "LinkedField",
@@ -493,7 +498,7 @@ return {
     "operationKind": "query",
     "name": "ArtistAuctionResultsQuery",
     "id": null,
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2TjZs4\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_2TjZs4 on Artist {\n  slug\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2TjZs4\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_2TjZs4 on Artist {\n  slug\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_artist.graphql.ts
@@ -18,6 +18,7 @@ export type ArtistAuctionResults_artist = {
                 readonly " $fragmentRefs": FragmentRefs<"ArtistAuctionResultItem_auctionResult">;
             } | null;
         } | null> | null;
+        readonly " $fragmentRefs": FragmentRefs<"AuctionResultsCount_results">;
     } | null;
     readonly " $refType": "ArtistAuctionResults_artist";
 };
@@ -183,10 +184,15 @@ const node: ReaderFragment = {
               ]
             }
           ]
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "AuctionResultsCount_results",
+          "args": null
         }
       ]
     }
   ]
 };
-(node as any).hash = '91a544d759a1674fbda032fab9cf830d';
+(node as any).hash = '7ba95d8a09043fc63f344b9434f24f8d';
 export default node;

--- a/src/__generated__/AuctionResultsCount_results.graphql.ts
+++ b/src/__generated__/AuctionResultsCount_results.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type AuctionResultsCount_results = {
+    readonly totalCount: number | null;
+    readonly " $refType": "AuctionResultsCount_results";
+};
+export type AuctionResultsCount_results$data = AuctionResultsCount_results;
+export type AuctionResultsCount_results$key = {
+    readonly " $data"?: AuctionResultsCount_results$data;
+    readonly " $fragmentRefs": FragmentRefs<"AuctionResultsCount_results">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "AuctionResultsCount_results",
+  "type": "AuctionResultConnection",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "totalCount",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = 'b7cf8e974b1ff36d00728045da16d9eb';
+export default node;

--- a/src/__generated__/AuctionResults_Test_Query.graphql.ts
+++ b/src/__generated__/AuctionResults_Test_Query.graphql.ts
@@ -14,6 +14,7 @@ export type AuctionResults_Test_QueryRawResponse = {
     readonly artist: ({
         readonly slug: string;
         readonly auctionResultsConnection: ({
+            readonly totalCount: number | null;
             readonly pageInfo: {
                 readonly hasNextPage: boolean;
                 readonly endCursor: string | null;
@@ -39,7 +40,6 @@ export type AuctionResults_Test_QueryRawResponse = {
                     readonly page: number;
                 }) | null;
             };
-            readonly totalCount: number | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly title: string | null;
@@ -109,6 +109,7 @@ fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
 fragment ArtistAuctionResults_artist on Artist {
   slug
   auctionResultsConnection(first: 10, sort: DATE_DESC) {
+    ...AuctionResultsCount_results
     pageInfo {
       hasNextPage
       endCursor
@@ -124,6 +125,10 @@ fragment ArtistAuctionResults_artist on Artist {
       }
     }
   }
+}
+
+fragment AuctionResultsCount_results on AuctionResultConnection {
+  totalCount
 }
 
 fragment AuctionResults_artist on Artist {
@@ -277,6 +282,13 @@ return {
             "plural": false,
             "selections": [
               {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
+              {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "pageInfo",
@@ -354,13 +366,6 @@ return {
                     ]
                   }
                 ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "totalCount",
-                "args": null,
-                "storageKey": null
               },
               {
                 "kind": "LinkedField",
@@ -498,7 +503,7 @@ return {
     "operationKind": "query",
     "name": "AuctionResults_Test_Query",
     "id": null,
-    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_AuctionResultsQuery.graphql.ts
+++ b/src/__generated__/routes_AuctionResultsQuery.graphql.ts
@@ -51,6 +51,7 @@ fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
 fragment ArtistAuctionResults_artist on Artist {
   slug
   auctionResultsConnection(first: 10, sort: DATE_DESC) {
+    ...AuctionResultsCount_results
     pageInfo {
       hasNextPage
       endCursor
@@ -66,6 +67,10 @@ fragment ArtistAuctionResults_artist on Artist {
       }
     }
   }
+}
+
+fragment AuctionResultsCount_results on AuctionResultConnection {
+  totalCount
 }
 
 fragment AuctionResults_artist on Artist {
@@ -219,6 +224,13 @@ return {
             "plural": false,
             "selections": [
               {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
+              {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "pageInfo",
@@ -296,13 +308,6 @@ return {
                     ]
                   }
                 ]
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "totalCount",
-                "args": null,
-                "storageKey": null
               },
               {
                 "kind": "LinkedField",
@@ -440,7 +445,7 @@ return {
     "operationKind": "query",
     "name": "routes_AuctionResultsQuery",
     "id": null,
-    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
This PR:

- Removes the sidebar (which will be re-added with filters)
- Updates the results to be on top of the auction results list
- Slightly updates the result language

<img width="444" alt="image" src="https://user-images.githubusercontent.com/3087225/73580852-2280d980-4455-11ea-9dcb-99029006137c.png">

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/3087225/73580868-3a585d80-4455-11ea-87ee-a3b559dd06a6.png">

A few learnings from this

- When we add the filtering we'll have to pay special attention to how we do the `Showing X of Y results`
- We need to make sure we're properly co-locating components 
