### PR TITLE
[Bugfix] Prefix injected split tag scripts with CDN_URL

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -18,6 +18,7 @@ const cacheDirectory = path.resolve(__dirname, "../", ".cache")
 const {
   ADMIN_URL,
   APP_URL,
+  CDN_URL,
   CI,
   CMS_URL,
   ENABLE_REQUEST_CONDITION_REPORT,
@@ -52,6 +53,7 @@ const notOnCI = value => (isCI ? [] : [value])
 const sharifyPath = sharify({
   ADMIN_URL,
   APP_URL,
+  CDN_URL,
   CMS_URL,
   ENABLE_REQUEST_CONDITION_REPORT,
   EXPERIMENTAL_APP_SHELL,

--- a/src/Artsy/Router/__tests__/buildServerApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildServerApp.test.tsx
@@ -22,7 +22,8 @@ jest.unmock("react-relay")
 jest.mock("@loadable/server", () => ({
   ChunkExtractor: class {
     collectChunks = x => x
-    getScriptTags = x => ""
+    getScriptTags = x =>
+      `<script src="/assets/foo.js"></script> <script src="/assets/bar.js"></script>`
   },
 }))
 
@@ -75,9 +76,31 @@ describe("buildServerApp", () => {
     expect(bodyHTML).toEqual(ReactDOMServer.renderToString(<ServerApp />))
   })
 
-  it("bootstraps relay SSR data", async () => {
-    const { scripts } = await getWrapper()
-    expect(scripts).toContain("__RELAY_BOOTSTRAP__")
+  describe("scripts", () => {
+    const prevEnv = process.env
+    const CDN_URL = "http://test.com"
+
+    afterAll(() => {
+      process.env = prevEnv
+    })
+
+    it("bootstraps relay SSR data", async () => {
+      const { scripts } = await getWrapper()
+      expect(scripts).toContain("__RELAY_BOOTSTRAP__")
+    })
+
+    it("does not prefix CDN_URL if not available", async () => {
+      const postScripts = `<script src="/assets/foo.js"></script> <script src="/assets/bar.js"></script>`
+      const { scripts } = await getWrapper()
+      expect(scripts).toContain(postScripts)
+    })
+
+    it("prefixes CDN_URL to script tags if available", async () => {
+      process.env.CDN_URL = CDN_URL
+      const postScripts = `<script src="${CDN_URL}/assets/foo.js"></script> <script src="${CDN_URL}/assets/bar.js"></script>`
+      const { scripts } = await getWrapper()
+      expect(scripts).toContain(postScripts)
+    })
   })
 
   it("resolves with a 200 status if url matches request", async () => {

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -176,7 +176,10 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
                 bundleScriptTags
                   .split("\n")
                   .map(script => {
-                    // In production, prefix injected script src with CDN endpoint
+                    /**
+                     * In production, prefix injected script src with CDN endpoint.
+                     * @see https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts#L23
+                     */
                     if (getENV("CDN_URL")) {
                       const scriptTagWithCDN = script.replace(
                         /src="\/assets/g,

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -175,24 +175,35 @@ export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
               scripts.push(
                 bundleScriptTags
                   .split("\n")
-                  .filter(
-                    script =>
-                      !(
-                        /**
-                         * Since these files are already embedded in our main
-                         * layout file, omit them from the scripts array.
-                         *
-                         * TODO: Don't include these files in the main layout
-                         * and instead relay on dynamically including them here.
-                         * Will require some shuffling in the jade template,
-                         * however.
-                         */
-                        (
-                          script.includes("/assets/runtime-manifest.") ||
-                          script.includes("/assets/common.")
-                        )
+                  .map(script => {
+                    // In production, prefix injected script src with CDN endpoint
+                    if (getENV("CDN_URL")) {
+                      const scriptTagWithCDN = script.replace(
+                        /src="\/assets/g,
+                        `src="${getENV("CDN_URL")}/assets`
                       )
-                  )
+                      return scriptTagWithCDN
+                    } else {
+                      return script
+                    }
+                  })
+                  .filter(script => {
+                    return !(
+                      /**
+                       * Since these files are already embedded in our main
+                       * layout file, omit them from the scripts array.
+                       *
+                       * TODO: Don't include these files in the main layout
+                       * and instead relay on dynamically including them here.
+                       * Will require some shuffling in the jade template,
+                       * however.
+                       */
+                      (
+                        script.includes("/assets/runtime-manifest.") ||
+                        script.includes("/assets/common.")
+                      )
+                    )
+                  })
                   .join("\n")
               )
 


### PR DESCRIPTION
Fixes issue where injected bundle-split scripts aren't prefixed with CDN url when `CDN_URL` is available. 

This mirrors how our [assetMiddleware](https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts#L23) function works over in force.

A future refactor would be to pass back concrete script src elements that can be individually piped into the asset helper. 