### PR TITLE
Ensure PNG → JPG in Collection Hubs's related rail

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -142,6 +142,7 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
               width: 500,
               height: 500,
               quality: 80,
+              convert_to: "jpg",
             })}
           />
         </Flex>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1675

One more quickie optimization, thanks to Calibre's [report for hub pages](https://calibreapp.com/teams/artsy/artsy-net?page=9cd7a86b-b201-4479-8730-004f75cda411), which alerted me to the fact that we still had a few inappropriate PNGs on the page. 

![Screen Shot 2020-02-06 at 9 34 21 AM](https://user-images.githubusercontent.com/140521/73946523-0c936e80-48c4-11ea-8e73-7d508ea443ad.png)
