### PR TITLE
Note that canaries are auto published

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ version and add the `Skip Release` label. That'll ensure when the next release h
 
 ### Publishing a Canary to NPM
 
-If needing to publish a canary package a few manual steps are required:
+Canaries are [automatically published](https://github.com/artsy/reaction/pull/3168) to NPM when creating a PR based off of a repo branch (i.e. not a fork). If you need to publish a canary of a fork you'll have to do a few manual steps:
 
 1. Update `package.json`, set version to a canary version, e.g. `2.0.0-canary-<PR#>`, `3.1.5-canary-<PR#>`, ...
 1. Run `npm publish --tag canary` to publish the package under the canary tag


### PR DESCRIPTION
Just a small update to note that canaries are auto published. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.11.2-canary.3172.51862.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.11.2-canary.3172.51862.0
  # or 
  yarn add @artsy/reaction@25.11.2-canary.3172.51862.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
