### PR TITLE
[Clientside Routing] Update mobile page loader to be more obvious

### DIFF
--- a/src/Artsy/Router/Utils/RenderStatus.tsx
+++ b/src/Artsy/Router/Utils/RenderStatus.tsx
@@ -6,6 +6,7 @@ import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
+import { Media } from "Utils/Responsive"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
@@ -17,16 +18,34 @@ export const RenderPending = () => {
   return (
     <>
       <Renderer>{null}</Renderer>
-      <PageLoader
-        className="reactionPageLoader" // positional styling comes from Force body.styl
-        showBackground={false}
-        style={{
-          position: "fixed",
-          left: 0,
-          top: -6,
-          zIndex: 1000,
-        }}
-      />
+      <Media lessThan="md">
+        <Box
+          className="reactionPageLoader" // positional styling comes from Force body.styl
+          style={{
+            background: "#ffffff10",
+            position: "fixed",
+            width: "100%",
+            height: "100%",
+            left: 0,
+            top: -6,
+            zIndex: 1000,
+          }}
+        >
+          hi mobile!
+        </Box>
+      </Media>
+      <Media greaterThanOrEqual="md">
+        <PageLoader
+          className="reactionPageLoader" // positional styling comes from Force body.styl
+          showBackground={false}
+          style={{
+            position: "fixed",
+            left: 0,
+            top: -6,
+            zIndex: 1000,
+          }}
+        />
+      </Media>
     </>
   )
 }

--- a/src/Artsy/Router/Utils/RenderStatus.tsx
+++ b/src/Artsy/Router/Utils/RenderStatus.tsx
@@ -5,6 +5,7 @@ import { Box, PageLoader } from "@artsy/palette"
 import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
+import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 
@@ -15,26 +16,56 @@ export const RenderPending = () => {
    * TODO: Add timeout here for when a request takes too long. Show generic error
    * and notify Sentry.
    */
-  return (
-    <>
-      <Renderer>{null}</Renderer>
-      <Media lessThan="md">
-        <Box
-          className="reactionPageLoader" // positional styling comes from Force body.styl
-          style={{
-            background: "#ffffff10",
-            position: "fixed",
-            width: "100%",
-            height: "100%",
-            left: 0,
-            top: -6,
-            zIndex: 1000,
-          }}
-        >
-          hi mobile!
-        </Box>
-      </Media>
-      <Media greaterThanOrEqual="md">
+  if (getENV("EXPERIMENTAL_APP_SHELL")) {
+    return (
+      <>
+        <Renderer>{null}</Renderer>
+
+        {/*
+          FIXME: Remove when EXPERIMENTAL_APP_SHELL a/b test is complete
+        */}
+        <Media lessThan="md">
+          <Box
+            className="reactionPageLoader" // positional styling comes from Force body.styl
+            style={{
+              background: "#ffffff90",
+              position: "fixed",
+              width: "100%",
+              height: "100%",
+              left: 0,
+              top: -6,
+              zIndex: 1000,
+            }}
+          >
+            <PageLoader
+              showBackground={false}
+              style={{
+                top: "50vh",
+                position: "absolute",
+                left: 0,
+                zIndex: 1000,
+              }}
+            />
+          </Box>
+        </Media>
+        <Media greaterThanOrEqual="md">
+          <PageLoader
+            className="reactionPageLoader" // positional styling comes from Force body.styl
+            showBackground={false}
+            style={{
+              position: "fixed",
+              left: 0,
+              top: -6,
+              zIndex: 1000,
+            }}
+          />
+        </Media>
+      </>
+    )
+  } else {
+    return (
+      <>
+        <Renderer>{null}</Renderer>
         <PageLoader
           className="reactionPageLoader" // positional styling comes from Force body.styl
           showBackground={false}
@@ -45,9 +76,9 @@ export const RenderPending = () => {
             zIndex: 1000,
           }}
         />
-      </Media>
-    </>
-  )
+      </>
+    )
+  }
 }
 
 export const RenderReady: React.FC<{


### PR DESCRIPTION
We're speculating that this might be what impacted inquiries on mobile during the A/B test -- meaning, a user has clicked a link, and they can't see that a loader is going by on the top of the screen and they think the page may have timed out? This puts it in the middle, and dims the background a bit. After the A/B test results we'll need to go back to design for something a more permanent. 

![loader](https://user-images.githubusercontent.com/236943/74098490-8e0a1d00-4acd-11ea-826e-8b234db74467.gif)
