### PR TITLE
Remove deprecated fonts from classic articles, fix bylines

### DIFF
--- a/2
+++ b/2
@@ -1,0 +1,1 @@
+"./scripts/quicklink-to-project.sh"

--- a/src/Components/Publishing/Byline/ClassicByline.tsx
+++ b/src/Components/Publishing/Byline/ClassicByline.tsx
@@ -1,9 +1,13 @@
-import { color } from "@artsy/palette"
-import { avantgarde } from "Assets/Fonts"
+import { Box, color, Sans } from "@artsy/palette"
+import { Share, ShareContainer } from "Components/Publishing/Byline/Share"
+import {
+  getArticleFullHref,
+  getAuthorByline,
+  getDate,
+} from "Components/Publishing/Constants"
+import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
-import { getAuthorByline, getDate } from "../Constants"
-import { ArticleData } from "../Typings"
 
 interface ClassicBylineProps {
   date?: string
@@ -12,33 +16,55 @@ interface ClassicBylineProps {
 
 export const ClassicByline: React.SFC<ClassicBylineProps> = props => {
   const {
-    article: { contributing_authors, author, published_at },
+    article: {
+      channel,
+      contributing_authors,
+      author,
+      published_at,
+      slug,
+      social_title,
+      thumbnail_title,
+    },
     date,
   } = props
 
   const contributors = getAuthorByline(contributing_authors, false)
+  const byline = author ? author.name : channel && channel.name
 
   return (
-    <ClassicBylineContainer>
+    <ClassicBylineContainer textAlign={["left", "center"]}>
       {contributors ? (
         <div>
-          <TextSm>{author.name}</TextSm>
-          <div>{`By ${contributors}`}</div>
+          {author && (
+            <Sans size="3" weight="medium">
+              {author.name}
+            </Sans>
+          )}
+          <Sans size="4" weight="medium">{`By ${contributors}`}</Sans>
         </div>
       ) : (
-        author.name
+        byline && (
+          <Sans size="4" weight="medium">
+            {byline}
+          </Sans>
+        )
       )}
-      <TextSm color={color("black60")}>{getDate(date || published_at)}</TextSm>
+      <Sans size="3" weight="medium" color={color("black60")}>
+        {getDate(date || published_at)}
+      </Sans>
+
+      <Share
+        url={getArticleFullHref(slug)}
+        title={social_title || thumbnail_title}
+      />
     </ClassicBylineContainer>
   )
 }
 
-const TextSm = styled.div.attrs<{ color?: string }>({})`
-  ${avantgarde("s11")}
-  color: ${props => (props.color ? props.color : "black")};
-`
-
-const ClassicBylineContainer = styled.div`
+const ClassicBylineContainer = styled(Box)`
   display: block;
-  ${avantgarde("s13")};
+
+  ${ShareContainer} {
+    display: inline-block;
+  }
 `

--- a/src/Components/Publishing/Byline/__tests__/ClassicByline.test.tsx
+++ b/src/Components/Publishing/Byline/__tests__/ClassicByline.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import renderer from "react-test-renderer"
 import {
   ClassicArticle,
+  ClassicArticleInternalChannel,
   ClassicArticleManyAuthors,
 } from "../../Fixtures/Articles"
 import { ClassicByline } from "../ClassicByline"
@@ -24,6 +25,13 @@ describe("ClassicByline", () => {
       expect(snapshot).toMatchSnapshot()
     })
 
+    it("renders internal channel bylines", () => {
+      const snapshot = renderer.create(
+        <ClassicByline article={ClassicArticleInternalChannel} />
+      )
+      expect(snapshot).toMatchSnapshot()
+    })
+
     it("renders a custom date", () => {
       const snapshot = renderer.create(
         <ClassicByline
@@ -36,10 +44,11 @@ describe("ClassicByline", () => {
   })
 
   describe("Unit", () => {
-    const getWrapper = _props => {
+    let props
+    const getWrapper = (_props = props) => {
       return mount(<ClassicByline {..._props} />)
     }
-    let props
+
     beforeEach(() => {
       props = {
         article: ClassicArticle,
@@ -47,27 +56,34 @@ describe("ClassicByline", () => {
     })
 
     it("renders a single author", () => {
-      const component = getWrapper(props)
+      const component = getWrapper()
       expect(component.text()).toMatch("Joanne Artman Gallery")
     })
 
     it("renders multiple authors", () => {
       props.article = ClassicArticleManyAuthors
-      const component = getWrapper(props)
+      const component = getWrapper()
       expect(component.text()).toMatch("Joanne Artman Gallery")
       expect(component.text()).toMatch(
         "By First Author, Second Author and Third Author"
       )
     })
 
+    it("renders internal channels as author", () => {
+      props.article = ClassicArticleInternalChannel
+      delete props.article.author
+      const component = getWrapper()
+      expect(component.text()).toMatch("Artsy Jobs")
+    })
+
     it("renders published date", () => {
-      const component = getWrapper(props)
+      const component = getWrapper()
       expect(component.text()).toMatch("Jul 28, 2017 4:38pm")
     })
 
     it("renders a custom date", () => {
       props.date = "2017-05-19T13:09:18.567Z"
-      const component = getWrapper(props)
+      const component = getWrapper()
       expect(component.text()).toMatch("May 19, 2017 9:09am")
     })
   })

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/ClassicByline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/ClassicByline.test.tsx.snap
@@ -388,6 +388,179 @@ exports[`ClassicByline Snapshots renders a single author 1`] = `
 </div>
 `;
 
+exports[`ClassicByline Snapshots renders internal channel bylines 1`] = `
+.c1 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c2 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
+  color: #666;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c5 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c5:hover {
+  opacity: 0.6;
+}
+
+.c5:first-child {
+  padding-left: 0;
+}
+
+.c0 {
+  text-align: left;
+  display: block;
+}
+
+.c0 .c3 {
+  display: inline-block;
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    text-align: center;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    fontFamily={
+      Object {
+        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontWeight": 500,
+      }
+    }
+    fontSize="16px"
+  >
+    Artsy Jobs
+  </div>
+  <div
+    className="c2"
+    color="#666"
+    fontFamily={
+      Object {
+        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontWeight": 500,
+      }
+    }
+    fontSize="14px"
+  >
+    Feb 5, 2020 3:51pm
+  </div>
+  <div
+    className="c3 c4"
+  >
+    <a
+      className="c5"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-jobs-consignments-intern-02-05-20"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 14 14"
+        width="14px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c5"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-jobs-consignments-intern-02-05-20&text=Consignments Intern&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fartsy-jobs-consignments-intern-02-05-20&via=artsy"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 16 14"
+        width="16px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c5"
+      href="mailto:?subject=Consignments Intern&body=Check out Consignments Intern on Artsy: https://www.artsy.net/article/artsy-jobs-consignments-intern-02-05-20"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 17 14"
+        width="17px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+  </div>
+</div>
+`;
+
 exports[`ClassicByline Snapshots renders multiple authors 1`] = `
 .c1 {
   font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;

--- a/src/Components/Publishing/Byline/__tests__/__snapshots__/ClassicByline.test.tsx.snap
+++ b/src/Components/Publishing/Byline/__tests__/__snapshots__/ClassicByline.test.tsx.snap
@@ -2,42 +2,69 @@
 
 exports[`ClassicByline Snapshots renders a custom date 1`] = `
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
-  color: black;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
 }
 
 .c2 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
   color: #666;
 }
 
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c6 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c6:hover {
+  opacity: 0.6;
+}
+
+.c6:first-child {
+  padding-left: 0;
+}
+
 .c0 {
+  text-align: left;
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 13px;
-  line-height: 1.65em;
+}
+
+.c0 .c4 {
+  display: inline-block;
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    text-align: center;
+  }
 }
 
 <div
@@ -46,60 +73,192 @@ exports[`ClassicByline Snapshots renders a custom date 1`] = `
   <div>
     <div
       className="c1"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="14px"
     >
       Joanne Artman Gallery
     </div>
-    <div>
+    <div
+      className="c2"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="16px"
+    >
       By First Author, Second Author and Third Author
     </div>
   </div>
   <div
-    className="c2"
+    className="c3"
     color="#666"
+    fontFamily={
+      Object {
+        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontWeight": 500,
+      }
+    }
+    fontSize="14px"
   >
     May 19, 2017 9:09am
+  </div>
+  <div
+    className="c4 c5"
+  >
+    <a
+      className="c6"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 14 14"
+        width="14px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 16 14"
+        width="16px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="mailto:?subject=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/article/joanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 17 14"
+        width="17px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
   </div>
 </div>
 `;
 
 exports[`ClassicByline Snapshots renders a single author 1`] = `
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
-  color: black;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
 }
 
 .c2 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
   color: #666;
 }
 
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c6 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c6:hover {
+  opacity: 0.6;
+}
+
+.c6:first-child {
+  padding-left: 0;
+}
+
 .c0 {
+  text-align: left;
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 13px;
-  line-height: 1.65em;
+}
+
+.c0 .c4 {
+  display: inline-block;
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    text-align: center;
+  }
 }
 
 <div
