### PR TITLE
@damassi => [ArtistMeta] Be defensive about missing ES data

### DIFF
--- a/src/Apps/Artist/Components/ArtistMeta.tsx
+++ b/src/Apps/Artist/Components/ArtistMeta.tsx
@@ -53,7 +53,8 @@ export const imageObjectAttributes = (item: ItemWithImage) => {
 }
 
 export const offersAttributes = (artist: ArtistMeta_artist) => {
-  const { edges } = artist.artworks_connection
+  const { artworks_connection } = artist
+  const edges = artworks_connection && artworks_connection.edges
 
   const offers =
     edges &&

--- a/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistMeta.test.tsx
@@ -340,5 +340,11 @@ describe("Meta", () => {
         },
       })
     })
+
+    it("#offersAttributes doesn't error out when the ES-backed connection is missing", () => {
+      const { artworks_connection, ...rest } = artist
+      const artistWithoutESData = { artworks_connection: undefined, ...rest }
+      expect(offersAttributes(artistWithoutESData)).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
Seeing this in datadog (likely getting crawled), and occasional ES glitches lead this component (and possibly others, but this one for now), to blow up when the data comes back missing.