### PR TITLE
Simplify A/B test lookup via `express-http-context`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,6 +19,8 @@
       }
     ],
     "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
     [
       "relay",
       {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "peerDependencies": {
     "@artsy/palette": "^4.16.0 || ^5.0.0 || ^7.0.0",
     "@sentry/browser": "^4.2.3",
+    "express-http-context": "^1.2.3",
     "flickity": "2.1.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
@@ -115,6 +116,7 @@
     "dotenv": "4.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
+    "express-http-context": "^1.2.3",
     "flickity": "2.1.2",
     "fork-ts-checker-notifier-webpack-plugin": "0.6.2",
     "fork-ts-checker-webpack-plugin": "0.4.10",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@babel/plugin-proposal-class-properties": "7.3.4",
     "@babel/plugin-proposal-decorators": "7.3.0",
     "@babel/plugin-proposal-json-strings": "7.2.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-syntax-import-meta": "7.0.0",
     "@babel/preset-env": "7.3.4",

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -222,7 +222,14 @@ export class ArtworkApp extends React.Component<Props> {
             </Col>
           </Row>
 
-          <div id="lightbox-container" />
+          <div
+            id="lightbox-container"
+            style={{
+              position: "absolute",
+              top: 0,
+              zIndex: 1100, // over top nav
+            }}
+          />
           <SystemContextConsumer>
             {({ mediator }) => <>{this.enableIntercomForBuyers(mediator)}</>}
           </SystemContextConsumer>

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -245,7 +245,6 @@ export class ArtworkApp extends React.Component<Props> {
 export const ArtworkAppFragmentContainer = createFragmentContainer(
   (props: Props) => {
     const {
-      match,
       match: {
         location: { pathname, state },
       },

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -31,6 +31,7 @@ export interface Props {
   artwork: ArtworkApp_artwork
   tracking?: TrackingProp
   routerPathname: string
+  referrer: string
 }
 
 declare const window: any
@@ -53,6 +54,7 @@ export class ArtworkApp extends React.Component<Props> {
   trackPageview() {
     const {
       artwork: { listPrice, availability, is_offerable, is_acquireable },
+      referrer,
     } = this.props
 
     // FIXME: This breaks our global pageview tracking in the router level.
@@ -64,6 +66,7 @@ export class ArtworkApp extends React.Component<Props> {
       offerable: is_offerable,
       availability,
       price_listed: !!listPrice,
+      referrer,
     }
 
     if (typeof window.analytics !== "undefined") {
@@ -242,12 +245,16 @@ export class ArtworkApp extends React.Component<Props> {
 export const ArtworkAppFragmentContainer = createFragmentContainer(
   (props: Props) => {
     const {
+      match,
       match: {
-        location: { pathname },
+        location: { pathname, state },
       },
     } = useContext(RouterContext)
 
-    return <ArtworkApp {...props} routerPathname={pathname} />
+    const referrer = state && state.previousHref
+    return (
+      <ArtworkApp {...props} routerPathname={pathname} referrer={referrer} />
+    )
   },
   {
     artwork: graphql`

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -87,7 +87,7 @@ export class ArtworkActions extends React.Component<
     if (is_downloadable || this.isAdmin) {
       const artistNames = artists.map(({ name }) => name).join(", ")
       const filename = slugify(compact([artistNames, title, date]).join(" "))
-      const downloadableImageUrl = `${sd.APP_URL}${href}/download/${filename}.jpg` // prettier-ignore
+      const downloadableImageUrl = `${href}/download/${filename}.jpg` // prettier-ignore
       return downloadableImageUrl
     }
   }

--- a/src/Apps/Artwork/Components/OtherWorks/Header.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/Header.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Serif } from "@artsy/palette"
+import { RouterLink } from "Artsy/Router/RouterLink"
 import React from "react"
 
 interface HeaderProps {
@@ -16,14 +17,11 @@ export const Header: React.SFC<HeaderProps> = props => {
         {title}
       </Serif>
       {buttonHref && (
-        <Button
-          variant="secondaryOutline"
-          mb={3}
-          // FIXME: Move to <Link> component once https://github.com/artsy/palette/pull/130 is merged
-          onClick={() => (window.location.href = buttonHref)}
-        >
-          View all
-        </Button>
+        <RouterLink to={buttonHref}>
+          <Button variant="secondaryOutline" mb={3}>
+            View all
+          </Button>
+        </RouterLink>
       )}
       {children}
     </Flex>

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -71,7 +71,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           }
 
           // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-          if (getENV("EXPERIMENTAL_APP_SHELL")) {
+          if (sd.CLIENT_NAVIGATION_V3) {
             trackExperimentViewed("client_navigation_v3")
           }
 

--- a/src/Artsy/Relay/renderWithLoadProgress.tsx
+++ b/src/Artsy/Relay/renderWithLoadProgress.tsx
@@ -71,7 +71,7 @@ export function renderWithLoadProgress<P>(
   initialProps: object = {},
   wrapperProps: object = {},
   spinnerProps: SpinnerProps = {
-    delay: 800,
+    delay: 1000,
   }
 ): LoadProgressRenderer<P> {
   // TODO: We need design for retrying or the approval to use the iOS design.

--- a/src/Artsy/Router/makeAppRoutes.tsx
+++ b/src/Artsy/Router/makeAppRoutes.tsx
@@ -38,7 +38,15 @@ export function makeAppRoutes(routeList: RouteList[]): RouteConfig[] {
         const foundUrl = props.router.matcher.matchRoutes(routes, url)
 
         if (foundUrl) {
-          props.router.push(url)
+          const location = props.router.createLocation(url)
+          const previousHref = window.location.href
+
+          props.router.push({
+            ...location,
+            state: {
+              previousHref,
+            },
+          })
         } else {
           window.location.assign(url)
         }

--- a/src/Utils/getENV.tsx
+++ b/src/Utils/getENV.tsx
@@ -6,7 +6,7 @@ export function getENV(ENV_VAR) {
   let envVar
   if (isServer) {
     const httpContext = require("express-http-context")
-    envVar = httpContext.get(ENV_VAR) || process.env[ENV_VAR]
+    envVar = httpContext.get(ENV_VAR) ?? process.env[ENV_VAR]
   } else {
     envVar = sd[ENV_VAR]
   }

--- a/src/Utils/getENV.tsx
+++ b/src/Utils/getENV.tsx
@@ -2,6 +2,14 @@ import { data as sd } from "sharify"
 
 export function getENV(ENV_VAR) {
   const isServer = typeof window === "undefined"
-  const envVar = isServer ? process.env[ENV_VAR] : sd[ENV_VAR]
+
+  let envVar
+  if (isServer) {
+    const httpContext = require("express-http-context")
+    envVar = httpContext.get(ENV_VAR) || process.env[ENV_VAR]
+  } else {
+    envVar = sd[ENV_VAR]
+  }
+
   return envVar
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,36 +6,18 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "dom",
-      "es2015",
-      "es2016",
-      "es2017",
-      "esnext.asynciterable"
-    ],
+    "lib": ["dom", "es2015", "es2016", "es2017", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist",
     "paths": {
-      "storybook/*": [
-        "./__stories__/*"
-      ],
-      "Analytics/*": [
-        "./Analytics/*"
-      ],
-      "Assets/*": [
-        "./Assets/*"
-      ],
-      "Components/*": [
-        "./Components/*"
-      ],
-      "Styleguide/*": [
-        "./Styleguide/*"
-      ],
-      "package.json": [
-        "./package.json"
-      ]
+      "storybook/*": ["./__stories__/*"],
+      "Analytics/*": ["./Analytics/*"],
+      "Assets/*": ["./Assets/*"],
+      "Components/*": ["./Components/*"],
+      "Styleguide/*": ["./Styleguide/*"],
+      "package.json": ["./package.json"]
     },
     "plugins": [
       {
@@ -47,11 +29,7 @@
     "sourceMap": true,
     "target": "es2015"
   },
-  "include": [
-    "typings/*.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
+  "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
     "node_modules",
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,20 +5,37 @@
     "declaration": true,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "incremental": true,
     "jsx": "react",
-    "lib": ["dom", "es2015", "es2016", "es2017", "esnext.asynciterable"],
+    "lib": [
+      "dom",
+      "es2015",
+      "es2016",
+      "es2017",
+      "esnext.asynciterable"
+    ],
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist",
     "paths": {
-      "storybook/*": ["./__stories__/*"],
-      "Analytics/*": ["./Analytics/*"],
-      "Assets/*": ["./Assets/*"],
-      "Components/*": ["./Components/*"],
-      "Styleguide/*": ["./Styleguide/*"],
-      "package.json": ["./package.json"]
+      "storybook/*": [
+        "./__stories__/*"
+      ],
+      "Analytics/*": [
+        "./Analytics/*"
+      ],
+      "Assets/*": [
+        "./Assets/*"
+      ],
+      "Components/*": [
+        "./Components/*"
+      ],
+      "Styleguide/*": [
+        "./Styleguide/*"
+      ],
+      "package.json": [
+        "./package.json"
+      ]
     },
     "plugins": [
       {
@@ -30,7 +47,11 @@
     "sourceMap": true,
     "target": "es2015"
   },
-  "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "include": [
+    "typings/*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,6 +20,7 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
+      readonly CLIENT_NAVIGATION_V3: "experiment" | "control" // TODO: Remove after A/B test.
       readonly CMS_URL: string
       readonly ENABLE_PRICE_TRANSPARENCY: string
       readonly ENABLE_REQUEST_CONDITION_REPORT: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,6 +2835,14 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/chalk@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
@@ -2846,6 +2854,20 @@
   version "0.22.8"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.8.tgz#5702f74f78b73e13f1eb1bd435c2c9de61a250d4"
   integrity sha512-LzF540VOFabhS2TR2yYFz2Mu/fTfkA+5AwYddtJbOJGwnYrr2e7fHadT7/Z3jNGJJdCRlO3ySxmW26NgRdwhNA==
+
+"@types/cls-hooked@^4.2.1":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.0.tgz#290fa14946b88b11e65d68e487eda78a4d5a927e"
+  integrity sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/dd-trace@0.6.0":
   version "0.6.0"
@@ -2866,6 +2888,23 @@
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
+
+"@types/express-serve-static-core@*":
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz#f6f41fa35d42e79dbf6610eccbb2637e6008a0cf"
+  integrity sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.16.0":
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
+  integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/flickity@2.2.2":
   version "2.2.2"
@@ -2929,6 +2968,11 @@
   resolved "https://registry.yarnpkg.com/@types/memoize-one/-/memoize-one-3.1.1.tgz#0e21a1b91dc031fb59c1e1657b807ca9aec77475"
   integrity sha512-VlMu4eWNfQ8CDfhHYe8P/RgBq8vgce8LMo4vVKASPPAv+TE9SCR1bH6pA4nHEKNUQz1L/PIdElU2vqA2m366Dw==
 
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/node@*":
   version "10.12.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.29.tgz#c2c8d2d27bb55649fbafe8ea1731658421f38acf"
@@ -2955,6 +2999,11 @@
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.3.tgz#1c3b71b091eaeaf5924538006b7f70603ce63d38"
   integrity sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/react-dom@16.8.4":
   version "16.8.4"
@@ -3048,6 +3097,14 @@
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-6.0.11.tgz#635e0e7d60d6b66fa632bdeb7e3d02b44f9add03"
   integrity sha512-59JBBYnO6aHvIoVoUHuXQbZA/FWPfQgUPr34xOXKTiJ04cV1Mp+JRmtGBmuBw9N9dT/aDMwq1SOgHMQdAha4Pg==
+
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -3774,6 +3831,13 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -5318,6 +5382,15 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6548,6 +6621,13 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emitter-listener@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -6951,6 +7031,15 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+express-http-context@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/express-http-context/-/express-http-context-1.2.3.tgz#780c96006e5b6f0a384a175afb35b40411d4f331"
+  integrity sha512-Cde8XZJ8qYc4ACZSwn2NxuBG6mnPfXDtJUW+Ppgb2AhyNP4ttESK2SrYfAk6CluFADbxy24C5mVP25sOeBAgbQ==
+  dependencies:
+    "@types/cls-hooked" "^4.2.1"
+    "@types/express" "^4.16.0"
+    cls-hooked "^4.2.2"
 
 express@^4.16.3:
   version "4.16.3"
@@ -14329,6 +14418,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -14592,6 +14686,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 stack-utils@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
-"@babel/helper-plugin-utils@^7.8.0":
+"@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
@@ -676,6 +676,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz#e4572253fdeed65cddeecfdab3f928afeb2fd5d2"
+  integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
 "@babel/plugin-proposal-object-rest-spread@7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz#be27cd416eceeba84141305b93c282f5de23bbb4"
@@ -707,6 +715,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz#ae10b3214cb25f7adb1f3bc87ba42ca10b7e2543"
+  integrity sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.2.0"
@@ -796,6 +812,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
@@ -809,6 +832,13 @@
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-typescript@^7.2.0":
   version "7.3.3"


### PR DESCRIPTION
See https://github.com/artsy/force/pull/5099 for more info. 

This updates our `getENV` isomorphic ENV lookup util with another server-side layer:
- First, check to see if `SOME_ENV` var exists within the request / response cycle, stored within express-http-context. If so, return that value. Useful for A/B testing.
- If undefined, fall back to `process.env.SOME_ENV`