### PR TITLE
[Clientside Nav] Fix double track on artwork page

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -50,24 +50,6 @@ export class ArtworkApp extends React.Component<Props> {
     this.trackLotView()
   }
 
-  componentDidUpdate(prevProps) {
-    /**
-     * If we've changed routes within the app, trigger pageView and productView.
-     *
-     * FIXME: We're manually invoking pageView tracking here, instead of within
-     * the `trackingMiddleware` file as we need to pass along additional metadata.
-     * Waiting on analytics team to decide if there's a better way to capture this
-     * data that remains consistent with the rest of the app.
-     */
-    if (this.props.routerPathname !== prevProps.routerPathname) {
-      if (this.props.routerPathname.includes("/artwork/")) {
-        this.trackPageview()
-        this.trackProductView()
-        this.trackLotView()
-      }
-    }
-  }
-
   trackPageview() {
     const {
       artwork: { listPrice, availability, is_offerable, is_acquireable },

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -86,6 +86,11 @@ class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   }
 
   preventHardReload = event => {
+    // Don't block navigation for status page, as we've completed the flow
+    if (window.location.pathname.includes("/status")) {
+      return false
+    }
+
     event.preventDefault()
     event.returnValue = true
   }

--- a/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
+++ b/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
@@ -53,11 +53,11 @@ describe("trackingMiddleware", () => {
 
   it("excludes paths based on config option", () => {
     trackingMiddleware({
-      excludePaths: ["/bar"],
+      excludePaths: ["/artwork/"],
     })(store)(noop)({
       type: ActionTypes.UPDATE_LOCATION,
       payload: {
-        pathname: "/bar",
+        pathname: "/artwork/some-id",
       },
     })
     expect(global.analytics.page).not.toBeCalled()


### PR DESCRIPTION
Fixes a browser-level alert guard when navigating away from completed order -> status page. Don't need it there.

Also fixes double tracking on artwork page. 