@@ -108,60 +267,192 @@ exports[`ClassicByline Snapshots renders a single author 1`] = `
   <div>
     <div
       className="c1"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="14px"
     >
       Joanne Artman Gallery
     </div>
-    <div>
+    <div
+      className="c2"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="16px"
+    >
       By First Author, Second Author and Third Author
     </div>
   </div>
   <div
-    className="c2"
+    className="c3"
     color="#666"
+    fontFamily={
+      Object {
+        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontWeight": 500,
+      }
+    }
+    fontSize="14px"
   >
     Jul 28, 2017 4:38pm
+  </div>
+  <div
+    className="c4 c5"
+  >
+    <a
+      className="c6"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 14 14"
+        width="14px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 16 14"
+        width="16px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="mailto:?subject=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/article/joanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 17 14"
+        width="17px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
   </div>
 </div>
 `;
 
 exports[`ClassicByline Snapshots renders multiple authors 1`] = `
 .c1 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
-  color: black;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
 }
 
 .c2 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c3 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
   color: #666;
 }
 
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c6 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c6:hover {
+  opacity: 0.6;
+}
+
+.c6:first-child {
+  padding-left: 0;
+}
+
 .c0 {
+  text-align: left;
   display: block;
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 13px;
-  line-height: 1.65em;
+}
+
+.c0 .c4 {
+  display: inline-block;
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    text-align: center;
+  }
 }
 
 <div
@@ -170,18 +461,123 @@ exports[`ClassicByline Snapshots renders multiple authors 1`] = `
   <div>
     <div
       className="c1"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="14px"
     >
       Joanne Artman Gallery
     </div>
