### PR TITLE
Link header badges to Auction Result / Career Highlights

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -405,7 +405,13 @@ const renderAuctionHighlight = artist => {
   )
   if (topAuctionResult) {
     const auctionLabel = topAuctionResult + " Auction Record"
-    return <ArtistIndicator label={auctionLabel} type="high-auction" />
+    return (
+      <ArtistIndicator
+        label={auctionLabel}
+        type="high-auction"
+        link={`/artist/${artist.slug}/auction-results`}
+      />
+    )
   }
 }
 
@@ -420,7 +426,11 @@ const renderRepresentationStatus = artist => {
     const highCategory = highestCategory(partnersConnection.edges)
 
     return (
-      <ArtistIndicator label={CATEGORIES[highCategory]} type={highCategory} />
+      <ArtistIndicator
+        label={CATEGORIES[highCategory]}
+        type={highCategory}
+        link={`/artist/${artist.slug}/cv`}
+      />
     )
   }
 }

--- a/src/Apps/Artist/Components/ArtistIndicator.tsx
+++ b/src/Apps/Artist/Components/ArtistIndicator.tsx
@@ -8,10 +8,12 @@ import {
   TopEstablishedIcon,
 } from "@artsy/palette"
 import styled from "styled-components"
+import { StyledLink } from "./StyledLink"
 
 interface ArtistIndicatorProps {
   type: string
   label: string
+  link: string
 }
 
 const ICON_MAPPING = {
@@ -33,21 +35,23 @@ export class ArtistIndicator extends React.Component<ArtistIndicatorProps> {
   }
 
   render() {
-    const { label, type } = this.props
+    const { label, type, link } = this.props
 
     return (
-      <RoundedFlex
-        background={color("black5")}
-        width="auto"
-        py={5}
-        px={10}
-        mt={1}
-      >
-        {this.renderIcon(type)}
-        <Sans pt="2px" size="2">
-          {label}
-        </Sans>
-      </RoundedFlex>
+      <StyledLink to={link}>
+        <RoundedFlex
+          background={color("black5")}
+          width="auto"
+          py={5}
+          px={10}
+          mt={1}
+        >
+          {this.renderIcon(type)}
+          <Sans pt="2px" size="2">
+            {label}
+          </Sans>
+        </RoundedFlex>
+      </StyledLink>
     )
   }
 }

--- a/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "Apps/Artist/Components/ArtistHeader"
 import { renderRelayTree } from "DevTools"
 import { graphql } from "react-relay"
+import { ArtistIndicator } from "../ArtistIndicator"
 
 jest.unmock("react-relay")
 
@@ -17,7 +18,7 @@ describe("ArtistHeader", () => {
       Component: ArtistHeader,
       query: graphql`
         query ArtistHeader_Test_Query @raw_response_type {
-          artist(id: "pablo-picasso") {
+          artist(id: "cecily-brown") {
             ...ArtistHeader_artist
           }
         }
@@ -49,10 +50,30 @@ describe("ArtistHeader", () => {
     expect(html).toContain("Blue Chip")
   })
 
+  it("career stage links to cv page", async () => {
+    const wrapper = await getWrapper()
+    expect(
+      wrapper
+        .find(ArtistIndicator)
+        .at(0)
+        .props().link
+    ).toEqual("/artist/cecily-brown/cv")
+  })
+
   it("renders auction record indicator when data is present", async () => {
     const wrapper = await getWrapper()
     const html = wrapper.html()
     expect(html).toContain("Auction Record")
+  })
+
+  it("auction record indicator links to auction results tab", async () => {
+    const wrapper = await getWrapper()
+    expect(
+      wrapper
+        .find(ArtistIndicator)
+        .at(1)
+        .props().link
+    ).toEqual("/artist/cecily-brown/auction-results")
   })
 
   it("hides auction record indicator when data is not present", async () => {


### PR DESCRIPTION
# [PURCHASE-1782]

User experience feedback: The new labels Highest auction result and Career Stage feel/look tappable – could also lead users to Auction Result / Career Highlights?

I updated the indicators so that the auction record indicator links to the auction results tab, and the career stage indicator links to the cv page.

[PURCHASE-1782]: https://artsyproduct.atlassian.net/browse/PURCHASE-1782