### PR TITLE
[Do Not Merge] [Clientside Routing] Enable artwork page caching on inquiry works

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "found": "^0.4.9",
     "found-relay": "^0.5",
     "found-scroll": "^0.1.5",
+    "graphql-request": "^1.8.2",
     "history": "^4.6.1",
     "isomorphic-fetch": "^2.2.1",
     "jsonp": "^0.2.1",

--- a/src/Apps/Artwork/routes.tsx
+++ b/src/Apps/Artwork/routes.tsx
@@ -1,5 +1,7 @@
 import loadable from "@loadable/component"
+import { request } from "graphql-request"
 import { graphql } from "react-relay"
+import { getENV } from "Utils/getENV"
 
 export const routes = [
   {
@@ -12,8 +14,35 @@ export const routes = [
         }
       }
     `,
-    cacheConfig: {
-      force: true,
+
+    /**
+     * Disable artwork page caching for everything but *inquiry works*
+     */
+    getCacheConfig: async ({ params }) => {
+      if (getENV("EXPERIMENTAL_APP_SHELL")) {
+        const query = `{
+          artwork(id: "${params.artworkID}") {
+            is_inquireable
+            is_acquireable
+            is_offerable
+          }
+        }`
+
+        const { artwork } = await request(getENV("METAPHYSICS_ENDPOINT"), query)
+        const inquiryWork =
+          artwork.is_inquireable &&
+          !artwork.is_acquireable &&
+          !artwork.is_offerable
+        const force = inquiryWork ? false : true
+
+        return {
+          force,
+        }
+      } else {
+        return {
+          force: true,
+        }
+      }
     },
   },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5814,6 +5814,14 @@ create-react-context@^0.2.1, create-react-context@^0.2.2, create-react-context@^
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-fetch@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
+  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -8047,6 +8055,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graphql-request@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
+  dependencies:
+    cross-fetch "2.2.2"
 
 graphql-tools@^4.0.2:
   version "4.0.3"
@@ -11074,6 +11089,11 @@ node-dir@^0.1.10, node-dir@^0.1.17:
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
   dependencies:
     minimatch "^3.0.2"
+
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -16548,7 +16568,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@2.0.4, whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==


### PR DESCRIPTION
Opening this PR for comments. 

With the current setup, we're forcing a data refetch on all artworks even if a user has already visited the page. This is due to stateful things like BNMO, Auctions, etc. However, inquiry works don't contain said state, and are largely static. With this in mind, we can cache these kinds of works and speed up the browsing experience for a large number of works on Artsy, while also reducing server load. 

The flow:
- Replace `cacheControl` setting in route config with `getCacheConfig`
- This async function makes a quick request to MP to determine is the work is an inquiry work; if so, cache the response. 

While this strategy still requires a request it's vastly more performant:

#### Before:

![caching](https://user-images.githubusercontent.com/236943/74633527-a81fad00-5116-11ea-9f07-1dad74587583.gif)

#### After: 

![caching2](https://user-images.githubusercontent.com/236943/74633536-ad7cf780-5116-11ea-8e74-1c4b5741d4ec.gif)