-    <div>
+    <div
+      className="c2"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="16px"
+    >
       By First Author, Second Author and Third Author
     </div>
   </div>
   <div
-    className="c2"
+    className="c3"
     color="#666"
+    fontFamily={
+      Object {
+        "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontWeight": 500,
+      }
+    }
+    fontSize="14px"
   >
     Jul 28, 2017 4:38pm
+  </div>
+  <div
+    className="c4 c5"
+  >
+    <a
+      className="c6"
+      href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 14 14"
+        width="14px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 16 14"
+        width="16px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c6"
+      href="mailto:?subject=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/article/joanne-artman-gallery-poetry-naturerefinement-form"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <svg
+        height="14px"
+        version="1.1"
+        viewBox="0 0 17 14"
+        width="17px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="1"
+        >
+          <path
+            d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+            fill="black"
+          />
+        </g>
+      </svg>
+    </a>
   </div>
 </div>
 `;

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -35,7 +35,9 @@ export const getArticleFullHref = slug => `${APP_URL}/article/${slug}`
  */
 
 export const getPreSlugPath = layout => {
-  return ["standard", "feature"].includes(layout) ? "article" : layout
+  return ["standard", "feature", "classic"].includes(layout)
+    ? "article"
+    : layout
 }
 
 /**

--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -68,7 +68,7 @@ export const getAuthorByline = (authors, isEditoral = true) => {
   const authorCount = Number(authors && authors.length)
 
   if (authorCount === 1) {
-    return authors[0].name || ""
+    return (authors[0] && authors[0].name) || ""
   } else if (authorCount > 1) {
     const names = authors.reduce((prev, curr, i) => {
       let delim

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -141,6 +141,35 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
   margin-bottom: 20px;
 }
 
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c23 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c23:hover {
+  opacity: 0.6;
+}
+
+.c23:first-child {
+  padding-left: 0;
+}
+
 .c20 {
   margin: 10px 20px 0 0;
 }
@@ -172,35 +201,6 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
 .c21 {
   margin: 5px 20px 0 0;
   white-space: nowrap;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  white-space: nowrap;
-  line-height: 1em;
-  margin-top: 5px;
-}
-
-.c23 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding-left: 7px;
-  padding-right: 7px;
-}
-
-.c23:hover {
-  opacity: 0.6;
-}
-
-.c23:first-child {
-  padding-left: 0;
 }
 
 .c18 {
@@ -6637,25 +6637,6 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
   line-height: 32px;
 }
 
-.c21 {
-  margin: 10px 20px 0 0;
-}
-
-.c21::before {
-  content: "";
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin: 5px 5px 1px 0;
-  background-color: black;
-}
-
-.c23 {
-  margin: 5px 20px 0 0;
-  white-space: nowrap;
-}
-
 .c16 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -6683,6 +6664,25 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
 
 .c17:first-child {
   padding-left: 0;
+}
+
+.c21 {
+  margin: 10px 20px 0 0;
+}
+
+.c21::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin: 5px 5px 1px 0;
+  background-color: black;
+}
+
+.c23 {
+  margin: 5px 20px 0 0;
+  white-space: nowrap;
 }
 
 .c37 {

--- a/src/Components/Publishing/Fixtures/Articles.ts
+++ b/src/Components/Publishing/Fixtures/Articles.ts
@@ -166,6 +166,53 @@ export const ClassicArticleManyAuthors = extend({}, ClassicArticle, {
   ],
 })
 
+export const ClassicArticleInternalChannel: ArticleData = {
+  id: "5e3b232c77aee50020ddfb7f",
+  title: "Consignments Intern",
+  description:
+    "Artsy’s mission is to expand the art market to support more artists and art in the world. Artsy has created the world’s largest two-sided art marketpl...",
+  thumbnail_image:
+    "https://artsy-media-uploads.s3.amazonaws.com/QqdsjeaNSJcspGs0pEw_7A%2F18_11_09_Artsy_0377%2B0366%2B0386.jpg",
+  thumbnail_title: "Consignments Intern",
+  published_at: "2020-02-05T20:51:39.758Z",
+  tags: [],
+  tracking_tags: [],
+  slug: "artsy-jobs-consignments-intern-02-05-20",
+  layout: "classic",
+  featured: false,
+  channel_id: "578eb73cb5989e6f98f779a1",
+  partner_channel_id: null,
+  lead_paragraph:
+    "<p>Artsy’s mission is to expand the art market to support more artists and art in the world. Artsy has created the world’s largest two-sided art marketplace, with more than 1,000,000 works by 100,000 artists from 4,000 of the world’s leading galleries, auction houses, art fairs, and institutions across 190 countries. </p>",
+  keywords: [],
+  published: true,
+  email_metadata: {
+    headline: "Consignments Intern",
+    author: "Artsy Jobs",
+    image_url:
+      "https://artsy-media-uploads.s3.amazonaws.com/e7TOhXLnd0vkNqtFRByrgQ%2F18_11_09_Artsy_0123.jpg",
+  },
+  author: {
+    name: "Artsy Jobs",
+  },
+  authors: null,
+  channel: {
+    name: "Artsy Jobs",
+  },
+  sections: [
+    {
+      type: "text",
+      body:
+        '<p>We are currently seeking an analytical and driven Consignments Intern who will help grow this new Artsy business and provide guidance and expertise to collectors while selling their art.</p><p>The Consignments team is a recent area of business investment that aims to create more liquidity in the market and enable collectors to sell and rotate their collection more frequently, seamlessly and with the best outcome.</p><p>The Consignments Intern will be responsible for being the first person reviewing incoming Consignment property submissions, addressing inquiries from collectors via email and phone, as well as supporting the team of Specialists with a variety of administrative tasks. This is a unique opportunity for a professional early in their career in the art industry, who is eager to play an important role in growing a new business within Artsy. </p><p><br></p><h2>Key Responsibilities:</h2><ul><li>Review consignment submissions and ensuring that consignment requests are being evaluated promptly</li><li>Identify and surface high-value property and consignors to Specialists </li><li>Catalog consignment submissions data </li><li>Create consignment reports </li><li>Address consignment requests via email, phone and in-person requests</li><li>Log and synthesize feedback from clients</li><li>Track the status of Artsy’s consignments thorough follow-ups with partners and logging consignments outcomes </li></ul><p><br></p><h2>Candidate Qualifications:</h2><ul><li>0-3 years of professional experience (preferably in an auction house setting)</li><li>Background or experience in art market and/or art history - preferably with a focus on research, data or analytics</li><li>Excellent analytical skills and focus on process</li><li>Strong written and verbal communication skills</li><li>Ability to work on tight deadlines and under pressure</li><li>Comfort operating independently in a fast-paced environment</li><li>Proficiency in a language other than English is a plus, but not required</li><li>Solutions-oriented and go-getter mentality</li></ul><p><br></p><h2>To Apply:</h2><p>This position is a paid full-time, six month internship based in our Manhattan offices. To apply, please submit your resumé and a cover letter <strong><a href="https://grnh.se/298b49861">here</a>.</strong> </p><p><em>When you apply, you will be directed to a third party site.</em></p>',
+    },
+    {
+      type: "text",
+      body:
+        "<h2>Artsy Values</h2><p>Artsy has five core values that will inform your experience at Artsy.</p><p><strong>Art x Science:</strong> We believe in uniting empathy with logic, emotion with data, and intuition with research in everything we do. Whether in business strategy or design, culture or code, we seek the magic that happens when the often separate worlds of art and science come together.</p><p><strong>People are Paramount:</strong> We spend extraordinary energy finding the best person for a job—and once found, we give them the trust and autonomy to be CEO of their role. We avoid pointless bureaucracy and prefer to empower people with information rather than limit them with process.</p><p><strong>Quality Worthy of Art:</strong> We aim to create an experience worthy of all the world’s art and so hold ourselves to the highest standards in all our work. We believe that the best long term quality comes from rapid shipping, iterating, and learning as we go.</p><p><strong>Positive Energy:</strong> We know positivity and optimism benefit our work, and we harness positive energy as a vehicle towards greater awareness, growth, and collaboration. We believe in cultivating a positive relationship to art as opposed to one based on exclusivity or scarcity.</p><p><strong>Openness:</strong> We believe in being open with each other and the world—whether in open-sourcing our code, sharing feedback, or building a diverse and inclusive work culture. We believe in bringing our full selves to work and manifesting an open world where everyone has access to art.</p><p><em>Artsy is an equal opportunity employer. We value a diverse workforce and an inclusive culture. We encourage applications from all qualified individuals without regard to race, color, religion, gender, sexual orientation, gender identity or expression, age, national origin, marital status, disability, and veteran status.</em></p>",
+    },
+  ],
+}
+
 export const StandardArticle: ArticleData = {
   id: "594a7e2254c37f00177c0ea9",
   title: "New York's Next Art District",

--- a/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/ClassicHeader.tsx
@@ -1,13 +1,11 @@
-import { space } from "@artsy/palette"
-import { garamond } from "Assets/Fonts"
+import { Flex, Serif, space } from "@artsy/palette"
+import { ClassicByline } from "Components/Publishing/Byline/ClassicByline"
+import { ArticleData } from "Components/Publishing/Typings"
 import React, { ReactElement } from "react"
 import styled from "styled-components"
-import { pMedia } from "../../../Helpers"
-import { ClassicByline } from "../../Byline/ClassicByline"
-import { ArticleData } from "../../Typings"
 
 interface ClassicHeaderProps {
-  article?: ArticleData
+  article: ArticleData
   date?: string
   editLeadParagraph?: ReactElement<any>
   editTitle?: ReactElement<any>
@@ -15,62 +13,44 @@ interface ClassicHeaderProps {
 
 export const ClassicHeader: React.SFC<ClassicHeaderProps> = props => {
   const { article, date, editTitle, editLeadParagraph } = props
-  return (
-    <ClassicHeaderContainer>
-      <Title>{editTitle || <h1>{article.title}</h1>}</Title>
 
+  return (
+    <Flex
+      flexDirection="column"
+      my={space(4)}
+      mx="auto"
+      px={[space(2), 0]}
+      alignItems={["left", "center"]}
+      maxWidth={["580px", "900px"]}
+    >
+      <Title size={["8", "10"]} pb={space(3)} textAlign={["left", "center"]}>
+        {editTitle || <h1>{article.title}</h1>}
+      </Title>
       {editLeadParagraph ? (
-        <LeadParagraph>{editLeadParagraph}</LeadParagraph>
+        <LeadParagraph size="4">{editLeadParagraph}</LeadParagraph>
       ) : (
-        <LeadParagraph
-          dangerouslySetInnerHTML={{ __html: article.lead_paragraph }}
-        />
+        article.lead_paragraph && (
+          <LeadParagraph size="4">
+            <div dangerouslySetInnerHTML={{ __html: article.lead_paragraph }} />
+          </LeadParagraph>
+        )
       )}
       <ClassicByline article={article} date={date} />
-    </ClassicHeaderContainer>
+    </Flex>
   )
 }
 
-const ClassicHeaderContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  max-width: 900px;
-  width: 100%;
-  margin: ${space(4)}px auto;
-  box-sizing: border-box;
-  text-align: center;
+export const Title = styled(Serif)``
 
-  ${pMedia.xl`padding: 0 ${space(2)}px;`};
-
-  ${pMedia.xs`
-    text-align: left;
-  `};
-`
-
-export const Title = styled.div`
-  padding-bottom: ${space(3)}px;
-  ${garamond("s37")};
-
-  ${pMedia.xs`
-    ${garamond("s34")}
-  `};
-`
-
-export const LeadParagraph = styled.div`
-  ${garamond("s19")};
-  line-height: 1.35em;
-  text-align: left;
+export const LeadParagraph = styled(Serif)`
   max-width: 580px;
   width: 100%;
   margin: 0 auto;
   padding-bottom: ${space(3)}px;
