### PR TITLE
Add attachments to each message

### DIFF
--- a/src/Apps/Conversation/Components/ConversationSnippet.tsx
+++ b/src/Apps/Conversation/Components/ConversationSnippet.tsx
@@ -54,7 +54,7 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
         alignItems="center"
         justifyContent="space-between"
       >
-        <Flex width="350px">
+        <Flex>
           <Flex height="auto" alignItems="center" mr={2}>
             <Image src={imageURL} width="55px" />
           </Flex>
@@ -63,11 +63,17 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
               href={`/user/conversations/${conversation.internalID}`}
               underlineBehavior="hover"
             >
-              {partnerName} - {conversationText}
+              <Flex flexDirection="row">
+                <Serif size="2">{partnerName}</Serif>
+                <Serif size="2" ml={0.5} mr={0.5}>
+                  -
+                </Serif>
+                <Serif italic size="2" color="black60">
+                  {title && title.trim()}, {date}
+                </Serif>
+              </Flex>
             </Link>
-            <Serif italic size="2" color="black60" lineHeight={1.3}>
-              {title && title.trim()}, {date}
-            </Serif>
+            {conversationText}
           </Flex>
         </Flex>
         <Flex>

--- a/src/Apps/Conversation/Components/Message.tsx
+++ b/src/Apps/Conversation/Components/Message.tsx
@@ -1,10 +1,35 @@
-import { BorderBox, Sans } from "@artsy/palette"
+import { BorderBox, Box, Flex, Image, Link, Sans, Serif } from "@artsy/palette"
 import { Message_message } from "__generated__/Message_message.graphql"
 import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
 
+interface AttachmentProps {
+  item: Message_message["attachments"][0]
+}
+
+const Attachment: React.FC<AttachmentProps> = props => {
+  const { item } = props
+  if (item.contentType.startsWith("image")) {
+    return (
+      <Flex flexDirection="column" m={2}>
+        <Image src={item.downloadURL} width="75px" title={item.fileName} />
+        <Link href={item.downloadURL}>
+          <Serif size="2">{item.fileName}</Serif>
+        </Link>
+      </Flex>
+    )
+  } else if (item.contentType === "application/pdf") {
+    return (
+      <Box>
+        <Link href={item.downloadURL}>{item.fileName}</Link>
+      </Box>
+    )
+  } else {
+    return null
+  }
+}
 interface MessageProps {
   message: Message_message
   initialMessage?: string
@@ -19,6 +44,14 @@ const Message: React.FC<MessageProps> = props => {
         From: {message.from.name} - {createdAt}
       </Sans>
       <Sans size="2">{isFirst ? initialMessage : message.body}</Sans>
+      {message.attachments && message.attachments.length > 0 && (
+        <Serif size="3" mt={3}>
+          Attachments
+        </Serif>
+      )}
+      {message.attachments.map(a => (
+        <Attachment item={a} key={a.id} />
+      ))}
     </BorderBox>
   )
 }
