### PR TITLE
Article text components use relay follow buttons

### DIFF
--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -1,6 +1,8 @@
 import ReactHtmlParser, { convertNodeToElement } from "@artsy/react-html-parser"
 import { startsWith } from "lodash"
+import PropTypes from "prop-types"
 import React, { Component } from "react"
+import styled from "styled-components"
 import { get } from "Utils/get"
 import { ArticleLayout } from "../Typings"
 import { StyledText } from "./StyledText"
@@ -23,6 +25,11 @@ export class Text extends Component<Props, State> {
   static defaultProps = {
     color: "black",
     showTooltips: false,
+  }
+
+  static contextTypes = {
+    tooltipsData: PropTypes.object,
+    onOpenAuthModal: PropTypes.func,
   }
 
   state = {
@@ -72,12 +79,76 @@ export class Text extends Component<Props, State> {
     return false
   }
 
-  transformNode = (node: Element, index) => {
-    const { color } = this.props
+  renderLinkWithToolTip = (node: Element, index) => {
     // Dont include relay components unless necessary
     // To avoid 'regeneratorRuntime' error
     const LinkWithTooltip = require("../ToolTip/LinkWithTooltip").default
+    const linkNode = node.childNodes[0]
 
+    if (linkNode && linkNode.textContent) {
+      const href = node.getAttribute("href")
+      const { color } = this.props
+      const props = { key: href + index, url: href, color }
+      const next = node.nextSibling
+      const text = linkNode.textContent
+
+      // Check to see if there's an apostrophe following a linked section of
+      // text and if found, return it.
+      const apostrophe = get(next, n => {
+        const str = n.textContent.substr(0, 2)
+        if (/[’'][a-zA-Z]/.test(str)) {
+          return str
+        }
+      })
+
+      if (apostrophe) {
+        // Remove the apostrophe from the original text
+        next.textContent = next.textContent.substring(2)
+        // And wrap the whole thing with a span preventing whitespace breaks
+        return (
+          <span
+            className="preventLineBreak"
+            key={`apostropheLinkNode-${props.key}`}
+          >
+            <LinkWithTooltip {...props}>{text}</LinkWithTooltip>
+            {apostrophe}
+          </span>
+        )
+      }
+
+      return <LinkWithTooltip {...props}>{text}</LinkWithTooltip>
+    }
+  }
+
+  isArtistFollow = (node: Element) => {
+    return (node.getAttribute("class") || "").includes("artist-follow")
+  }
+
+  artistIdToArtistFollow = (artistId: string) => {
+    const data = this.context.tooltipsData
+    if (!data || !data.artists) return null
+    return data.artists[artistId]
+  }
+
+  renderArtistFollowButton = (node: Element) => {
+    // Dont include relay components unless necessary
+    // To avoid 'regeneratorRuntime' error
+    const FollowButton = require("../../FollowButton/FollowArtistButton")
+      .FollowArtistButtonFragmentContainer
+
+    const { onOpenAuthModal } = this.context
+    const artistId = node.getAttribute("data-id")
+    const artist = this.artistIdToArtistFollow(artistId)
+    const props = { artist, onOpenAuthModal }
+
+    return (
+      <FollowContainer>
+        <FollowButton {...props} />
+      </FollowContainer>
+    )
+  }
+
+  transformNode = (node: Element, index) => {
     if (node.tagName === "P") {
       const newNode = node.ownerDocument.createElement("div")
       newNode.setAttribute("class", "paragraph")
@@ -85,40 +156,12 @@ export class Text extends Component<Props, State> {
       return convertNodeToElement(newNode, index, this.transformNode)
     }
 
-    if (node.tagName === "A" && this.shouldShowTooltipForURL(node)) {
-      const href = node.getAttribute("href")
-      const linkNode = node.childNodes[0]
-
-      if (linkNode && linkNode.textContent) {
-        const props = { key: href + index, url: href, color }
-        const next = node.nextSibling
-        const text = linkNode.textContent
-
-        // Check to see if there's an apostrophe following a linked section of
-        // text and if found, return it.
-        const apostrophe = get(next, n => {
-          const str = n.textContent.substr(0, 2)
-          if (/[’'][a-zA-Z]/.test(str)) {
-            return str
-          }
-        })
-
-        if (apostrophe) {
-          // Remove the apostrophe from the original text
-          next.textContent = next.textContent.substring(2)
-          // And wrap the whole thing with a span preventing whitespace breaks
-          return (
-            <span
-              className="preventLineBreak"
-              key={`apostropheLinkNode-${props.key}`}
-            >
-              <LinkWithTooltip {...props}>{text}</LinkWithTooltip>
-              {apostrophe}
-            </span>
-          )
-        }
-
-        return <LinkWithTooltip {...props}>{text}</LinkWithTooltip>
+    if (node.tagName === "A") {
+      if (this.isArtistFollow(node)) {
+        return this.renderArtistFollowButton(node)
+      }
+      if (this.shouldShowTooltipForURL(node)) {
+        return this.renderLinkWithToolTip(node, index)
       }
     }
   }
@@ -158,3 +201,9 @@ export class Text extends Component<Props, State> {
     )
   }
 }
+
+const FollowContainer = styled.div`
+  display: inline-block;
+  vertical-align: middle;
+  padding-left: 15px;
+`

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -142,7 +142,7 @@ export class Text extends Component<Props, State> {
     const props = { artist, onOpenAuthModal }
 
     return (
-      <FollowContainer>
+      <FollowContainer key={artistId}>
         <FollowButton {...props} />
       </FollowContainer>
     )

--- a/src/Components/Publishing/Sections/__tests__/Text.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Text.test.tsx
@@ -1,4 +1,5 @@
 import { SystemContextProvider } from "Artsy"
+import { FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { TextFeatureArticle } from "Components/Publishing/Fixtures/Articles"
 import { TextFromArticle } from "Components/Publishing/Fixtures/Helpers"
 import { wrapperWithContext } from "Components/Publishing/Fixtures/Helpers"
@@ -66,61 +67,76 @@ describe("Text", () => {
   // })
 
   describe("Unit", () => {
-    it("Inserts content-end spans if isContentEnd", () => {
-      testProps.html = TextFromArticle(TextFeatureArticle)
-      testProps.layout = "feature"
-      testProps.isContentEnd = true
-      const wrapper = mount(getWrapper(testProps))
+    describe("content-end", () => {
+      it("Inserts content-end spans if isContentEnd", () => {
+        testProps.html = TextFromArticle(TextFeatureArticle)
+        testProps.layout = "feature"
+        testProps.isContentEnd = true
+        const wrapper = mount(getWrapper(testProps))
 
-      expect(wrapper.html()).toMatch("content-end")
+        expect(wrapper.html()).toMatch("content-end")
+      })
+
+      it("Inserts content-end spans in last paragraph, even if another block follows", () => {
+        testProps.html = "<p>The end of the article</p><h3>An h3 after</h3>"
+        testProps.layout = "standard"
+        testProps.isContentEnd = true
+        const wrapper = mount(getWrapper(testProps))
+
+        expect(wrapper.html()).toMatch(
+          `<p>The end of the article<span class=\"content-end\"> </span></p><h3>An h3 after</h3>`
+        )
+      })
+
+      it("Removes content-end spans if not isContentEnd", () => {
+        testProps.html =
+          "<p>The end of a great article. <span class='content-end> </span></p>"
+        testProps.layout = "feature"
+        const wrapper = mount(getWrapper(testProps))
+
+        expect(wrapper.html()).not.toMatch("content-end")
+      })
     })
 
-    it("Inserts content-end spans in last paragraph, even if another block follows", () => {
-      testProps.html = "<p>The end of the article</p><h3>An h3 after</h3>"
-      testProps.layout = "standard"
-      testProps.isContentEnd = true
-      const wrapper = mount(getWrapper(testProps))
+    describe("ToolTips", () => {
+      it("Should add LinkWithTooltip when artsy link is contained", () => {
+        testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy">Banksy</a></p>`
+        testProps.layout = "standard"
+        testProps.showTooltips = true
+        const wrapper = mount(getWrapper(testProps))
 
-      expect(wrapper.html()).toMatch(
-        `<p>The end of the article<span class=\"content-end\"> </span></p><h3>An h3 after</h3>`
-      )
+        expect(wrapper.find(LinkWithTooltip)).toHaveLength(1)
+      })
+
+      it("Does not render for empty links", () => {
+        testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy"></a></p>`
+        testProps.layout = "standard"
+        testProps.showTooltips = true
+        const wrapper = mount(getWrapper(testProps))
+
+        expect(wrapper.find(LinkWithTooltip)).toHaveLength(0)
+      })
+
+      it("Creates a wrapper around links with 's text nodes, preventing line breaks", () => {
+        testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy">Banksy</a>'s other amazing content <a href="https://www.artsy.net/artist/pablo-picasso">Picasso</a>'s other amazing...</p>`
+        testProps.layout = "standard"
+        testProps.showTooltips = true
+        const wrapper = mount(getWrapper(testProps))
+
+        expect(wrapper.find(".preventLineBreak").length).toEqual(2)
+        expect(wrapper.html()).toContain("'s</span>")
+      })
     })
 
-    it("Removes content-end spans if not isContentEnd", () => {
-      testProps.html =
-        "<p>The end of a great article. <span class='content-end> </span></p>"
-      testProps.layout = "feature"
-      const wrapper = mount(getWrapper(testProps))
+    describe("Follow Buttons", () => {
+      it("Should add FollowArtistButton when .artist-follow link is present", () => {
+        testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy"></a><a data-id="banksy" class="artist-follow"></a></p>`
+        testProps.layout = "standard"
+        testProps.showTooltips = true
+        const wrapper = mount(getWrapper(testProps))
 
-      expect(wrapper.html()).not.toMatch("content-end")
-    })
-
-    it("Should add LinkWithTooltip when artsy link is contained", () => {
-      testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy">Banksy</a></p>`
-      testProps.layout = "standard"
-      testProps.showTooltips = true
-      const wrapper = mount(getWrapper(testProps))
-
-      expect(wrapper.find(LinkWithTooltip)).toHaveLength(1)
-    })
-
-    it("Does not render for empty links", () => {
-      testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy"></a></p>`
-      testProps.layout = "standard"
-      testProps.showTooltips = true
-      const wrapper = mount(getWrapper(testProps))
-
-      expect(wrapper.find(LinkWithTooltip)).toHaveLength(0)
-    })
-
-    it("Creates a wrapper around links with 's text nodes, preventing line breaks", () => {
-      testProps.html = `<p>Amazing content <a href="https://www.artsy.net/artist/banksy">Banksy</a>'s other amazing content <a href="https://www.artsy.net/artist/pablo-picasso">Picasso</a>'s other amazing...</p>`
-      testProps.layout = "standard"
-      testProps.showTooltips = true
-      const wrapper = mount(getWrapper(testProps))
-
-      expect(wrapper.find(".preventLineBreak").length).toEqual(2)
-      expect(wrapper.html()).toContain("'s</span>")
+        expect(wrapper.find(FollowArtistButton)).toHaveLength(1)
+      })
     })
   })
 })


### PR DESCRIPTION
We have been applying the Backbone follow button on the client, despite already fetching the necessary follow data for tooltips. 
This PR updates the text component to display Relay artist-follow buttons wherever the 'artist-follow' class is present on a link.

Related PR: https://github.com/artsy/force/pull/5004