### PR TITLE
Add canary deployment to reaction PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@3.0.0
+  yarn: artsy/yarn@dev:94201cf9cd41b8b0d7441b5095ea044d
   codecov: codecov/codecov@1.0.5
   auto: artsy/auto@dev:94201cf9cd41b8b0d7441b5095ea044d
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   yarn: artsy/yarn@3.0.0
   codecov: codecov/codecov@1.0.5
+  auto: artsy/auto@dev:94201cf9cd41b8b0d7441b5095ea044d
 
 workflows:
   build_and_verify:
@@ -27,10 +28,19 @@ workflows:
           post-steps:
             - codecov/upload:
               file: coverage/lcov.info
-      - yarn/auto-release:
-          # The deploy job is the _only_ job that should have access to our npm
-          # tokens. We include a context that has our publish credentials
-          # explicitly in this step. https://circleci.com/docs/2.0/contexts/
+      - auto/publish-canary:
+          context: npm-deploy
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - yarn/jest
+            - yarn/relay
+            - yarn/lint
+            - yarn/type-check
+            - yarn/update-cache
+      - auto/publish:
           context: npm-deploy
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@dev:94201cf9cd41b8b0d7441b5095ea044d
+  yarn: artsy/yarn@4.0.0
   codecov: codecov/codecov@1.0.5
-  auto: artsy/auto@dev:94201cf9cd41b8b0d7441b5095ea044d
+  auto: artsy/auto@1.0.1
 
 workflows:
   build_and_verify:


### PR DESCRIPTION
This uses https://github.com/artsy/orbs/pull/86 to automatically publish canaries from any branch PRs added to reaction. 

We'll need to consider if it'll create too much noise for automated PRs like renovate. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.11.1-canary.3168.51833.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.11.1-canary.3168.51833.0
  # or 
  yarn add @artsy/reaction@25.11.1-canary.3168.51833.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
