### PR TITLE
[Analytics] Path is relative

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -24,7 +24,6 @@ import { Footer } from "Components/v2/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "Components/v2/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
-import { data as sd } from "sharify"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -81,7 +80,7 @@ export class ArtworkApp extends React.Component<Props> {
     // Can these props be tracked on mount using our typical @track() or
     // trackEvent() patterns as used in other apps?
     const properties = {
-      path: sd.APP_URL + window.location.pathname,
+      path: window.location.pathname,
       acquireable: is_acquireable,
       offerable: is_offerable,
       availability,

--- a/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
+++ b/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
@@ -34,7 +34,7 @@ describe("trackingMiddleware", () => {
 
     expect(global.analytics.page).toBeCalledWith(
       {
-        path: "http://testing.com/foo",
+        path: "/foo",
         url: "http://testing.com/foo",
       },
       { integrations: { Marketo: false } }
@@ -90,7 +90,7 @@ describe("trackingMiddleware", () => {
 
         expect(global.analytics.page).toBeCalledWith(
           {
-            path: `http://testing.com${pathToTest}`,
+            path: pathToTest,
             referrer: `http://testing.com/referrer`,
             url: `http://testing.com${pathToTest}`,
           },

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -52,7 +52,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
               referrer?: string
               url: string
             } = {
-              path: sd.APP_URL + pathname,
+              path: pathname,
               url: sd.APP_URL + pathname,
             }
 


### PR DESCRIPTION
@anipetrov pinged this morning and mentioned that the path doesn't need to be full -- communication mixup on my side. 

```
path: "/collection/post-war-print-renaissance"
url: "https://www.artsy.net/collection/post-war-print-renaissance"
referrer: "https://www.artsy.net/collection/post-war"
```