### PR TITLE
[Tracking Bugfix] Fix artwork page 1-off

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -24,6 +24,7 @@ import { Footer } from "Components/v2/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "Components/v2/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
+import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -78,7 +79,7 @@ export class ArtworkApp extends React.Component<Props> {
     // Can these props be tracked on mount using our typical @track() or
     // trackEvent() patterns as used in other apps?
     const properties = {
-      path: window.location.pathname,
+      path: sd.APP_URL + window.location.pathname,
       acquireable: is_acquireable,
       offerable: is_offerable,
       availability,

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -37,6 +37,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           typeof window.analytics !== "undefined" && window.analytics
 
         if (analytics) {
+          // TODO: Pass referrer over to Artwork page if A/B test passes
+          // window.sd.routerReferrer = referrer
+
           const foundExcludedPath = excludePaths.some(excludedPath => {
             return pathname.includes(excludedPath)
           })
@@ -55,7 +58,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
             if (getENV("EXPERIMENTAL_APP_SHELL")) {
-              trackingData.referrer = sd.APP_URL + referrer
+              if (referrer) {
+                trackingData.referrer = sd.APP_URL + referrer
+              }
             }
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.


### PR DESCRIPTION
Caught a small bug on staging related to how we handle page-view tracking differently in the Artwork app. Had to update with the full path. 