### PR TITLE
Bundle split search; fix SSR search input

### DIFF
--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -226,3 +226,6 @@ export const SearchResultsArtistsRouteFragmentContainer = createRefetchContainer
     }
   `
 )
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default SearchResultsArtistsRouteFragmentContainer

--- a/src/Apps/Search/Routes/Artworks/index.tsx
+++ b/src/Apps/Search/Routes/Artworks/index.tsx
@@ -43,3 +43,6 @@ export const SearchResultsArtworksRoute = withRouter((props => {
     </Box>
   )
 }) as React.FC<SearchResultsRouteProps>)
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default SearchResultsArtworksRoute

--- a/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
+++ b/src/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
@@ -234,3 +234,6 @@ export const SearchResultsEntityRouteFragmentContainer = createRefetchContainer(
     }
   `
 )
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default SearchResultsEntityRouteFragmentContainer

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -1,15 +1,11 @@
+import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 
-import { SearchResultsArtistsRouteFragmentContainer as SearchResultsArtistsRoute } from "Apps/Search/Routes/Artists/SearchResultsArtists"
-import { SearchResultsArtworksRoute } from "Apps/Search/Routes/Artworks"
-import { SearchResultsEntityRouteFragmentContainer as SearchResultsEntityRoute } from "Apps/Search/Routes/Entity/SearchResultsEntity"
-
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { ArtworkQueryFilter } from "Components/v2/ArtworkFilter/ArtworkQueryFilter"
 import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
-import { SearchAppFragmentContainer as SearchApp } from "./SearchApp"
 
 const prepareVariables = (_params, { location }) => {
   return {
@@ -33,7 +29,8 @@ const tabsToEntitiesMap = {
 const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   return {
     path: key,
-    Component: SearchResultsEntityRoute,
+    getComponent: () =>
+      loadable(() => import("./Routes/Entity/SearchResultsEntity")),
 
     // FIXME: We shouldn't overwrite our route functionality, as that breaks
     // global route configuration behavior.
@@ -67,7 +64,7 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
 export const routes: RouteConfig[] = [
   {
     path: "/search",
-    Component: SearchApp,
+    getComponent: () => loadable(() => import("./SearchApp")),
     query: graphql`
       query routes_SearchResultsTopLevelQuery($term: String!) {
         viewer {
@@ -79,13 +76,14 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "/",
-        Component: SearchResultsArtworksRoute,
+        getComponent: () => loadable(() => import("./Routes/Artworks")),
         prepareVariables,
         query: ArtworkQueryFilter,
       },
       {
         path: "artists",
-        Component: SearchResultsArtistsRoute,
+        getComponent: () =>
+          loadable(() => import("./Routes/Artists/SearchResultsArtists")),
         prepareVariables,
         query: graphql`
           query routes_SearchResultsArtistsQuery($term: String!, $page: Int) {

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -32,7 +32,7 @@ import { RenderError, RenderPending, RenderReady } from "./Utils/RenderStatus"
 import { ChunkExtractor } from "@loadable/server"
 import { getENV } from "Utils/getENV"
 
-interface Resolve {
+export interface ServerAppResolve {
   bodyHTML?: string
   redirect?: {
     url: string
@@ -50,7 +50,9 @@ export interface ServerRouterConfig extends RouterConfig {
   userAgent?: string
 }
 
-export function buildServerApp(config: ServerRouterConfig): Promise<Resolve> {
+export function buildServerApp(
+  config: ServerRouterConfig
+): Promise<ServerAppResolve> {
   return trace(
     "buildServerApp",
     new Promise(async (resolve, reject) => {

--- a/src/Artsy/Router/server.ts
+++ b/src/Artsy/Router/server.ts
@@ -1,2 +1,2 @@
 export * from "./index"
-export { buildServerApp } from "./buildServerApp"
+export { buildServerApp, ServerAppResolve } from "./buildServerApp"

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -25,6 +25,7 @@ import request from "superagent"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
 import { getENV } from "Utils/getENV"
+import { useDidMount } from "Utils/Hooks/useDidMount"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 import { SearchInputContainer } from "./SearchInputContainer"
@@ -157,7 +158,8 @@ export class SearchBar extends Component<Props, State> {
     super(props)
 
     this.enableExperimentalAppShell =
-      sd.CLIENT_NAVIGATION_V2 === "experiment" &&
+      // FIXME: Reenable A/B test
+      // sd.CLIENT_NAVIGATION_V2 === "experiment" &&
       getENV("EXPERIMENTAL_APP_SHELL")
   }
 
@@ -460,6 +462,35 @@ export const SearchBarRefetchContainer = createRefetchContainer(
 
 export const SearchBarQueryRenderer: React.FC = () => {
   const { relayEnvironment, searchQuery = "" } = useContext(SystemContext)
+  const isMounted = useDidMount(typeof window !== "undefined")
+
+  /**
+   * Displays during SSR render, but once mounted is swapped out with
+   * QueryRenderer below.
+   */
+  const StaticSearchContainer = () => {
+    return (
+      <>
+        <Box display={["block", "none"]}>
+          <SearchInputContainer
+            placeholder={searchQuery || PLACEHOLDER_XS}
+            defaultValue={searchQuery}
+          />
+        </Box>
+        <Box display={["none", "block"]}>
+          <SearchInputContainer
+            placeholder={searchQuery || PLACEHOLDER}
+            defaultValue={searchQuery}
+          />
+        </Box>
+      </>
+    )
+  }
+
+  if (!isMounted) {
+    return <StaticSearchContainer />
+  }
+
   return (
     <QueryRenderer<SearchBarSuggestQuery>
       environment={relayEnvironment}
@@ -481,22 +512,7 @@ export const SearchBarQueryRenderer: React.FC = () => {
           // from within the NavBar (it's not a part of any app) we need to lean
           // on styled-system for showing / hiding depending upon breakpoint.
         } else {
-          return (
-            <>
-              <Box display={["block", "none"]}>
-                <SearchInputContainer
-                  placeholder={searchQuery || PLACEHOLDER_XS}
-                  defaultValue={searchQuery}
-                />
-              </Box>
-              <Box display={["none", "block"]}>
-                <SearchInputContainer
-                  placeholder={searchQuery || PLACEHOLDER}
-                  defaultValue={searchQuery}
-                />
-              </Box>
-            </>
-          )
+          return <StaticSearchContainer />
         }
       }}
     />

--- a/src/Utils/Hooks/useDidMount.ts
+++ b/src/Utils/Hooks/useDidMount.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 
-export function useDidMount() {
-  const [isMounted, toggleMounted] = useState(false)
+export function useDidMount(defaultMounted = false) {
+  const [isMounted, toggleMounted] = useState(defaultMounted)
 
   useEffect(() => {
     toggleMounted(true)


### PR DESCRIPTION
Adding bundle splitting to the SearchApp, and also fix SSR rendering on the search input in the nav bar, which flashes in because on client-side load initial render is behind a QueryRenderer.