### PR TITLE
[QueryRenderers] Delay showing spinner

### DIFF
--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -19,13 +19,6 @@ const SpinnerContainer = styled.figure`
   flex-direction: column;
   justify-content: center;
   position: relative;
-
-  /*
-    Noticed some weird behavior in force due to figure margin being set to 0
-    in global css. Adding padding of 22 gets things back to visual default.
-  */
-  margin: unset;
-  padding: 22px;
 `
 
 const RouteSpinnerContainer = styled.figure`
@@ -77,7 +70,9 @@ export function renderWithLoadProgress<P>(
   Container: RelayContainer<P>,
   initialProps: object = {},
   wrapperProps: object = {},
-  spinnerProps: SpinnerProps = {}
+  spinnerProps: SpinnerProps = {
+    delay: 800,
+  }
 ): LoadProgressRenderer<P> {
   // TODO: We need design for retrying or the approval to use the iOS design.
   // See also: https://artsyproduct.atlassian.net/browse/PLATFORM-1272


### PR DESCRIPTION
Companion PR: https://github.com/artsy/palette/pull/640

This fixes the issue thats frequently seen on our artist, artwork and collect and search pages where we conditionally render content in query renderers on the client. For a large number of pages we never render these sections, yet we always see a preloader that flashes while we make a request, and shifts our layouts all around in an ugly unstable way. 

This adds a default delay of 800ms until we show the preloader, which covers cases when a request takes an unreasonable amount of time. 

In most cases though, the area will return empty, and no loader will show, keeping the layout stable. 

#### Before: 

![before](https://user-images.githubusercontent.com/236943/75020618-f2bb6500-5447-11ea-9b53-efa46501c169.gif)

#### After: 

![after](https://user-images.githubusercontent.com/236943/75020634-f818af80-5447-11ea-8bd3-fc7017603e2c.gif)
