### PR TITLE
[step 2] Update schema to use MP's schema at mp@rename-wizard-to-flow

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1327,6 +1327,8 @@ type Attachment {
 
   # File name.
   fileName: String!
+
+  # URL of attachment.
   downloadURL: String!
 }
 
@@ -7251,7 +7253,7 @@ type StartIdentityVerificationSuccess {
   identityVerificationId: String
 
   # URL that hosts the user-facing identity verification flow (Jumio)
-  identityVerificationWizardUrl: String
+  identityVerificationFlowUrl: String
 }
 
 type StaticContent {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "yarn storybook",
     "storybook": "concurrently --raw --kill-others 'yarn relay --watch' 'start-storybook --quiet -s ./public -p 9001'",
     "sync-schema": "curl https://raw.githubusercontent.com/artsy/metaphysics/master/_schemaV2.graphql -o data/schema.graphql; yarn prettier --write --parser graphql data/schema.graphql",
-    "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema -- ../reaction/data",
+    "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema v2 ../reaction/data/",
     "test": "jest",
     "test:watch": "jest --watch --runInBand",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
- Tooling: Fix `yarn schema-schema`
- Update schema to use MP's schema at mp@rename-wizard-to-flow

Merge after: https://github.com/artsy/metaphysics/pull/2203
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.21.2-canary.3205.52776.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.21.2-canary.3205.52776.0
  # or 
  yarn add @artsy/reaction@25.21.2-canary.3205.52776.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