+  font-style: italic;
+  text-align: left;
 
   p {
     margin: 0;
   }
-
-  ${pMedia.xs`
-    ${garamond("s17")}
-    line-height: 1.35em;
-  `};
 `

--- a/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
+++ b/src/Components/Publishing/Header/Layouts/__tests__/__snapshots__/ClassicHeader.test.tsx.snap
@@ -1,100 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Classic Header Snapshots renders editable props properly 1`] = `
-.c4 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
-  color: #666;
-}
-
-.c3 {
-  display: block;
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 13px;
-  line-height: 1.65em;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: left;
+  -webkit-box-align: left;
+  -ms-flex-align: left;
+  align-items: left;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: 900px;
-  width: 100%;
-  margin: 40px auto;
-  box-sizing: border-box;
-  text-align: center;
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
 .c1 {
-  padding-bottom: 30px;
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 37px;
-  line-height: 1.2em;
-  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 38px;
+  padding-bottom: 30px;
+  text-align: left;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+}
+
+.c5 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c6 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
+  color: #666;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c9 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c9:hover {
+  opacity: 0.6;
+}
+
+.c9:first-child {
+  padding-left: 0;
+}
+
+.c4 {
+  text-align: left;
+  display: block;
+}
+
+.c4 .c7 {
+  display: inline-block;
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 19px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  line-height: 1.35em;
-  text-align: left;
   max-width: 580px;
   width: 100%;
   margin: 0 auto;
   padding-bottom: 30px;
+  font-style: italic;
+  text-align: left;
 }
 
 .c2 p {
   margin: 0;
 }
 
-@media (max-width:1280px) {
+@media screen and (min-width:40em) {
   .c0 {
-    padding: 0 20px;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
   }
 }
 
-@media (max-width:600px) {
+@media screen and (min-width:40em) {
   .c0 {
-    text-align: left;
+    max-width: 900px;
   }
 }
 
-@media (max-width:600px) {
+@media screen and (min-width:40em) {
+  .c0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c1 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 34px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
+    font-size: 44px;
   }
 }
 
-@media (max-width:600px) {
-  .c2 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 17px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
-    line-height: 1.35em;
+@media screen and (min-width:40em) {
+  .c1 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
+    text-align: center;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    text-align: center;
   }
 }
 
@@ -103,6 +153,13 @@ exports[`Classic Header Snapshots renders editable props properly 1`] = `
 >
   <div
     className="c1"
