### PR TITLE
Remove Node verson requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "repository": "https://github.com/artsy/reaction.git",
   "author": "Art.sy Inc <it@artsymail.com>",
   "license": "MIT",
-  "engines": {
-    "node": "^10.13.0"
-  },
   "peerDependencies": {
     "@artsy/palette": "^4.16.0 || ^5.0.0",
     "@sentry/browser": "^4.2.3",


### PR DESCRIPTION
Reaction isn't doing anything special that would require a constraint like this -- just running storybooks and compiling files with babel. However, when upgrading other apps that consume reaction, this constrain often gets in the way and requires more coordination than necessary. This removes that friction. 