### PR TITLE
[Tracking Bugfix] Fix url and referrer tracking

### DIFF
--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -1,5 +1,6 @@
 import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import ActionTypes from "farce/lib/ActionTypes"
+import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
@@ -43,13 +44,34 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           if (!foundExcludedPath) {
             logger.warn("Tracking PageView:", pathname)
 
-            analytics.page(
-              { path: pathname, referrer },
-              { integrations: { Marketo: false } }
-            )
+            const trackingData: {
+              path: string
+              referrer?: string
+              url: string
+            } = {
+              path: pathname,
+              url: sd.APP_URL + pathname,
+            }
+
+            // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+            if (getENV("EXPERIMENTAL_APP_SHELL")) {
+              trackingData.referrer = sd.APP_URL + referrer
+            }
+
+            // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+            if (
+              ["/collect", "/collections", "/collection/"].some(path =>
+                pathname.includes(path)
+              ) &&
+              referrer
+            ) {
+              trackingData.referrer = sd.APP_URL + referrer
+            }
+
+            analytics.page(trackingData, { integrations: { Marketo: false } })
           }
 
-          // TODO: Remove after AB test ends.
+          // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
           if (getENV("EXPERIMENTAL_APP_SHELL")) {
             trackExperimentViewed("client_navigation_v2")
           }


### PR DESCRIPTION
Fixes an issue that was observed by @anipetrov: 

From [Slack message](https://artsy.slack.com/archives/CA8SANW3W/p1581028242462600?thread_ts=1580919019.365800&cid=CA8SANW3W): 

1. tracking pageview referrers from within reaction is producing referrers that are paths eg referrer: "/collection/post-war". in our transformations, we expect those to be urls, eg. referrer: "https://www.artsy.net/collection/post-war" we use external libraries to parse pageview referrers to define when a session is external and give proper channel attribution (eg if someone is coming from google, we parse that to search). those libraries expect urls.
2. the url property on reaction pages is inconsistent, eg in this case, the path is correct, referring to collection/roy-lihtenstein-landscapes but the url is the url of the previous page. seems to only happen upon a consecutive pageview of the same type, so collection > collection 

So the fix entailed bringing incorporating `sd.APP_URL` from force, and explicitly setting the `url` property to avoid the race. 