@@ -33,6 +66,13 @@ export const MessageFragmentContainer = createFragmentContainer(Message, {
       from {
         name
         email
+      }
+      attachments {
+        id
+        internalID
+        contentType
+        fileName
+        downloadURL
       }
     }
   `,

--- a/src/Apps/Conversation/Mutation/SendConversationMessage.ts
+++ b/src/Apps/Conversation/Mutation/SendConversationMessage.ts
@@ -91,6 +91,7 @@ export const SendConversationMessage = (
             },
             isFromUser: true,
             createdAt: null, // Intentionally left blank so Message can recognize this as an optimistic response.
+            attachments: [],
           } as any,
         },
       },

--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -63,7 +63,7 @@ describe("Conversation app", () => {
         }
         const component = await render(mockMe, userType)
         const text = component.text()
-        expect(text).toContain("ConversationsAshkan Gallery - Title 1")
+        expect(text).toContain("ConversationsAshkan Gallery-Title 1")
         const btn = component.find("ArrowRightCircleIcon")
         expect(btn.length).toBe(1)
       })

--- a/src/Apps/__tests__/Fixtures/Conversation.ts
+++ b/src/Apps/__tests__/Fixtures/Conversation.ts
@@ -7,6 +7,7 @@ export const Message = {
     name: "Ashkan",
     email: "ashkan@ross.biz",
   },
+  attachments: [],
 }
 
 export const Items = [

--- a/src/__generated__/Message_message.graphql.ts
+++ b/src/__generated__/Message_message.graphql.ts
@@ -11,6 +11,13 @@ export type Message_message = {
         readonly name: string | null;
         readonly email: string | null;
     } | null;
+    readonly attachments: ReadonlyArray<{
+        readonly id: string;
+        readonly internalID: string;
+        readonly contentType: string;
+        readonly fileName: string;
+        readonly downloadURL: string;
+    } | null> | null;
     readonly " $refType": "Message_message";
 };
 export type Message_message$data = Message_message;
@@ -21,20 +28,22 @@ export type Message_message$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+};
+return {
   "kind": "Fragment",
   "name": "Message_message",
   "type": "Message",
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "internalID",
-      "args": null,
-      "storageKey": null
-    },
+    (v0/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
@@ -80,8 +89,49 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "attachments",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Attachment",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        (v0/*: any*/),
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "contentType",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "fileName",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "downloadURL",
+          "args": null,
+          "storageKey": null
+        }
+      ]
     }
   ]
 };
-(node as any).hash = '8f5506e296f74d8b4a79772cff897128';
+})();
+(node as any).hash = 'a0bb840faf9e20e16a5b20a7e14582aa';
 export default node;

--- a/src/__generated__/SendConversationMessageMutation.graphql.ts
+++ b/src/__generated__/SendConversationMessageMutation.graphql.ts
@@ -60,6 +60,13 @@ fragment Message_message on Message {
     name
     email
   }
+  attachments {
+    id
+    internalID
+    contentType
+    fileName
+    downloadURL
+  }
 }
 */
 
@@ -236,6 +243,40 @@ return {
                         "storageKey": null
                       }
                     ]
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "attachments",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Attachment",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "contentType",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "fileName",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "downloadURL",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
                   }
                 ]
               }
@@ -249,7 +290,7 @@ return {
     "operationKind": "mutation",
     "name": "SendConversationMessageMutation",
     "id": null,
-    "text": "mutation SendConversationMessageMutation(\n  $input: SendConversationMessageMutationInput!\n) {\n  sendConversationMessage(input: $input) {\n    messageEdge {\n      node {\n        impulseID\n        isFromUser\n        body\n        id\n        internalID\n        ...Message_message\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n}\n",
+    "text": "mutation SendConversationMessageMutation(\n  $input: SendConversationMessageMutationInput!\n) {\n  sendConversationMessage(input: $input) {\n    messageEdge {\n      node {\n        impulseID\n        isFromUser\n        body\n        id\n        internalID\n        ...Message_message\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_DetailQuery.graphql.ts
+++ b/src/__generated__/routes_DetailQuery.graphql.ts
@@ -106,6 +106,13 @@ fragment Message_message on Message {
     name
     email
   }
+  attachments {
+    id
+    internalID
+    contentType
+    fileName
+    downloadURL
+  }
 }
 */
 
@@ -395,6 +402,40 @@ return {
                               (v4/*: any*/)
                             ]
                           },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "attachments",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Attachment",
+                            "plural": true,
+                            "selections": [
+                              (v1/*: any*/),
+                              (v2/*: any*/),
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "contentType",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "fileName",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "downloadURL",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
                           (v6/*: any*/)
                         ]
                       },
@@ -520,7 +561,7 @@ return {
     "operationKind": "query",
     "name": "routes_DetailQuery",
     "id": null,
-    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: ASC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  conversation(id: $conversationID) {\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n}\n",
+    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: ASC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  conversation(id: $conversationID) {\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
# Change
Add Image and PDF attachments to conversation messages.

This is a follow up on #3173 where we added conversations to admins but in there we were not showing message attachments.

# Screenshot
![image](https://user-images.githubusercontent.com/1230819/75121797-7bfbb300-5665-11ea-9b1c-ad430e9fbf34.png)
