### PR TITLE
Remove weird 2 file generated by yarn integrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ storybook_build
 .yalc
 yalc.lock
 coverage*
+2

--- a/2
+++ b/2
@@ -1,1 +1,0 @@
-"./scripts/quicklink-to-project.sh"


### PR DESCRIPTION
`yarn integrate` likes to create this file which accidentally gets checked in. Not sure what it's for, but it doesn't need to be in git. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.11.7-canary.3180.52017.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.11.7-canary.3180.52017.0
  # or 
  yarn add @artsy/reaction@25.11.7-canary.3180.52017.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
