### PR TITLE
Fixes a bug where unregistered users who bid and register and don't meet the reserve do not get feedback that their bid did not meet the reserve

### DIFF
--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -356,17 +356,13 @@ export const StripeWrappedConfirmBidRoute: React.FC<ConfirmBidProps> = props => 
   )
 }
 
-const TrackingWrappedConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
-  const Component = track<ConfirmBidProps>(p => ({
-    context_page: Schema.PageName.AuctionConfirmBidPage,
-    auction_slug: p.artwork.saleArtwork.sale.slug,
-    artwork_slug: p.artwork.slug,
-    sale_id: p.artwork.saleArtwork.sale.internalID,
-    user_id: p.me.internalID,
-  }))(StripeWrappedConfirmBidRoute)
-
-  return <Component {...props} />
-}
+const TrackingWrappedConfirmBidRoute = track<ConfirmBidProps>(props => ({
+  context_page: Schema.PageName.AuctionConfirmBidPage,
+  auction_slug: props.artwork.saleArtwork.sale.slug,
+  artwork_slug: props.artwork.slug,
+  sale_id: props.artwork.saleArtwork.sale.internalID,
+  user_id: props.me.internalID,
+}))(StripeWrappedConfirmBidRoute)
 
 export const ConfirmBidRouteFragmentContainer = createFragmentContainer(
   TrackingWrappedConfirmBidRoute,


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-835

We were seeing the following warning as well as the issue described in the ticket:

<img width="1121" alt="Screen Shot 2020-01-30 at 4 43 20 PM" src="https://user-images.githubusercontent.com/386234/73788053-5ec07c80-476a-11ea-8c01-a983b06a9d1a.png">

The reason why this is occurring is that we are dynamically creating a trackable component while rendering in `ConfirmBid/index.tsx`: 

https://github.com/artsy/reaction/blob/98f689f4bda9f53b09b92135fedb2d376806a8fc/src/Apps/Auction/Routes/ConfirmBid/index.tsx#L360-L366

And here the `Component` variable always holds a reference to a newly created object. When this component is passed into the React VDOM and a re-render is triggered, the newly created component is considered to be a "diff" even though it's essentially the same thing. As a result of this, all the components below it would get thrown away once the new trackable component gets in, making all object references stale (and thus the warning above). The solution is simply to avoid creating component definitions dynamically.

## Mitigation

It is a bit tricky to write a test. In theory, we should be able to replicate this bug with the test below:

```tsx
it("allows the user to place a bid after agreeing to terms", async () => {
  const env = setupTestEnv()
  const page = await env.buildPage({
    mockData: FixtureForUnregisteredUserWithoutCreditCard,
  })

  createTokenMock.mockResolvedValue(stripeTokenResponse)
  env.mutations.useResultsOnce(createCreditCardAndUpdatePhoneSuccessful)
  env.mutations.useResultsOnce(createBidderPositionSuccessfulAndBidder)
  mockBidderPositionQuery.mockResolvedValue(
    confirmBidBidderPositionQueryWithOutbid
  )

  await page.fillFormWithValidValues()
  await page.agreeToTerms()
  await page.submitForm()

  expect(window.location.assign).not.toHaveBeenCalled()
  expect(page.text()).toContain("Your bid wasn’t high enough.")
})
```

Unfortunately, this test passes because of the difference between the actual production code and the test setup. One way to work around this is to deliberately change the `track<ConfirmBidProps>(...)` part of the code to:

```tsx
export class TrackingWrappedConfirmBidRoute extends React.Component<ConfirmBidProps> {
  render() {
    const Component = track<ConfirmBidProps>(props => ({
      context_page: Schema.PageName.AuctionConfirmBidPage,
      auction_slug: props.artwork.saleArtwork.sale.slug,
      artwork_slug: props.artwork.slug,
      sale_id: props.artwork.saleArtwork.sale.internalID,
      user_id: props.me.internalID,
    }))(StripeWrappedConfirmBidRoute)

    return <Component {...this.props} />
  }
}
```

And then we could call the `forceUpdate()` function:

```tsx
// It is important to force-update here otherwise the test does not
// replicate the issue described in:
// https://artsyproduct.atlassian.net/browse/AUCT-835
page.find(TrackingWrappedConfirmBidRoute).instance().forceUpdate()

expect(window.location.assign).not.toHaveBeenCalled()
expect(page.text()).toContain("Your bid wasn’t high enough.")
```

At this point the test would start failing the way we want it to fail.

Finally, we could fix the test by moving the `Component` definition out of the tracking component:

```tsx
const Component = track<ConfirmBidProps>(props => ({
  context_page: Schema.PageName.AuctionConfirmBidPage,
  auction_slug: props.artwork.saleArtwork.sale.slug,
  artwork_slug: props.artwork.slug,
  sale_id: props.artwork.saleArtwork.sale.internalID,
  user_id: props.me.internalID,
}))(StripeWrappedConfirmBidRoute)

export class TrackingWrappedConfirmBidRoute extends React.Component<ConfirmBidProps> {
  render() {
    return <Component {...this.props} />
  }
}
```

This seems like deliberately written code and questionable if you have no context around what happened to the bid + register form.

So I don't think testing is a good way to capture potential problems like this. The change in this PR will solve the issue, but here are some other things we can do to avoid running into the same issue in the future:

 * Just be careful when you are using `track` :trollface: 
 * Use a class component and `@track` decorator so TS will deal with creating a new component for us
 * Write a linter that checks certain calls that could invalidate the VDOM tree are not being used at runtime

So I'd be curious to hear what you all think.

## Screenshot

![AUCT-835](https://user-images.githubusercontent.com/386234/74276515-d8fd7d80-4ce3-11ea-9c96-06dba57f4cf2.gif)
