### PR TITLE
[Bugfix] Ensure all search-bar nav items navigate properly

### DIFF
--- a/src/Artsy/Router/makeAppRoutes.tsx
+++ b/src/Artsy/Router/makeAppRoutes.tsx
@@ -18,31 +18,7 @@ interface RouteList {
 }
 
 export function makeAppRoutes(routeList: RouteList[]): RouteConfig[] {
-  function removeDisabledRoutes(acc, route: RouteList) {
-    if (route.disabled) {
-      return acc
-    } else {
-      return acc.concat(route.routes)
-    }
-  }
-
-  function createRouteConfiguration(route): RouteConfig {
-    let path = route.path
-    if (path.slice(-1) === "/") {
-      path = route.path.substring(1) // remove leading slash from route
-    }
-
-    return {
-      ...route,
-      fetchIndicator: "overlay",
-      path,
-    }
-  }
-
-  // Build route list
-  const routes = flatten(routeList.reduce(removeDisabledRoutes, [])).map(
-    createRouteConfiguration
-  )
+  const routes = getActiveRoutes(routeList)
 
   const Component = props => {
     const { router, setRouter } = useSystemContext()
@@ -81,4 +57,30 @@ export function makeAppRoutes(routeList: RouteList[]): RouteConfig[] {
       children: routes,
     },
   ]
+}
+
+function getActiveRoutes(routeList) {
+  const routes = flatten(
+    routeList.reduce((acc, route: RouteList) => {
+      if (route.disabled) {
+        return acc
+      } else {
+        return acc.concat(route.routes)
+      }
+    }, [])
+  ).map(createRouteConfiguration)
+  return routes
+}
+
+function createRouteConfiguration(route): RouteConfig {
+  let path = route.path
+  if (path.slice(-1) === "/") {
+    path = route.path.substring(1) // remove leading slash from route
+  }
+
+  return {
+    ...route,
+    fetchIndicator: "overlay",
+    path,
+  }
 }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -263,9 +263,21 @@ export class SearchBar extends Component<Props, State> {
 
     if (this.enableExperimentalAppShell) {
       if (this.props.router) {
-        this.props.router.push(href)
-        this.onBlur({})
+        // @ts-ignore (routeConfig not found; need to update DT types)
+        const routes = this.props.router.matcher.routeConfig
+        // @ts-ignore (matchRoutes not found; need to update DT types)
+        const isSupportedInRouter = !!this.props.router.matcher.matchRoutes(
+          routes,
+          href
+        )
 
+        // Check if url exists within the global router context
+        if (isSupportedInRouter) {
+          this.props.router.push(href)
+          this.onBlur({})
+        } else {
+          window.location.assign(href)
+        }
         // Outside of router context
       } else {
         window.location.assign(href)


### PR DESCRIPTION
Fixes issue where search result item urls not within the global router context returned 404; e.g., https://staging.artsy.net/pushkin-house. 