### PR TITLE
Fix issue where expanding auction result changed page

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -21,7 +21,7 @@ import { useTracking } from "react-tracking"
 import { get } from "Utils/get"
 
 export interface Props extends SystemContextProps {
-  expanded: boolean
+  expanded?: boolean
   auctionResult: ArtistAuctionResultItem_auctionResult
   index: number
   mediator?: Mediator

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useReducer } from "react"
 export interface AuctionResultsFilters {
   organizations?: string[]
   sizes?: string[]
-  openedItemIndex: number | null
   page?: number
   sort?: string
 }
@@ -17,7 +16,6 @@ interface AuctionResultsFiltersState extends AuctionResultsFilters {
 export const initialAuctionResultsFilterState: AuctionResultsFilters = {
   organizations: [],
   sizes: [],
-  openedItemIndex: null,
   page: 1,
   sort: "DATE_DESC",
 }
@@ -28,7 +26,6 @@ export interface AuctionResultsFilterContextProps {
   resetFilters: () => void
   setFilter: (name: keyof AuctionResultsFilters, value: any) => void
   unsetFilter: (name: keyof AuctionResultsFilters) => void
-  onAuctionResultClick?: (index: number) => void
   onFilterClick?: (
     key: keyof AuctionResultsFilters,
     value: string,
@@ -46,7 +43,6 @@ export const AuctionResultsFilterContext = React.createContext<
   setFilter: null,
   resetFilters: null,
   unsetFilter: null,
-  onAuctionResultClick: null,
 })
 
 export type SharedAuctionResultsFilterContextProps = Pick<
@@ -74,15 +70,6 @@ export const AuctionResultsFilterContextProvider: React.FC<SharedAuctionResultsF
 
     // Handlers
     onFilterClick,
-    onAuctionResultClick: index => {
-      dispatch({
-        type: "SET",
-        payload: {
-          name: "openedItemIndex",
-          value: index,
-        },
-      })
-    },
 
     setFilter: (name, val) => {
       if (onFilterClick) {
@@ -142,7 +129,6 @@ const AuctionResultsFilterReducer = (
 
       const filterState: AuctionResultsFilters = {
         page: 1,
-        openedItemIndex: null,
       }
 
       arrayFilterTypes.forEach(filter => {
@@ -155,7 +141,6 @@ const AuctionResultsFilterReducer = (
       const primitiveFilterTypes: Array<keyof AuctionResultsFilters> = [
         "sort",
         "page",
-        "openedItemIndex",
       ]
       primitiveFilterTypes.forEach(filter => {
         if (name === filter) {
@@ -179,13 +164,9 @@ const AuctionResultsFilterReducer = (
 
       const filterState: AuctionResultsFilters = {
         page: 1,
-        openedItemIndex: null,
       }
 
-      const filters: Array<keyof AuctionResultsFilters> = [
-        "sort",
-        "openedItemIndex",
-      ]
+      const filters: Array<keyof AuctionResultsFilters> = ["sort"]
       filters.forEach(filter => {
         if (name === filter) {
           filterState[name as any] = null

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -199,7 +199,6 @@ describe("AuctionResults", () => {
                   sizes: ["MEDIUM"],
                   page: 1,
                   sort: "DATE_DESC",
-                  openedItemIndex: null,
                   organizations: [],
                 },
               })

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.test.tsx
@@ -29,11 +29,6 @@ describe("AuctionResultsFilterContext", () => {
   })
 
   describe("behaviors", () => {
-    it("#onAuctionResultClick changes openItemIndex", () => {
-      context.onAuctionResultClick(2)
-      expect(context.filters.openedItemIndex).toBe(2)
-    })
-
     // it("#onFilterClick", () => {
     //   const spy = jest.fn()
     //   getWrapper({ onFilterClick: spy })

--- a/src/Apps/Artist/Routes/AuctionResults/state.ts
+++ b/src/Apps/Artist/Routes/AuctionResults/state.ts
@@ -2,21 +2,11 @@ import { Container } from "unstated"
 
 interface StateContainer {
   selectedAuction?: any
-  page?: number
   showDetails: boolean
-  sort?: string
 }
 
 export class AuctionResultsState extends Container<StateContainer> {
-  state = { showDetails: false, sort: "DATE_DESC", selectedAuction: null }
-
-  setPage = page => {
-    this.setState({ page })
-  }
-
-  setSort = sort => {
-    this.setState({ sort })
-  }
+  state = { showDetails: false, selectedAuction: null }
 
   openDetailsCollpase = selectedAuction => {
     this.setState({ showDetails: true, selectedAuction })

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -64,6 +64,7 @@ export enum ActionType {
 
   CommercialFilterParamsChanged = "Commercial filter params changed",
   AuctionResultFilterParamChanged = "Auction results filter params changed",
+  AuctionResultItemClicked = "Auction result item clicked",
 
   /**
    * A/B Test Experiments


### PR DESCRIPTION
When on any auction results page other than the initial page, expanding an auction card would bring you back to the first page and expand whatever auction card was at that position on the first page. 

The index of the expanded card was previously stored as a filter. When we updated the filter logic to not reset the page we were puzzled when it continued to reset anyway. After some exploration, we discovered a different bug where pagination disregards the page provided by the filters: it just always resets to 1 when a filter changes. This isn't an issue normally because the default expected behavior is to go back to the first page when a filter is changed. In this case though, we wanted to keep the current page.

Instead of fixing that larger underlying bug, which very likely would require metaphysics changes, we decided to simplify the card expanding logic by pulling it out of filters. There is a slight behavior change in which multiple cards can be expanded at one time. If needed we can follow up and fix that behavior.

Given that expansion is no longer driven by filters we added a new tracking method called `Auction result item clicked`. cc @louislecluse, you might want to test this after we merge. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.18.2-canary.3198.52571.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.18.2-canary.3198.52571.0
  # or 
  yarn add @artsy/reaction@25.18.2-canary.3198.52571.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
