### PR TITLE
[Bugfix] Ensure nav closed on clienside routes

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -15,8 +15,14 @@ import {
 
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
+import { getENV } from "Utils/getENV"
 
-export const MobileNavMenu: React.FC = () => {
+interface MobileNavMenuProps {
+  onNavItemClick?: () => void
+}
+
+export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
+  const { onNavItemClick } = props
   const { trackEvent } = useTracking()
   const { user } = useContext(SystemContext)
   const isLoggedIn = Boolean(user)
@@ -31,6 +37,11 @@ export const MobileNavMenu: React.FC = () => {
       subject: text,
       destination_path: href,
     })
+
+    // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+    if (getENV("EXPERIMENTAL_APP_SHELL") && href === "/collect") {
+      onNavItemClick()
+    }
   }
 
   return (

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -229,7 +229,7 @@ export const NavBar: React.FC = track(
       {showMobileMenu && (
         <>
           <MobileNavCover onClick={() => toggleMobileNav(false)} />
-          <MobileNavMenu />
+          <MobileNavMenu onNavItemClick={() => toggleMobileNav(false)} />
         </>
       )}
     </header>

--- a/src/Components/NavBarTest/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBarTest/Menus/MobileNavMenu.tsx
@@ -15,8 +15,14 @@ import {
 
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
+import { getENV } from "Utils/getENV"
 
-export const MobileNavMenu: React.FC = () => {
+interface MobileNavMenuProps {
+  onNavItemClick?: () => void
+}
+
+export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
+  const { onNavItemClick } = props
   const { trackEvent } = useTracking()
   const { user } = useContext(SystemContext)
   const isLoggedIn = Boolean(user)
@@ -31,6 +37,11 @@ export const MobileNavMenu: React.FC = () => {
       subject: text,
       destination_path: href,
     })
+
+    // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+    if (getENV("EXPERIMENTAL_APP_SHELL") && href === "/collect") {
+      onNavItemClick()
+    }
   }
 
   return (

--- a/src/Components/NavBarTest/NavBar.tsx
+++ b/src/Components/NavBarTest/NavBar.tsx
@@ -220,7 +220,7 @@ export const NavBarTest: React.FC = track(
       {showMobileMenu && (
         <>
           <MobileNavCover onClick={() => toggleMobileNav(false)} />
-          <MobileNavMenu />
+          <MobileNavMenu onNavItemClick={() => toggleMobileNav(false)} />
         </>
       )}
     </>


### PR DESCRIPTION
Noticed a little bug in the mobile nav: When the new app shell is enabled, the mobile nav doesn't close on `/collect` link click because there's not a full page transition. 