### PR TITLE
[Clientside Nav] Move to more conventional A/B test structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "peerDependencies": {
     "@artsy/palette": "^4.16.0 || ^5.0.0 || ^7.0.0",
     "@sentry/browser": "^4.2.3",
-    "express-http-context": "^1.2.3",
     "flickity": "2.1.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
@@ -118,7 +117,6 @@
     "dotenv": "4.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
-    "express-http-context": "1.2.3",
     "flickity": "2.1.2",
     "fork-ts-checker-notifier-webpack-plugin": "0.6.2",
     "fork-ts-checker-webpack-plugin": "0.4.10",

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
@@ -19,11 +19,11 @@ import { SystemContextConsumer, useSystemContext } from "Artsy"
 import * as Schema from "Artsy/Analytics/Schema"
 import { Router } from "found"
 import track from "react-tracking"
-import { getENV } from "Utils/getENV"
 
 export interface ArtworkSidebarBidActionProps {
   artwork: ArtworkSidebarBidAction_artwork
   router?: Router
+  EXPERIMENTAL_APP_SHELL?: boolean
 }
 
 export interface ArtworkSidebarBidActionState {
@@ -48,7 +48,7 @@ export class ArtworkSidebarBidAction extends React.Component<
     const href = `/auction-registration/${sale.slug}`
 
     // TODO: Remove once A/B test completes
-    if (getENV("EXPERIMENTAL_APP_SHELL")) {
+    if (this.props.EXPERIMENTAL_APP_SHELL) {
       this.props.router.push(href)
     } else {
       window.location.href = href
@@ -77,7 +77,7 @@ export class ArtworkSidebarBidAction extends React.Component<
     const href = `/auction/${sale.slug}/bid/${slug}?bid=${bid}`
 
     // TODO: Remove once A/B test completes
-    if (getENV("EXPERIMENTAL_APP_SHELL")) {
+    if (this.props.EXPERIMENTAL_APP_SHELL) {
       this.props.router.push(href)
     } else {
       window.location.href = href
@@ -231,8 +231,14 @@ export class ArtworkSidebarBidAction extends React.Component<
 
 export const ArtworkSidebarBidActionFragmentContainer = createFragmentContainer(
   (props: ArtworkSidebarBidActionProps) => {
-    const { router } = useSystemContext()
-    return <ArtworkSidebarBidAction {...props} router={router} />
+    const { router, EXPERIMENTAL_APP_SHELL } = useSystemContext()
+    return (
+      <ArtworkSidebarBidAction
+        {...props}
+        router={router}
+        EXPERIMENTAL_APP_SHELL={EXPERIMENTAL_APP_SHELL}
+      />
+    )
   },
   {
     artwork: graphql`

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -28,7 +28,6 @@ import {
 } from "react-relay"
 import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { ArtworkSidebarSizeInfoFragmentContainer as SizeInfo } from "./ArtworkSidebarSizeInfo"
 
@@ -39,6 +38,7 @@ export interface ArtworkSidebarCommercialContainerProps
   mediator: Mediator
   router?: Router
   user: User
+  EXPERIMENTAL_APP_SHELL?: boolean
 }
 
 export interface ArtworkSidebarCommercialContainerState {
@@ -234,7 +234,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                       const url = `/orders/${orderOrError.order.internalID}`
 
                       // FIXME: Remove once A/B test completes
-                      if (getENV("EXPERIMENTAL_APP_SHELL")) {
+                      if (this.props.EXPERIMENTAL_APP_SHELL) {
                         this.props.router.push(url)
                       } else {
                         window.location.assign(url)
@@ -323,7 +323,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
                       const url = `/orders/${orderOrError.order.internalID}/offer`
 
                       // FIXME: Remove once A/B test completes
-                      if (getENV("EXPERIMENTAL_APP_SHELL")) {
+                      if (this.props.EXPERIMENTAL_APP_SHELL) {
                         this.props.router.push(url)
                       } else {
                         window.location.assign(url)
@@ -461,7 +461,9 @@ interface ArtworkSidebarCommercialProps {
 }
 
 export const ArtworkSidebarCommercial: FC<ArtworkSidebarCommercialProps> = props => {
-  const { mediator, router, user } = useContext(SystemContext)
+  const { mediator, router, user, EXPERIMENTAL_APP_SHELL } = useContext(
+    SystemContext
+  )
 
   return (
     <ArtworkSidebarCommercialContainer
@@ -469,6 +471,7 @@ export const ArtworkSidebarCommercial: FC<ArtworkSidebarCommercialProps> = props
       mediator={mediator}
       router={router}
       user={user}
+      EXPERIMENTAL_APP_SHELL={EXPERIMENTAL_APP_SHELL}
     />
   )
 }

--- a/src/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -39,7 +39,6 @@ import {
 } from "react-stripe-elements"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
@@ -63,7 +62,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
   let pollCount = 0
   let registrationTracked = false
 
-  const { router } = useSystemContext()
+  const { router, EXPERIMENTAL_APP_SHELL } = useSystemContext()
   const { artwork, me, relay, stripe } = props
   const { saleArtwork } = artwork
   const { sale } = saleArtwork
@@ -285,7 +284,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
       const href = `/artwork/${artwork.slug}`
 
-      if (getENV("EXPERIMENTAL_APP_SHELL")) {
+      if (EXPERIMENTAL_APP_SHELL) {
         router.push(href)
       } else {
         window.location.assign(href)
@@ -299,7 +298,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
 
   // FIXME: Remove after A/B test completes
   let NavBar
-  if (getENV("EXPERIMENTAL_APP_SHELL")) {
+  if (EXPERIMENTAL_APP_SHELL) {
     NavBar = MinimalNavBar
   } else {
     NavBar = Box // pass-through; nav bar comes from the server right now

--- a/src/Apps/Auction/Routes/Register/index.tsx
+++ b/src/Apps/Auction/Routes/Register/index.tsx
@@ -11,7 +11,7 @@ import {
   StripeWrappedRegistrationForm,
 } from "Apps/Auction/Components/RegistrationForm"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { track } from "Artsy"
+import { track, useSystemContext } from "Artsy"
 import * as Schema from "Artsy/Analytics/Schema"
 import { MinimalNavBar } from "Components/NavBar/MinimalNavBar"
 import { FormikActions } from "formik"
@@ -25,7 +25,6 @@ import {
 } from "react-relay"
 import { TrackingProp } from "react-tracking"
 import { data as sd } from "sharify"
-import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 
 const logger = createLogger("Apps/Auction/Routes/Register")
@@ -101,6 +100,7 @@ export function createCreditCardAndUpdatePhone(relayEnvironment, phone, token) {
 
 export const RegisterRoute: React.FC<RegisterProps> = props => {
   const { me, relay, sale, tracking } = props
+  const { EXPERIMENTAL_APP_SHELL } = useSystemContext()
 
   const commonProperties = {
     auction_slug: sale.slug,
@@ -195,7 +195,7 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
 
   // FIXME: Remove after A/B test completes
   let NavBar
-  if (getENV("EXPERIMENTAL_APP_SHELL")) {
+  if (EXPERIMENTAL_APP_SHELL) {
     NavBar = MinimalNavBar
   } else {
     NavBar = Box // pass-through; nav bar comes from the server right now

--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -13,6 +13,16 @@ import { Environment, RecordSource, Store } from "relay-runtime"
 import { DeepPartial } from "Utils/typeSupport"
 
 describe("Auction/routes", () => {
+  // FIXME: Remove after A/B test runs
+  beforeEach(() => {
+    // @ts-ignore
+    window.sd = { CLIENT_NAVIGATION_V3: "experiment" }
+  })
+  beforeEach(() => {
+    // @ts-ignore
+    delete window.sd.CLIENT_NAVIGATION_V3
+  })
+
   async function render(
     url,
     mockData:

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -3,7 +3,7 @@ import { ErrorPage } from "Components/ErrorPage"
 import { RedirectException, RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
-import { getENV } from "Utils/getENV"
+import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
 import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
 
@@ -117,7 +117,8 @@ function handleRedirect(redirect: Redirect, location: Location) {
     )
 
     // FIXME: Remove after A/B test completes
-    if (getENV("EXPERIMENTAL_APP_SHELL")) {
+    if (sd.CLIENT_NAVIGATION_V3 === "experiment") {
+      // This path will only ever be reached on the client
       // Perform a hard jump to login page as it doesn't exist within router
       if (redirect.path.includes("/log_in?")) {
         window.location.href = redirect.path

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -3,7 +3,6 @@ import { ErrorPage } from "Components/ErrorPage"
 import { RedirectException, RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"
-import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
 import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
 
@@ -116,12 +115,17 @@ function handleRedirect(redirect: Redirect, location: Location) {
       `Redirecting from ${location.pathname} to ${redirect.path} because '${redirect.reason}'`
     )
 
-    // FIXME: Remove after A/B test completes
-    if (sd.CLIENT_NAVIGATION_V3 === "experiment") {
-      // This path will only ever be reached on the client
-      // Perform a hard jump to login page as it doesn't exist within router
-      if (redirect.path.includes("/log_in?")) {
-        window.location.href = redirect.path
+    if (typeof window !== "undefined") {
+      // FIXME: Remove after A/B test completes
+      // @ts-ignore
+      if (window.sd.CLIENT_NAVIGATION_V3 === "experiment") {
+        // This path will only ever be reached on the client
+        // Perform a hard jump to login page as it doesn't exist within router
+        if (redirect.path.includes("/log_in?")) {
+          window.location.href = redirect.path
+        } else {
+          throw new RedirectException(redirect.path)
+        }
       } else {
         throw new RedirectException(redirect.path)
       }

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -2,7 +2,7 @@ import { Box } from "@artsy/palette"
 import { OrderApp_order } from "__generated__/OrderApp_order.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { StickyFooter } from "Apps/Order/Components/StickyFooter"
-import { Mediator, SystemContextConsumer } from "Artsy"
+import { Mediator, SystemContextConsumer, withSystemContext } from "Artsy"
 import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "Components/ErrorPage"
 import { MinimalNavBar } from "Components/NavBar/MinimalNavBar"
@@ -13,7 +13,6 @@ import { graphql } from "react-relay"
 import { Elements, StripeProvider } from "react-stripe-elements"
 import styled from "styled-components"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
 import { ConnectedModalDialog } from "./Dialogs"
 
 declare global {
@@ -30,6 +29,7 @@ export interface OrderAppProps extends RouterState {
     orderID: string
   }
   order: OrderApp_order
+  EXPERIMENTAL_APP_SHELL: boolean
 }
 
 interface OrderAppState {
@@ -126,7 +126,7 @@ class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
 
     // FIXME: Remove after A/B test completes
     let NavBar
-    if (getENV("EXPERIMENTAL_APP_SHELL")) {
+    if (this.props.EXPERIMENTAL_APP_SHELL) {
       NavBar = MinimalNavBar
     } else {
       NavBar = Box // pass-through; nav bar comes from the server right now
@@ -169,7 +169,7 @@ class OrderApp extends React.Component<OrderAppProps, OrderAppState> {
   }
 }
 
-const OrderAppWithRouter = withRouter(OrderApp)
+const OrderAppWithRouter = withRouter(withSystemContext(OrderApp))
 
 export { OrderAppWithRouter as OrderApp }
 

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -2,7 +2,7 @@ import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import ActionTypes from "farce/lib/ActionTypes"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
+
 /**
  * PageView tracking middleware for use in our router apps. Middleware conforms
  * to Redux middleware spec.
@@ -51,7 +51,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             }
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-            if (getENV("EXPERIMENTAL_APP_SHELL")) {
+            if (sd.CLIENT_NAVIGATION_V3 === "experiment") {
               if (referrer) {
                 trackingData.referrer = sd.APP_URL + referrer
               }

--- a/src/Artsy/Router/Utils/RenderStatus.tsx
+++ b/src/Artsy/Router/Utils/RenderStatus.tsx
@@ -6,14 +6,17 @@ import { useSystemContext } from "Artsy"
 import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
-import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
 export const RenderPending = () => {
-  const { isFetching, setIsFetching } = useSystemContext()
+  const {
+    isFetching,
+    setIsFetching,
+    EXPERIMENTAL_APP_SHELL,
+  } = useSystemContext()
 
   if (!isFetching) {
     setIsFetching(true)
@@ -23,7 +26,7 @@ export const RenderPending = () => {
    * TODO: Add timeout here for when a request takes too long. Show generic error
    * and notify Sentry.
    */
-  if (getENV("EXPERIMENTAL_APP_SHELL")) {
+  if (EXPERIMENTAL_APP_SHELL) {
     return (
       <>
         <Renderer>{null}</Renderer>

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -139,15 +139,9 @@ export function buildServerApp(
           )
         }
 
-        // FIXME: Remove once EXPERIMENTAL_APP_SHELL A/B test completes
-        const entrypoints = []
-        if (getENV("EXPERIMENTAL_APP_SHELL")) {
-          entrypoints.push("experimental-app-shell")
-        }
-
         const extractor = new ChunkExtractor({
           statsFile,
-          entrypoints,
+          entrypoints: [],
         })
 
         // Wrap component tree in library contexts to extract usage

--- a/src/Artsy/SystemContext.tsx
+++ b/src/Artsy/SystemContext.tsx
@@ -60,6 +60,9 @@ export interface SystemContextProps {
    * and `USER_ACCESS_TOKEN` environment variables if available.
    */
   user?: User
+
+  // TODO: Remove once A/B test completes
+  EXPERIMENTAL_APP_SHELL?: boolean
 }
 
 export const SystemContext = React.createContext<SystemContextProps>({})

--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -15,7 +15,6 @@ import {
 
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
-import { getENV } from "Utils/getENV"
 
 interface MobileNavMenuProps {
   onNavItemClick?: () => void
@@ -24,7 +23,7 @@ interface MobileNavMenuProps {
 export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
   const { onNavItemClick } = props
   const { trackEvent } = useTracking()
-  const { user } = useContext(SystemContext)
+  const { user, EXPERIMENTAL_APP_SHELL } = useContext(SystemContext)
   const isLoggedIn = Boolean(user)
 
   const trackClick = event => {
@@ -39,7 +38,7 @@ export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
     })
 
     // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-    if (getENV("EXPERIMENTAL_APP_SHELL") && href === "/collect") {
+    if (EXPERIMENTAL_APP_SHELL && href === "/collect") {
       onNavItemClick()
     }
   }

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -24,7 +24,6 @@ import styled from "styled-components"
 import request from "superagent"
 import Events from "Utils/Events"
 import { get } from "Utils/get"
-import { getENV } from "Utils/getENV"
 import { useDidMount } from "Utils/Hooks/useDidMount"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
@@ -157,7 +156,7 @@ export class SearchBar extends Component<Props, State> {
   constructor(props) {
     super(props)
 
-    this.enableExperimentalAppShell = getENV("EXPERIMENTAL_APP_SHELL")
+    this.enableExperimentalAppShell = props.EXPERIMENTAL_APP_SHELL
   }
 
   componentDidMount() {

--- a/src/Utils/getENV.tsx
+++ b/src/Utils/getENV.tsx
@@ -1,12 +1,9 @@
 import { data as sd } from "sharify"
 
 export function getENV(ENV_VAR) {
-  const isServer = typeof window === "undefined"
-
   let envVar
-  if (isServer) {
-    const httpContext = require("express-http-context")
-    envVar = httpContext.get(ENV_VAR) ?? process.env[ENV_VAR]
+  if (typeof window === "undefined") {
+    envVar = process.env[ENV_VAR]
   } else {
     envVar = sd[ENV_VAR]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,14 +2865,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
-  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
 "@types/chalk@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
@@ -2884,20 +2876,6 @@
   version "0.22.8"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.8.tgz#5702f74f78b73e13f1eb1bd435c2c9de61a250d4"
   integrity sha512-LzF540VOFabhS2TR2yYFz2Mu/fTfkA+5AwYddtJbOJGwnYrr2e7fHadT7/Z3jNGJJdCRlO3ySxmW26NgRdwhNA==
-
-"@types/cls-hooked@^4.2.1":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.0.tgz#290fa14946b88b11e65d68e487eda78a4d5a927e"
-  integrity sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==
-  dependencies:
-    "@types/node" "*"
-
-"@types/connect@*":
-  version "3.4.33"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
-  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
-  dependencies:
-    "@types/node" "*"
 
 "@types/dd-trace@0.6.0":
   version "0.6.0"
@@ -2918,23 +2896,6 @@
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
-
-"@types/express-serve-static-core@*":
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz#f6f41fa35d42e79dbf6610eccbb2637e6008a0cf"
-  integrity sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==
-  dependencies:
-    "@types/node" "*"
-    "@types/range-parser" "*"
-
-"@types/express@^4.16.0":
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
-  integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
-    "@types/serve-static" "*"
 
 "@types/flickity@2.2.2":
   version "2.2.2"
@@ -2998,11 +2959,6 @@
   resolved "https://registry.yarnpkg.com/@types/memoize-one/-/memoize-one-3.1.1.tgz#0e21a1b91dc031fb59c1e1657b807ca9aec77475"
   integrity sha512-VlMu4eWNfQ8CDfhHYe8P/RgBq8vgce8LMo4vVKASPPAv+TE9SCR1bH6pA4nHEKNUQz1L/PIdElU2vqA2m366Dw==
 
-"@types/mime@*":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
-  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
-
 "@types/node@*":
   version "10.12.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.29.tgz#c2c8d2d27bb55649fbafe8ea1731658421f38acf"
@@ -3029,11 +2985,6 @@
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.3.tgz#1c3b71b091eaeaf5924538006b7f70603ce63d38"
   integrity sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==
-
-"@types/range-parser@*":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
-  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/react-dom@16.8.4":
   version "16.8.4"
@@ -3127,14 +3078,6 @@
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-6.0.11.tgz#635e0e7d60d6b66fa632bdeb7e3d02b44f9add03"
   integrity sha512-59JBBYnO6aHvIoVoUHuXQbZA/FWPfQgUPr34xOXKTiJ04cV1Mp+JRmtGBmuBw9N9dT/aDMwq1SOgHMQdAha4Pg==
-
-"@types/serve-static@*":
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
-  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
-  dependencies:
-    "@types/express-serve-static-core" "*"
-    "@types/mime" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -3861,13 +3804,6 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
-async-hook-jl@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
-  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
-  dependencies:
-    stack-chain "^1.3.7"
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -5412,15 +5348,6 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-cls-hooked@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
-  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
-  dependencies:
-    async-hook-jl "^1.7.6"
-    emitter-listener "^1.0.1"
-    semver "^5.4.1"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6651,13 +6578,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emitter-listener@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
-  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
-  dependencies:
-    shimmer "^1.2.0"
-
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -7061,15 +6981,6 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
-
-express-http-context@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/express-http-context/-/express-http-context-1.2.3.tgz#780c96006e5b6f0a384a175afb35b40411d4f331"
-  integrity sha512-Cde8XZJ8qYc4ACZSwn2NxuBG6mnPfXDtJUW+Ppgb2AhyNP4ttESK2SrYfAk6CluFADbxy24C5mVP25sOeBAgbQ==
-  dependencies:
-    "@types/cls-hooked" "^4.2.1"
-    "@types/express" "^4.16.0"
-    cls-hooked "^4.2.2"
 
 express@^4.16.3:
   version "4.16.3"
@@ -14448,11 +14359,6 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shimmer@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
-  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -14716,11 +14622,6 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
-stack-chain@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
-  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 stack-utils@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This moves things to a conventional A/B test structure. 

@mzikherman - I keep revisiting the strange production-only edgecase around the ENV var being unset when clicking `/collect` and want to play it safe because we can't afford to get incorrect metrics. We can't repo it locally. If there's a chance that things get out of sync we might be over or under reporting a given A/B test state. 

I don't know if it has anything to do with `express-http-context`, but I'd rather be 100% sure that it's safe for a change as big as this, especially if it has to do with concurrency. 