### PR TITLE
Resize category rail

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
+import { resize } from "Utils/resizer"
 
 export interface CollectionProps {
   member: OtherCollectionEntity_member
@@ -37,7 +38,13 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
       <Flex alignItems="center" height="60px">
         {thumbnail && (
           <ImageContainer>
-            <ThumbnailImage src={thumbnail} />
+            <ThumbnailImage
+              src={resize(thumbnail, {
+                width: 60,
+                height: 60,
+                convert_to: "jpg",
+              })}
+            />
           </ImageContainer>
         )}
         <Box>

--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.test.tsx
@@ -39,8 +39,8 @@ describe("OtherCollectionEntity", () => {
       .at(0)
       .getElement().props
 
-    expect(thumbnailImage.src).toBe(
-      "http://files.artsy.net/images/posters_thumbnail.png"
+    expect(thumbnailImage.src).toContain(
+      "posters_thumbnail.png&width=60&height=60&quality=80&convert_to=jpg"
     )
 
     const link = component


### PR DESCRIPTION
Addresses: [FX-1775](https://artsyproduct.atlassian.net/browse/FX-1775)

The "Browse by category" rail is another instances where we were pulling in larger images than are needed. This PR uses the resize util to resize the collection thumbnail to 60x60.

<img width="1198" alt="Screen Shot 2020-02-04 at 9 54 16 AM" src="https://user-images.githubusercontent.com/5201004/73755645-55b4b880-4734-11ea-8b76-61dc87e1816a.png">