+    fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+    fontSize={
+      Array [
+        "32px",
+        "44px",
+      ]
+    }
   >
     <div>
       Child 
@@ -110,7 +167,9 @@ exports[`Classic Header Snapshots renders editable props properly 1`] = `
     </div>
   </div>
   <div
-    className="c2"
+    className="c2 c3"
+    fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+    fontSize="18px"
   >
     <div>
       Child 
@@ -118,114 +177,264 @@ exports[`Classic Header Snapshots renders editable props properly 1`] = `
     </div>
   </div>
   <div
-    className="c3"
+    className="c4"
   >
-    Joanne Artman Gallery
     <div
-      className="c4"
+      className="c5"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="16px"
+    >
+      Joanne Artman Gallery
+    </div>
+    <div
+      className="c6"
       color="#666"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="14px"
     >
       Jun 19, 2015 9:09am
+    </div>
+    <div
+      className="c7 c8"
+    >
+      <a
+        className="c9"
+        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 14 14"
+          width="14px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
+      <a
+        className="c9"
+        href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 16 14"
+          width="16px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
+      <a
+        className="c9"
+        href="mailto:?subject=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/article/joanne-artman-gallery-poetry-naturerefinement-form"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 17 14"
+          width="17px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
     </div>
   </div>
 </div>
 `;
 
 exports[`Classic Header Snapshots renders properly 1`] = `
