### PR TITLE
Add missing title to sort select on auction results

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
@@ -23,7 +23,7 @@ export const SortSelect = () => {
     <Subscribe to={[AuctionResultsState]}>
       {(filters: AuctionResultsState) => (
         <SelectSmall
-          title="Sort:"
+          title="Sort"
           options={SORTS}
           selected={filters.state.sort}
           onSelect={filters.setSort}

--- a/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
@@ -6,7 +6,7 @@ import { AuctionResultsState } from "../state"
 const SORTS = [
   {
     value: "DATE_DESC",
-    text: "Sale Date (Most recent)",
+    text: "Sale Date (Most Recent First)",
   },
   {
     value: "ESTIMATE_AND_DATE_DESC",
@@ -23,6 +23,7 @@ export const SortSelect = () => {
     <Subscribe to={[AuctionResultsState]}>
       {(filters: AuctionResultsState) => (
         <SelectSmall
+          title="Sort:"
           options={SORTS}
           selected={filters.state.sort}
           onSelect={filters.setSort}

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -49,7 +49,7 @@ describe("AuctionResults", () => {
 
     it("renders proper select options", () => {
       const html = wrapper.find("SelectSmall").html()
-      expect(html).toContain("Most recent")
+      expect(html).toContain("Sale Date (Most Recent First)")
       expect(html).toContain("Estimate")
       expect(html).toContain("Sale price")
     })


### PR DESCRIPTION
Adds `Sort:` in front of the select as per the design specs. Also updates some of the language to match design spec. 

**Before**

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/3087225/73694954-2310ae80-46a7-11ea-8de3-35d0adb3ed37.png">

**After**

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/3087225/73694932-14c29280-46a7-11ea-8aa1-e9318c62d52e.png">
