### PR TITLE
[PURCHASE-1793] Fix artwork filter events being tracked twice.

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
@@ -1,7 +1,5 @@
 import { ArtistArtworkFilter_artist } from "__generated__/ArtistArtworkFilter_artist.graphql"
 import { Works_artist } from "__generated__/Works_artist.graphql"
-import { useTracking } from "Artsy"
-import * as Schema from "Artsy/Analytics/Schema"
 import { BaseArtworkFilter } from "Components/v2/ArtworkFilter"
 import { ArtworkFilterContextProvider } from "Components/v2/ArtworkFilter/ArtworkFilterContext"
 import { updateUrl } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
@@ -19,7 +17,6 @@ interface ArtistArtworkFilterProps {
 
 const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   const { match, relay, artist, sidebarAggregations } = props
-  const tracking = useTracking()
   const { filtered_artworks } = artist
 
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -41,13 +38,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       aggregations={sidebarAggregations.aggregations as any}
       counts={artist.counts}
       onChange={updateUrl}
-      onFilterClick={(key, value, filterState) => {
-        tracking.trackEvent({
-          action_type: Schema.ActionType.CommercialFilterParamsChanged,
-          changed: { [key]: value },
-          current: filterState,
-        })
-      }}
     >
       <BaseArtworkFilter
         relay={relay}

--- a/src/Apps/Collect2/Routes/Collect/index.tsx
+++ b/src/Apps/Collect2/Routes/Collect/index.tsx
@@ -9,7 +9,7 @@ import { SeoProductsForArtworks } from "Apps/Collect2/Components/SeoProductsForA
 import { buildUrlForCollectApp } from "Apps/Collect2/Utils/urlBuilder"
 import { AppContainer } from "Apps/Components/AppContainer"
 
-import { track, useTracking } from "Artsy/Analytics"
+import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { FrameWithRecentlyViewed } from "Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "Components/v2/Seo"
@@ -38,7 +38,6 @@ export const CollectApp = track({
   } = props
   const medium = params && params.medium
   const { description, breadcrumbTitle, title } = getMetadataForMedium(medium)
-  const { trackEvent } = useTracking()
 
   const canonicalHref = medium
     ? `${sd.APP_URL}/collect/${medium}`
@@ -123,13 +122,6 @@ export const CollectApp = track({
                 })
                *
                */
-            }}
-            onFilterClick={(key, value, filterState) => {
-              trackEvent({
-                action_type: Schema.ActionType.CommercialFilterParamsChanged,
-                changed: { [key]: value },
-                current: filterState,
-              })
             }}
           />
         </Box>

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -128,13 +128,6 @@ export class CollectionApp extends Component<CollectionAppProps> {
                 artworksConnection.aggregations as SharedArtworkFilterContextProps["aggregations"]
               }
               onChange={updateUrl}
-              onFilterClick={(key, value, filterState) => {
-                this.props.tracking.trackEvent({
-                  action_type: Schema.ActionType.CommercialFilterParamsChanged,
-                  changed: { [key]: value },
-                  current: filterState,
-                })
-              }}
             >
               <BaseArtworkFilter
                 relay={relay}

--- a/src/Apps/Search/Routes/Artworks/index.tsx
+++ b/src/Apps/Search/Routes/Artworks/index.tsx
@@ -30,14 +30,6 @@ export const SearchResultsArtworksRoute = withRouter((props => {
             destination_path: artwork.href,
           })
         }}
-        onFilterClick={(key, value, filterState) => {
-          tracking.trackEvent({
-            action_type:
-              AnalyticsSchema.ActionType.CommercialFilterParamsChanged,
-            changed: { [key]: value },
-            current: filterState,
-          })
-        }}
         ZeroState={ZeroState}
       />
     </Box>


### PR DESCRIPTION
Fixes [PURCHASE-1793](https://artsyproduct.atlassian.net/browse/PURCHASE-1793)


Noticed the event is already being tracked [here](https://github.com/sepans/reaction/blob/faf119874fbe9d518cddbd7d4704f06e9c6e14ba/src/Components/v2/ArtworkFilter/index.tsx#L127) inside the component so there is no need to track it using the `onFilterClick` prop. Today during grooming realized this has been also reported by #data-team.