-.c4 {
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 11px;
-  line-height: 1.65em;
-  color: #666;
-}
-
-.c3 {
-  display: block;
-  font-family: 'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075',AvantGardeGothicITCW01Dm,Helvetica,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  font-size: 13px;
-  line-height: 1.65em;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: left;
+  -webkit-box-align: left;
+  -ms-flex-align: left;
+  align-items: left;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: 900px;
-  width: 100%;
-  margin: 40px auto;
-  box-sizing: border-box;
-  text-align: center;
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
 .c1 {
-  padding-bottom: 30px;
   font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 37px;
-  line-height: 1.2em;
-  -webkit-font-smoothing: antialiased;
+  font-size: 32px;
+  line-height: 38px;
+  padding-bottom: 30px;
+  text-align: left;
+}
+
+.c3 {
+  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
+  font-size: 18px;
+  line-height: 26px;
+}
+
+.c5 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.c6 {
+  font-family: Unica77LLWebMedium,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 24px;
+  color: #666;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  white-space: nowrap;
+  line-height: 1em;
+  margin-top: 5px;
+}
+
+.c9 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+
+.c9:hover {
+  opacity: 0.6;
+}
+
+.c9:first-child {
+  padding-left: 0;
+}
+
+.c4 {
+  text-align: left;
+  display: block;
+}
+
+.c4 .c7 {
+  display: inline-block;
 }
 
 .c2 {
-  font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-  font-size: 19px;
-  line-height: 1.5em;
-  -webkit-font-smoothing: antialiased;
-  line-height: 1.35em;
-  text-align: left;
   max-width: 580px;
   width: 100%;
   margin: 0 auto;
   padding-bottom: 30px;
+  font-style: italic;
+  text-align: left;
 }
 
 .c2 p {
   margin: 0;
 }
 
-@media (max-width:1280px) {
+@media screen and (min-width:40em) {
   .c0 {
-    padding: 0 20px;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
   }
 }
 
-@media (max-width:600px) {
+@media screen and (min-width:40em) {
   .c0 {
-    text-align: left;
+    max-width: 900px;
   }
 }
 
-@media (max-width:600px) {
+@media screen and (min-width:40em) {
+  .c0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+
+@media screen and (min-width:40em) {
   .c1 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 34px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
+    font-size: 44px;
   }
 }
 
-@media (max-width:600px) {
-  .c2 {
-    font-family: 'Adobe Garamond W08','adobe-garamond-pro','AGaramondPro-Regular','Times New Roman',Times,serif;
-    font-size: 17px;
-    line-height: 1.1em;
-    -webkit-font-smoothing: antialiased;
-    line-height: 1.35em;
+@media screen and (min-width:40em) {
+  .c1 {
+    line-height: 50px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
+    text-align: center;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c4 {
+    text-align: center;
   }
 }
 
@@ -234,28 +443,140 @@ exports[`Classic Header Snapshots renders properly 1`] = `
 >
   <div
     className="c1"
+    fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+    fontSize={
+      Array [
+        "32px",
+        "44px",
+      ]
+    }
   >
     <h1>
       New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple
     </h1>
   </div>
   <div
-    className="c2"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "<p>Critics were skeptical of Bambi when it was first released in 1942—what was the point, they wondered, of a cartoon that ignored fantasy in favor of naturalistic forest landscapes?</p>",
-      }
-    }
-  />
-  <div
-    className="c3"
+    className="c2 c3"
+    fontFamily="'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif"
+    fontSize="18px"
   >
-    Joanne Artman Gallery
     <div
-      className="c4"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>Critics were skeptical of Bambi when it was first released in 1942—what was the point, they wondered, of a cartoon that ignored fantasy in favor of naturalistic forest landscapes?</p>",
+        }
+      }
+    />
+  </div>
+  <div
+    className="c4"
+  >
+    <div
+      className="c5"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="16px"
+    >
+      Joanne Artman Gallery
+    </div>
+    <div
+      className="c6"
       color="#666"
+      fontFamily={
+        Object {
+          "fontFamily": "Unica77LLWebMedium, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+          "fontWeight": 500,
+        }
+      }
+      fontSize="14px"
     >
       Jul 28, 2017 4:38pm
+    </div>
+    <div
+      className="c7 c8"
+    >
+      <a
+        className="c9"
+        href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 14 14"
+          width="14px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M13.22846,-0.00014 L0.77266,-0.00014 C0.34566,-0.00014 -0.00014,0.34636 -0.00014,0.77266 L-0.00014,13.22706 C-0.00014,13.65336 0.34566,13.99986 0.77266,13.99986 L7.47866,13.99986 L7.47866,8.57836 L5.65376,8.57836 L5.65376,6.46576 L7.47866,6.46576 L7.47866,4.90686 C7.47866,3.09876 8.58256,2.11456 10.19606,2.11456 C10.74066,2.11246 11.28526,2.14046 11.82706,2.19786 L11.82706,4.08576 L10.70776,4.08576 C9.83066,4.08576 9.65846,4.50366 9.65846,5.11476 L9.65846,6.46366 L11.75146,6.46366 L11.47846,8.57696 L9.65986,8.57696 L9.65986,13.99986 L13.22776,13.99986 C13.65406,13.99986 13.99986,13.65406 13.99986,13.22706 L13.99986,0.77266 C13.99986,0.34636 13.65406,-0.00014 13.22776,-0.00014"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
+      <a
+        className="c9"
+        href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&text=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&url=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fjoanne-artman-gallery-poetry-naturerefinement-form&via=artsy"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 16 14"
+          width="16px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M15.9786472,1.9961647 C15.3802193,2.26166928 14.7456495,2.43612386 14.0957888,2.51257805 C14.7810964,2.1018105 15.2933396,1.45542502 15.537298,0.69435824 C14.8936926,1.07732426 14.189619,1.34699907 13.4542686,1.49087197 C12.8342946,0.828500604 11.967582,0.45318 11.0598622,0.45318 C9.25067784,0.458740305 7.78762253,1.92735593 7.78831756,3.73584521 C7.78762253,3.98744902 7.81542405,4.23835779 7.87033207,4.48370626 C5.23335731,4.35095397 2.77639743,3.10475056 1.11108601,1.05577808 C0.819169985,1.55620555 0.665566552,2.1254418 0.666261591,2.70510362 C0.664871514,3.80256887 1.21256158,4.82775015 2.12653675,5.4352135 C1.60595318,5.42061769 1.09649021,5.28021999 0.642630293,5.02583602 L0.642630293,5.06684327 C0.639155103,6.62859401 1.74009554,7.97488291 3.27195963,8.28139474 C2.99116422,8.36062909 2.70063827,8.40163634 2.40941728,8.40302642 C2.20229591,8.40372145 1.99517454,8.38426039 1.7922234,8.34603329 C2.22106194,9.68120158 3.45127948,10.5958718 4.85317144,10.6229783 C3.69315276,11.5362584 2.25928904,12.0311256 0.783028001,12.0283454 C0.520998616,12.0283454 0.25966427,12.0130546 -0.00028,11.9810828 C1.49961234,12.9437107 3.24554818,13.4552588 5.02762601,13.4531737 C11.0612522,13.4531737 14.3585132,8.45584932 14.3585132,4.12298146 C14.3585132,3.9798036 14.3585132,3.83940589 14.3473926,3.69970322 C14.9896079,3.23611277 15.5442483,2.66201126 15.9855976,2.00311509"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
+      <a
+        className="c9"
+        href="mailto:?subject=New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple&body=Check out New Study of Yale Grads Shows the Gender Pay Gap for Artists Is Not So Simple on Artsy: https://www.artsy.net/article/joanne-artman-gallery-poetry-naturerefinement-form"
+        onClick={[Function]}
+        target="_blank"
+      >
+        <svg
+          height="14px"
+          version="1.1"
+          viewBox="0 0 17 14"
+          width="17px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+            stroke="none"
+            strokeWidth="1"
+          >
+            <path
+              d="M8.09330005,8.15962873 L16.0866701,1.92619024 L16.0866701,1.14909566 C16.0866701,0.764718818 15.7752762,0.45402 15.3915944,0.45402 L0.795005656,0.45402 C0.411323894,0.45402 0.09993,0.764718818 0.09993,1.14909566 L0.09993,1.92619024 L8.09330005,8.15962873 Z M16.0866701,3.68820703 L16.0866701,12.7589443 C16.0866701,13.1426261 15.7752762,13.45402 15.3915944,13.45402 L0.795005656,13.45402 C0.411323894,13.45402 0.09993,13.1426261 0.09993,12.7589443 L0.09993,3.68820703 L7.66582852,9.58939935 C7.79163721,9.68740502 7.94246863,9.73606031 8.09330005,9.73606031 C8.24413147,9.73606031 8.39496288,9.68740502 8.52077158,9.58939935 L16.0866701,3.68820703 Z"
+              fill="black"
+            />
+          </g>
+        </svg>
+      </a>
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Layouts/ClassicLayout.tsx
+++ b/src/Components/Publishing/Layouts/ClassicLayout.tsx
@@ -1,8 +1,10 @@
+import { Box, space } from "@artsy/palette"
+import { Share } from "Components/Publishing/Byline/Share"
+import { getArticleFullHref } from "Components/Publishing/Constants"
+import { Header } from "Components/Publishing/Header/Header"
+import { Sections } from "Components/Publishing/Sections/Sections"
+import { ArticleData } from "Components/Publishing/Typings"
 import React from "react"
-import styled from "styled-components"
-import { Header } from "../Header/Header"
-import { Sections } from "../Sections/Sections"
-import { ArticleData } from "../Typings"
 
 export interface ArticleProps {
   article: ArticleData
@@ -10,14 +12,20 @@ export interface ArticleProps {
 }
 
 export const ClassicLayout: React.SFC<ArticleProps> = props => {
+  const { slug, social_title, thumbnail_title } = props.article
+
   return (
-    <ClassicLayoutContainer>
+    <Box position="relative" pt={space(2)} pb={space(4)}>
       <Header {...props} />
       <Sections {...props} />
-    </ClassicLayoutContainer>
+
+      <Box maxWidth={580} mx="auto" px={[space(2), 0]}>
+        <Share
+          hasLabel
+          url={getArticleFullHref(slug)}
+          title={social_title || thumbnail_title}
+        />
+      </Box>
+    </Box>
   )
 }
-
-const ClassicLayoutContainer = styled.div`
-  position: relative;
-`

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -89,6 +89,7 @@ export interface ArticleData {
   postscript?: string
   date?: string
   published_at?: string
+  lead_paragraph?: string
   sections?: SectionData[]
   series?: {
     description?: string


### PR DESCRIPTION
Some updates to enable displaying classic articles in React
- Use palette fonts
- Show channel name when provided for byline
- add share components

<img width="1752" alt="Screen Shot 2020-02-10 at 11 55 26 AM" src="https://user-images.githubusercontent.com/1497424/74171268-4b932e00-4bfc-11ea-9986-87ed20234825.png">

