### PR TITLE
[BundleSplitting] Comment out for now

### DIFF
--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -1,4 +1,3 @@
-import loadable from "@loadable/component"
 import { hasSections as showMarketInsights } from "Apps/Artist/Components/MarketInsights/MarketInsights"
 import {
   ArtworkFilters,
@@ -10,6 +9,16 @@ import { Redirect, RedirectException, RouteConfig } from "found"
 import * as React from "react"
 import { graphql } from "react-relay"
 import { hasOverviewContent } from "./Components/NavigationTabs"
+
+import ArtistApp from "./ArtistApp"
+import ArticlesRoute from "./Routes/Articles"
+import AuctionResultsRoute from "./Routes/AuctionResults"
+import CVRoute from "./Routes/CV"
+import OverviewRoute from "./Routes/Overview"
+import ShowsRoute from "./Routes/Shows"
+import WorksRoute from "./Routes/Works"
+
+// import loadable from "@loadable/component"
 
 graphql`
   fragment routes_Artist on Artist {
@@ -62,7 +71,8 @@ graphql`
 export const routes: RouteConfig[] = [
   {
     path: "/artist/:artistID",
-    getComponent: () => loadable(() => import("./ArtistApp")),
+    // getComponent: () => loadable(() => import("./ArtistApp")),
+    Component: ArtistApp,
     query: graphql`
       query routes_ArtistTopLevelQuery($artistID: String!) @raw_response_type {
         artist(id: $artistID) @principalField {
@@ -100,7 +110,8 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "/",
-        getComponent: () => loadable(() => import("./Routes/Overview")),
+        // getComponent: () => loadable(() => import("./Routes/Overview")),
+        Component: OverviewRoute,
         displayNavigationTabs: true,
         query: graphql`
           query routes_OverviewQuery($artistID: String!) @raw_response_type {
@@ -112,7 +123,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "cv",
-        getComponent: () => loadable(() => import("./Routes/CV")),
+        // getComponent: () => loadable(() => import("./Routes/CV")),
+        Component: CVRoute,
         query: graphql`
           query routes_CVQuery($artistID: String!) {
             viewer {
@@ -123,7 +135,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "articles",
-        getComponent: () => loadable(() => import("./Routes/Articles")),
+        // getComponent: () => loadable(() => import("./Routes/Articles")),
+        Component: ArticlesRoute,
         query: graphql`
           query routes_ArticlesQuery($artistID: String!) {
             artist(id: $artistID) {
@@ -134,7 +147,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "shows",
-        getComponent: () => loadable(() => import("./Routes/Shows")),
+        // getComponent: () => loadable(() => import("./Routes/Shows")),
+        Component: ShowsRoute,
         query: graphql`
           query routes_ShowsQuery($artistID: String!) {
             viewer {
@@ -145,7 +159,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "auction-results",
-        getComponent: () => loadable(() => import("./Routes/AuctionResults")),
+        // getComponent: () => loadable(() => import("./Routes/AuctionResults")),
+        Component: AuctionResultsRoute,
         displayNavigationTabs: true,
         query: graphql`
           query routes_AuctionResultsQuery($artistID: String!) {
@@ -157,7 +172,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "works-for-sale",
-        getComponent: () => loadable(() => import("./Routes/Works")),
+        // getComponent: () => loadable(() => import("./Routes/Works")),
+        Component: WorksRoute,
         displayNavigationTabs: true,
         query: graphql`
           query routes_WorksQuery(

--- a/src/Apps/Artwork/routes.tsx
+++ b/src/Apps/Artwork/routes.tsx
@@ -1,10 +1,12 @@
-import loadable from "@loadable/component"
+// import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import ArtworkApp from "./ArtworkApp"
 
 export const routes = [
   {
     path: "/artwork/:artworkID/(confirm-bid)?",
-    getComponent: () => loadable(() => import("./ArtworkApp")),
+    // getComponent: () => loadable(() => import("./ArtworkApp")),
+    Component: ArtworkApp,
     query: graphql`
       query routes_ArtworkQuery($artworkID: String!) {
         artwork(id: $artworkID) @principalField {

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -1,4 +1,3 @@
-import loadable from "@loadable/component"
 import { ErrorPage } from "Components/ErrorPage"
 import { RedirectException, RouteConfig } from "found"
 import React from "react"
@@ -7,12 +6,19 @@ import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
 
+import AuctionFAQ from "./Components/AuctionFAQ"
+import ConfirmBidRoute from "./Routes/ConfirmBid"
+import RegisterRoute from "./Routes/Register"
+
+// import loadable from "@loadable/component"
+
 const logger = createLogger("Apps/Auction/routes")
 
 export const routes: RouteConfig[] = [
   {
     path: "/auction-faq",
-    getComponent: () => loadable(() => import("./Components/AuctionFAQ")),
+    // getComponent: () => loadable(() => import("./Components/AuctionFAQ")),
+    Component: AuctionFAQ,
     query: graphql`
       query routes_AuctionFAQQuery {
         viewer {
@@ -24,7 +30,8 @@ export const routes: RouteConfig[] = [
   },
   {
     path: "/auction/:saleID/bid(2)?/:artworkID",
-    getComponent: () => loadable(() => import("./Routes/ConfirmBid")),
+    // getComponent: () => loadable(() => import("./Routes/ConfirmBid")),
+    Component: ConfirmBidRoute,
     render: ({ Component, props }) => {
       if (Component && props) {
         const { artwork, me, match } = props as any
@@ -73,7 +80,8 @@ export const routes: RouteConfig[] = [
   },
   {
     path: "/auction-registration(2)?/:saleID",
-    getComponent: () => loadable(() => import("./Routes/Register")),
+    // getComponent: () => loadable(() => import("./Routes/Register")),
+    Component: RegisterRoute,
     render: ({ Component, props }) => {
       if (Component && props) {
         const { match, sale, me } = props as any

--- a/src/Apps/Collect2/collectRoutes.tsx
+++ b/src/Apps/Collect2/collectRoutes.tsx
@@ -1,14 +1,19 @@
-import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import { graphql } from "react-relay"
 
 import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { CollectionAppQuery } from "./Routes/Collection/CollectionAppQuery"
 
+// import loadable from "@loadable/component"
+import CollectApp from "./Routes/Collect"
+import CollectionApp from "./Routes/Collection"
+import CollectionsApp from "./Routes/Collections"
+
 export const collectRoutes: RouteConfig[] = [
   {
     path: "/collect/:medium?",
-    getComponent: () => loadable(() => import("./Routes/Collect")),
+    // getComponent: () => loadable(() => import("./Routes/Collect")),
+    Component: CollectApp,
     fetchIndicator: "overlay",
     prepareVariables: initializeVariablesWithFilterState,
     query: graphql`
@@ -70,7 +75,8 @@ export const collectRoutes: RouteConfig[] = [
   },
   {
     path: "/collections",
-    getComponent: () => loadable(() => import("./Routes/Collections")),
+    // getComponent: () => loadable(() => import("./Routes/Collections")),
+    Component: CollectionsApp,
     fetchIndicator: "overlay",
     query: graphql`
       query collectRoutes_MarketingCollectionsAppQuery {
@@ -82,7 +88,8 @@ export const collectRoutes: RouteConfig[] = [
   },
   {
     path: "/collection/:slug",
-    getComponent: () => loadable(() => import("./Routes/Collection")),
+    // getComponent: () => loadable(() => import("./Routes/Collection")),
+    Component: CollectionApp,
     prepareVariables: initializeVariablesWithFilterState,
     fetchIndicator: "overlay",
     query: CollectionAppQuery,

--- a/src/Apps/Conversation/routes.tsx
+++ b/src/Apps/Conversation/routes.tsx
@@ -1,13 +1,15 @@
-import loadable from "@loadable/component"
+import { RouteConfig } from "found"
 import { graphql } from "react-relay"
 
-// @ts-ignore
-import { RouteConfig } from "found"
+// import loadable from "@loadable/component"
+import ConversationApp from "./ConversationApp"
+import ConversationRoute from "./Routes/Conversation"
 
 export const conversationRoutes: RouteConfig[] = [
   {
     path: "/user/conversations",
-    getComponent: () => loadable(() => import("./ConversationApp")),
+    // getComponent: () => loadable(() => import("./ConversationApp")),
+    Component: ConversationApp,
     query: graphql`
       query routes_ConversationQuery {
         me {
@@ -26,7 +28,8 @@ export const conversationRoutes: RouteConfig[] = [
   },
   {
     path: "/user/conversations/:conversationID",
-    getComponent: () => loadable(() => import("./Routes/Conversation")),
+    // getComponent: () => loadable(() => import("./Routes/Conversation")),
+    Component: ConversationRoute,
     prepareVariables: (params, _props) => {
       return {
         conversationID: params.conversationID,

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -1,4 +1,3 @@
-import loadable from "@loadable/component"
 import { getRedirect } from "Apps/Order/getRedirect"
 import { redirects } from "Apps/Order/redirects"
 import { ErrorPage } from "Components/ErrorPage"
@@ -6,12 +5,28 @@ import { Redirect, RedirectException, RouteConfig } from "found"
 import * as React from "react"
 import { graphql } from "react-relay"
 
+// import loadable from "@loadable/component"
+
+import OrderApp from "./OrderApp"
+
+import AcceptRoute from "./Routes/Accept"
+import CounterRoute from "./Routes/Counter"
+import NewPaymentRoute from "./Routes/NewPayment"
+import OfferRoute from "./Routes/Offer"
+import PaymentRoute from "./Routes/Payment"
+import RejectRoute from "./Routes/Reject"
+import RespondRoute from "./Routes/Respond"
+import ReviewRoute from "./Routes/Review"
+import ShippingRoute from "./Routes/Shipping"
+import StatusRoute from "./Routes/Status"
+
 // FIXME:
 // * `render` functions requires casting
 export const routes: RouteConfig[] = [
   {
     path: "/order(2|s)/:orderID",
-    getComponent: () => loadable(() => import("./OrderApp")),
+    // getComponent: () => loadable(() => import("./OrderApp")),
+    Component: OrderApp,
 
     // TODO: Better support `@principalField` in Metaphysics.
     // This currently only works because of the `order` field alias.
@@ -59,7 +74,8 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "respond",
-        getComponent: () => loadable(() => import("./Routes/Respond")),
+        // getComponent: () => loadable(() => import("./Routes/Respond")),
+        Component: RespondRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_RespondQuery($orderID: ID!) {
@@ -74,7 +90,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "offer",
-        getComponent: () => loadable(() => import("./Routes/Offer")),
+        // getComponent: () => loadable(() => import("./Routes/Offer")),
+        Component: OfferRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_OfferQuery($orderID: ID!) {
@@ -89,7 +106,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "shipping",
-        getComponent: () => loadable(() => import("./Routes/Shipping")),
+        // getComponent: () => loadable(() => import("./Routes/Shipping")),
+        Component: ShippingRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_ShippingQuery($orderID: ID!) {
@@ -104,7 +122,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "payment",
-        getComponent: () => loadable(() => import("./Routes/Payment")),
+        // getComponent: () => loadable(() => import("./Routes/Payment")),
+        Component: PaymentRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_PaymentQuery($orderID: ID!) {
@@ -122,7 +141,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "payment/new",
-        getComponent: () => loadable(() => import("./Routes/NewPayment")),
+        // getComponent: () => loadable(() => import("./Routes/NewPayment")),
+        Component: NewPaymentRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_NewPaymentQuery($orderID: ID!) {
@@ -140,7 +160,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/counter",
-        getComponent: () => loadable(() => import("./Routes/Counter")),
+        // getComponent: () => loadable(() => import("./Routes/Counter")),
+        Component: CounterRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_CounterQuery($orderID: ID!) {
@@ -155,7 +176,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review",
-        getComponent: () => loadable(() => import("./Routes/Review")),
+        // getComponent: () => loadable(() => import("./Routes/Review")),
+        Component: ReviewRoute,
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_ReviewQuery($orderID: ID!) {
@@ -170,7 +192,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/accept",
-        getComponent: () => loadable(() => import("./Routes/Accept")),
+        // getComponent: () => loadable(() => import("./Routes/Accept")),
+        Component: AcceptRoute,
         query: graphql`
           query routes_AcceptQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -184,7 +207,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/decline",
-        getComponent: () => loadable(() => import("./Routes/Reject")),
+        // getComponent: () => loadable(() => import("./Routes/Reject")),
+        Component: RejectRoute,
         query: graphql`
           query routes_RejectQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -195,7 +219,8 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "status",
-        getComponent: () => loadable(() => import("./Routes/Status")),
+        // getComponent: () => loadable(() => import("./Routes/Status")),
+        Component: StatusRoute,
         query: graphql`
           query routes_StatusQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -1,4 +1,4 @@
-import loadable from "@loadable/component"
+// import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
@@ -6,6 +6,11 @@ import { graphql } from "react-relay"
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { ArtworkQueryFilter } from "Components/v2/ArtworkFilter/ArtworkQueryFilter"
 import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
+
+import ArtistsRoute from "./Routes/Artists/SearchResultsArtists"
+import ArtworksRoute from "./Routes/Artworks"
+import Entity from "./Routes/Entity/SearchResultsEntity"
+import SearchApp from "./SearchApp"
 
 const prepareVariables = (_params, { location }) => {
   return {
@@ -29,8 +34,9 @@ const tabsToEntitiesMap = {
 const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   return {
     path: key,
-    getComponent: () =>
-      loadable(() => import("./Routes/Entity/SearchResultsEntity")),
+    // getComponent: () =>
+    //   loadable(() => import("./Routes/Entity/SearchResultsEntity")),
+    Component: Entity,
 
     // FIXME: We shouldn't overwrite our route functionality, as that breaks
     // global route configuration behavior.
@@ -64,7 +70,8 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
 export const routes: RouteConfig[] = [
   {
     path: "/search",
-    getComponent: () => loadable(() => import("./SearchApp")),
+    // getComponent: () => loadable(() => import("./SearchApp")),
+    Component: SearchApp,
     query: graphql`
       query routes_SearchResultsTopLevelQuery($term: String!) {
         viewer {
@@ -76,14 +83,16 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "/",
-        getComponent: () => loadable(() => import("./Routes/Artworks")),
+        // getComponent: () => loadable(() => import("./Routes/Artworks")),
+        Component: ArtworksRoute,
         prepareVariables,
         query: ArtworkQueryFilter,
       },
       {
         path: "artists",
-        getComponent: () =>
-          loadable(() => import("./Routes/Artists/SearchResultsArtists")),
+        // getComponent: () =>
+        //   loadable(() => import("./Routes/Artists/SearchResultsArtists")),
+        Component: ArtistsRoute,
         prepareVariables,
         query: graphql`
           query routes_SearchResultsArtistsQuery($term: String!, $page: Int) {


### PR DESCRIPTION
Noticed an issue where async chunk requested from the parent of an async chunk doesn't fetch from our CDN url, only top-level chunks. 

Breadcrumbs of previous work: 

- Ensure top-level chunks are served from `CDN_URL`: https://github.com/artsy/reaction/pull/3159 

The current flow in production is: 
1) Webpack will compile out all of our chunks and create a manifest
1) We check if we're in a prod environment, and prefix a cloudfront CDN url via our [asset helper](https://github.com/damassi/force/blob/c2ce1db7b7007721d768497439ae81e64380395b/src/lib/middleware/assetMiddleware.ts#L20-L27)
1) In reaction, when loadable components dynamically injects scripts into the page *_on the first render_* [we do the same](https://github.com/artsy/reaction/blob/master/src/Artsy/Router/buildServerApp.tsx#L171-L176)
1) However, this doesn't take into account _dynamic_ requests from top-level routes, such as clicking the [works-for-you](https://staging.artsy.net/artist/andy-warhol/works-for-sale) tab on the Artist page, at which point webpack resolves the split bundle via its own resolution mechanism, according to what is set in the `publicPath` entry of our base webpack config, which handles domain: https://github.com/artsy/force/blob/master/webpack/envs/baseConfig.js#L22

#### What we need to do to fix issue: 
We need to resolve the inconsistency between our asset helper's resolution mechanism and webpacks `publicPath`. 