### PR TITLE
[Clientside Nav] Add async bundle preloading pattern to router

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/flickity": "2.2.2",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "24.0.18",
+    "@types/loadable__component": "^5.10.0",
     "@types/lodash": "4.14.111",
     "@types/memoize-one": "3.1.1",
     "@types/prop-types": "15.7.1",

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -61,6 +61,11 @@ const OverviewRoute = loadable(() => import("./Routes/Overview"))
 const WorksForSaleRoute = loadable(() => import("./Routes/Works"))
 const AuctionResultsRoute = loadable(() => import("./Routes/AuctionResults"))
 
+// Artist pages tend to load almost instantly, so just preload it up front
+if (typeof window !== "undefined") {
+  ArtistApp.preload()
+}
+
 // FIXME:
 // * `render` functions requires casting
 // * `Redirect` needs to be casted, as it’s not compatible with `RouteConfig`

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -56,13 +56,21 @@ graphql`
   }
 `
 
+const ArtistApp = loadable(() => import("./ArtistApp"))
+const OverviewRoute = loadable(() => import("./Routes/Overview"))
+const WorksForSaleRoute = loadable(() => import("./Routes/Works"))
+const AuctionResultsRoute = loadable(() => import("./Routes/AuctionResults"))
+
 // FIXME:
 // * `render` functions requires casting
 // * `Redirect` needs to be casted, as it’s not compatible with `RouteConfig`
 export const routes: RouteConfig[] = [
   {
     path: "/artist/:artistID",
-    getComponent: () => loadable(() => import("./ArtistApp")),
+    getComponent: () => ArtistApp,
+    prepare: () => {
+      ArtistApp.preload()
+    },
     query: graphql`
       query routes_ArtistTopLevelQuery($artistID: String!) @raw_response_type {
         artist(id: $artistID) @principalField {
@@ -100,7 +108,10 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "/",
-        getComponent: () => loadable(() => import("./Routes/Overview")),
+        getComponent: () => OverviewRoute,
+        prepare: () => {
+          OverviewRoute.preload()
+        },
         displayNavigationTabs: true,
         query: graphql`
           query routes_OverviewQuery($artistID: String!) @raw_response_type {
@@ -111,53 +122,11 @@ export const routes: RouteConfig[] = [
         `,
       },
       {
-        path: "cv",
-        getComponent: () => loadable(() => import("./Routes/CV")),
-        query: graphql`
-          query routes_CVQuery($artistID: String!) {
-            viewer {
-              ...CV_viewer
-            }
-          }
-        `,
-      },
-      {
-        path: "articles",
-        getComponent: () => loadable(() => import("./Routes/Articles")),
-        query: graphql`
-          query routes_ArticlesQuery($artistID: String!) {
-            artist(id: $artistID) {
-              ...Articles_artist
-            }
-          }
-        `,
-      },
-      {
-        path: "shows",
-        getComponent: () => loadable(() => import("./Routes/Shows")),
-        query: graphql`
-          query routes_ShowsQuery($artistID: String!) {
-            viewer {
-              ...Shows_viewer
-            }
-          }
-        `,
-      },
-      {
-        path: "auction-results",
-        getComponent: () => loadable(() => import("./Routes/AuctionResults")),
-        displayNavigationTabs: true,
-        query: graphql`
-          query routes_AuctionResultsQuery($artistID: String!) {
-            artist(id: $artistID) {
-              ...AuctionResults_artist
-            }
-          }
-        `,
-      },
-      {
         path: "works-for-sale",
-        getComponent: () => loadable(() => import("./Routes/Works")),
+        getComponent: () => WorksForSaleRoute,
+        prepare: () => {
+          WorksForSaleRoute.preload()
+        },
         displayNavigationTabs: true,
         query: graphql`
           query routes_WorksQuery(
@@ -231,6 +200,57 @@ export const routes: RouteConfig[] = [
           return filterParams
         },
       },
+      {
+        path: "auction-results",
+        getComponent: () => AuctionResultsRoute,
+        prepare: () => {
+          AuctionResultsRoute.preload()
+        },
+        displayNavigationTabs: true,
+        query: graphql`
+          query routes_AuctionResultsQuery($artistID: String!) {
+            artist(id: $artistID) {
+              ...AuctionResults_artist
+            }
+          }
+        `,
+      },
+
+      // FIXME: Remove the following unused routes
+      {
+        path: "cv",
+        getComponent: () => loadable(() => import("./Routes/CV")),
+        query: graphql`
+          query routes_CVQuery($artistID: String!) {
+            viewer {
+              ...CV_viewer
+            }
+          }
+        `,
+      },
+      {
+        path: "articles",
+        getComponent: () => loadable(() => import("./Routes/Articles")),
+        query: graphql`
+          query routes_ArticlesQuery($artistID: String!) {
+            artist(id: $artistID) {
+              ...Articles_artist
+            }
+          }
+        `,
+      },
+      {
+        path: "shows",
+        getComponent: () => loadable(() => import("./Routes/Shows")),
+        query: graphql`
+          query routes_ShowsQuery($artistID: String!) {
+            viewer {
+              ...Shows_viewer
+            }
+          }
+        `,
+      },
+
       // Redirect all unhandled tabs to the artist page.
       // Note: there is a deep-linked standalone auction-lot page
       // in Force, under /artist/:artistID/auction-result/:id.

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -60,6 +60,9 @@ const ArtistApp = loadable(() => import("./ArtistApp"))
 const OverviewRoute = loadable(() => import("./Routes/Overview"))
 const WorksForSaleRoute = loadable(() => import("./Routes/Works"))
 const AuctionResultsRoute = loadable(() => import("./Routes/AuctionResults"))
+const CVRoute = loadable(() => import("./Routes/CV"))
+const ArticlesRoute = loadable(() => import("./Routes/Articles"))
+const ShowsRoute = loadable(() => import("./Routes/Shows"))
 
 // Artist pages tend to load almost instantly, so just preload it up front
 if (typeof window !== "undefined") {
@@ -111,6 +114,7 @@ export const routes: RouteConfig[] = [
       }
     },
     children: [
+      // Routes in tabs
       {
         path: "/",
         getComponent: () => OverviewRoute,
@@ -221,10 +225,13 @@ export const routes: RouteConfig[] = [
         `,
       },
 
-      // FIXME: Remove the following unused routes
+      // Routes not in tabs
       {
         path: "cv",
-        getComponent: () => loadable(() => import("./Routes/CV")),
+        getComponent: () => CVRoute,
+        prepare: () => {
+          CVRoute.preload()
+        },
         query: graphql`
           query routes_CVQuery($artistID: String!) {
             viewer {
@@ -235,7 +242,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "articles",
-        getComponent: () => loadable(() => import("./Routes/Articles")),
+        getComponent: () => ArticlesRoute,
+        prepare: () => {
+          ArticlesRoute.preload()
+        },
         query: graphql`
           query routes_ArticlesQuery($artistID: String!) {
             artist(id: $artistID) {
@@ -246,7 +256,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "shows",
-        getComponent: () => loadable(() => import("./Routes/Shows")),
+        getComponent: () => ShowsRoute,
+        prepare: () => {
+          ShowsRoute.preload()
+        },
         query: graphql`
           query routes_ShowsQuery($artistID: String!) {
             viewer {

--- a/src/Apps/Artwork/routes.tsx
+++ b/src/Apps/Artwork/routes.tsx
@@ -1,10 +1,15 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 
+const ArtworkApp = loadable(() => import("./ArtworkApp"))
+
 export const routes = [
   {
     path: "/artwork/:artworkID/(confirm-bid)?",
-    getComponent: () => loadable(() => import("./ArtworkApp")),
+    getComponent: () => ArtworkApp,
+    prepare: () => {
+      ArtworkApp.preload()
+    },
     query: graphql`
       query routes_ArtworkQuery($artworkID: String!) {
         artwork(id: $artworkID) @principalField {

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -8,10 +8,17 @@ import { confirmBidRedirect, Redirect, registerRedirect } from "./getRedirect"
 
 const logger = createLogger("Apps/Auction/routes")
 
+const AuctionFAQRoute = loadable(() => import("./Components/AuctionFAQ"))
+const ConfirmBidRoute = loadable(() => import("./Routes/ConfirmBid"))
+const RegisterRoute = loadable(() => import("./Routes/Register"))
+
 export const routes: RouteConfig[] = [
   {
     path: "/auction-faq",
-    getComponent: () => loadable(() => import("./Components/AuctionFAQ")),
+    getComponent: () => AuctionFAQRoute,
+    prepare: () => {
+      AuctionFAQRoute.preload()
+    },
     query: graphql`
       query routes_AuctionFAQQuery {
         viewer {
@@ -23,7 +30,10 @@ export const routes: RouteConfig[] = [
   },
   {
     path: "/auction/:saleID/bid(2)?/:artworkID",
-    getComponent: () => loadable(() => import("./Routes/ConfirmBid")),
+    getComponent: () => ConfirmBidRoute,
+    prepare: () => {
+      ConfirmBidRoute.preload()
+    },
     render: ({ Component, props }) => {
       if (Component && props) {
         const { artwork, me, match } = props as any
@@ -72,7 +82,10 @@ export const routes: RouteConfig[] = [
   },
   {
     path: "/auction-registration(2)?/:saleID",
-    getComponent: () => loadable(() => import("./Routes/Register")),
+    getComponent: () => RegisterRoute,
+    prepare: () => {
+      RegisterRoute.preload()
+    },
     render: ({ Component, props }) => {
       if (Component && props) {
         const { match, sale, me } = props as any

--- a/src/Apps/Collect2/collectRoutes.tsx
+++ b/src/Apps/Collect2/collectRoutes.tsx
@@ -5,10 +5,17 @@ import { graphql } from "react-relay"
 import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { CollectionAppQuery } from "./Routes/Collection/CollectionAppQuery"
 
+const CollectApp = loadable(() => import("./Routes/Collect"))
+const CollectionsApp = loadable(() => import("./Routes/Collections"))
+const CollectionApp = loadable(() => import("./Routes/Collection"))
+
 export const collectRoutes: RouteConfig[] = [
   {
     path: "/collect/:medium?",
-    getComponent: () => loadable(() => import("./Routes/Collect")),
+    getComponent: () => CollectApp,
+    prepare: () => {
+      CollectApp.preload()
+    },
     fetchIndicator: "overlay",
     prepareVariables: initializeVariablesWithFilterState,
     query: graphql`
@@ -70,7 +77,10 @@ export const collectRoutes: RouteConfig[] = [
   },
   {
     path: "/collections",
-    getComponent: () => loadable(() => import("./Routes/Collections")),
+    getComponent: () => CollectionsApp,
+    prepare: () => {
+      CollectionsApp.preload()
+    },
     fetchIndicator: "overlay",
     query: graphql`
       query collectRoutes_MarketingCollectionsAppQuery {
@@ -82,7 +92,10 @@ export const collectRoutes: RouteConfig[] = [
   },
   {
     path: "/collection/:slug",
-    getComponent: () => loadable(() => import("./Routes/Collection")),
+    getComponent: () => CollectionApp,
+    prepare: () => {
+      CollectionApp.preload()
+    },
     prepareVariables: initializeVariablesWithFilterState,
     fetchIndicator: "overlay",
     query: CollectionAppQuery,

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,9 +1,30 @@
 import { Box } from "@artsy/palette"
+import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { NavBar } from "Components/NavBar"
-import React from "react"
+import { isFunction } from "lodash"
+import React, { useEffect } from "react"
+import createLogger from "Utils/logger"
+
+const logger = createLogger("Apps/Components/AppShell")
 
 export const AppShell = props => {
-  const { children } = props
+  const { children, match } = props
+  const routeConfig = findCurrentRoute(match)
+
+  /**
+   * Check to see if a route has a prepare key; if so call it. Used typically to
+   * preload bundle-split components (import()) while the route is fetching data
+   * in the background.
+   */
+  useEffect(() => {
+    if (isFunction(routeConfig.prepare)) {
+      try {
+        routeConfig.prepare()
+      } catch (error) {
+        logger.error(error)
+      }
+    }
+  }, [routeConfig])
 
   return (
     <Box width="100%">

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -7,6 +7,16 @@ import * as React from "react"
 import { graphql } from "react-relay"
 
 const OrderApp = loadable(() => import("./OrderApp"))
+const RespondRoute = loadable(() => import("./Routes/Respond"))
+const OfferRoute = loadable(() => import("./Routes/Offer"))
+const ShippingRoute = loadable(() => import("./Routes/Shipping"))
+const PaymentRoute = loadable(() => import("./Routes/Payment"))
+const NewPaymentRoute = loadable(() => import("./Routes/NewPayment"))
+const CounterRoute = loadable(() => import("./Routes/Counter"))
+const ReviewRoute = loadable(() => import("./Routes/Review"))
+const AcceptRoute = loadable(() => import("./Routes/Accept"))
+const DeclineRoute = loadable(() => import("./Routes/Reject"))
+const StatusRoute = loadable(() => import("./Routes/Status"))
 
 // FIXME:
 // * `render` functions requires casting
@@ -64,7 +74,10 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "respond",
-        getComponent: () => loadable(() => import("./Routes/Respond")),
+        getComponent: () => RespondRoute,
+        prepare: () => {
+          RespondRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_RespondQuery($orderID: ID!) {
@@ -79,7 +92,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "offer",
-        getComponent: () => loadable(() => import("./Routes/Offer")),
+        getComponent: () => OfferRoute,
+        prepare: () => {
+          OfferRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_OfferQuery($orderID: ID!) {
@@ -94,7 +110,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "shipping",
-        getComponent: () => loadable(() => import("./Routes/Shipping")),
+        getComponent: () => ShippingRoute,
+        prepare: () => {
+          ShippingRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_ShippingQuery($orderID: ID!) {
@@ -109,7 +128,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "payment",
-        getComponent: () => loadable(() => import("./Routes/Payment")),
+        getComponent: () => PaymentRoute,
+        prepare: () => {
+          PaymentRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_PaymentQuery($orderID: ID!) {
@@ -127,7 +149,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "payment/new",
-        getComponent: () => loadable(() => import("./Routes/NewPayment")),
+        getComponent: () => NewPaymentRoute,
+        prepare: () => {
+          NewPaymentRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_NewPaymentQuery($orderID: ID!) {
@@ -145,7 +170,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/counter",
-        getComponent: () => loadable(() => import("./Routes/Counter")),
+        getComponent: () => CounterRoute,
+        prepare: () => {
+          CounterRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_CounterQuery($orderID: ID!) {
@@ -160,7 +188,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review",
-        getComponent: () => loadable(() => import("./Routes/Review")),
+        getComponent: () => ReviewRoute,
+        prepare: () => {
+          ReviewRoute.preload()
+        },
         shouldWarnBeforeLeaving: true,
         query: graphql`
           query routes_ReviewQuery($orderID: ID!) {
@@ -175,7 +206,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/accept",
-        getComponent: () => loadable(() => import("./Routes/Accept")),
+        getComponent: () => AcceptRoute,
+        prepare: () => {
+          AcceptRoute.preload()
+        },
         query: graphql`
           query routes_AcceptQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -189,7 +223,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "review/decline",
-        getComponent: () => loadable(() => import("./Routes/Reject")),
+        getComponent: () => DeclineRoute,
+        prepare: () => {
+          DeclineRoute.preload()
+        },
         query: graphql`
           query routes_RejectQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -200,7 +237,10 @@ export const routes: RouteConfig[] = [
       },
       {
         path: "status",
-        getComponent: () => loadable(() => import("./Routes/Status")),
+        getComponent: () => StatusRoute,
+        prepare: () => {
+          StatusRoute.preload()
+        },
         query: graphql`
           query routes_StatusQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {

--- a/src/Apps/Order/routes.tsx
+++ b/src/Apps/Order/routes.tsx
@@ -6,12 +6,17 @@ import { Redirect, RedirectException, RouteConfig } from "found"
 import * as React from "react"
 import { graphql } from "react-relay"
 
+const OrderApp = loadable(() => import("./OrderApp"))
+
 // FIXME:
 // * `render` functions requires casting
 export const routes: RouteConfig[] = [
   {
     path: "/order(2|s)/:orderID",
-    getComponent: () => loadable(() => import("./OrderApp")),
+    Component: OrderApp,
+    prepare: () => {
+      OrderApp.preload()
+    },
 
     // TODO: Better support `@principalField` in Metaphysics.
     // This currently only works because of the `order` field alias.

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -7,6 +7,12 @@ import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
 import { ArtworkQueryFilter } from "Components/v2/ArtworkFilter/ArtworkQueryFilter"
 import { paramsToCamelCase } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 
+const SearchApp = loadable(() => import("./SearchApp"))
+const ArtworksRoute = loadable(() => import("./Routes/Artworks"))
+const ArtistsRoute = loadable(() =>
+  import("./Routes/Artists/SearchResultsArtists")
+)
+
 const prepareVariables = (_params, { location }) => {
   return {
     ...paramsToCamelCase(location.query),
@@ -64,7 +70,10 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
 export const routes: RouteConfig[] = [
   {
     path: "/search",
-    getComponent: () => loadable(() => import("./SearchApp")),
+    getComponent: () => SearchApp,
+    prepare: () => {
+      SearchApp.preload()
+    },
     query: graphql`
       query routes_SearchResultsTopLevelQuery($term: String!) {
         viewer {
@@ -76,14 +85,19 @@ export const routes: RouteConfig[] = [
     children: [
       {
         path: "/",
-        getComponent: () => loadable(() => import("./Routes/Artworks")),
+        getComponent: () => ArtworksRoute,
+        prepare: () => {
+          ArtworksRoute.preload()
+        },
         prepareVariables,
         query: ArtworkQueryFilter,
       },
       {
         path: "artists",
-        getComponent: () =>
-          loadable(() => import("./Routes/Artists/SearchResultsArtists")),
+        getComponent: () => ArtistsRoute,
+        prepare: () => {
+          ArtistsRoute.preload()
+        },
         prepareVariables,
         query: graphql`
           query routes_SearchResultsArtistsQuery($term: String!, $page: Int) {

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -37,8 +37,9 @@ export interface ServerAppResolve {
     url: string
   }
   status?: number
-  headTags?: any[]
   scripts?: string
+  linkTags?: string[]
+  headTags?: any[]
   styleTags?: string
 }
 
@@ -153,6 +154,10 @@ export function buildServerApp(
 
         // Extract all dynamic `import()` bundle split tags from app
         const bundleScriptTags = extractor.getScriptTags()
+
+        // TODO: Wire up / experiment
+        // https://loadable-components.com/docs/api-loadable-server/
+        // const bundleLinkTags = extractor.getLinkTags()
 
         scripts.push(
           bundleScriptTags

--- a/src/Artsy/Router/buildServerApp.tsx
+++ b/src/Artsy/Router/buildServerApp.tsx
@@ -38,7 +38,6 @@ export interface ServerAppResolve {
   }
   status?: number
   scripts?: string
-  linkTags?: string[]
   headTags?: any[]
   styleTags?: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,6 +2944,13 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/loadable__component@^5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.10.0.tgz#178fdc401983f4f93647fac778226da7b8c1e080"
+  integrity sha512-AaDP1VxV3p7CdPOtOTl3ALgQ6ES4AxJKO9UGj9vJonq/w2yERxwdzFiWNQFh9fEDXEzjxujBlM2RmSJtHV1/pA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/lodash@4.14.111":
   version "4.14.111"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.111.tgz#d926250baa9526c0ffe85914dd10363068e7893a"


### PR DESCRIPTION
When we added bundle splitting we had a WIP item to figure out how to ensure that the split bundles were loaded once the route transitioned so as to mitigate the split-second white-screen flash. This PR adds a new pattern to address: 

```tsx
const MyApp = loadable(() => import('./MyApp')

const routes = [{
  path: '/path/to/app',
  getComponent: () => MyApp,
  prepare: () => {
    MyApp.preload()
  },
  ... 
}]
```

Whenever routes transition in the new router, `prepare` is called, which in turn calls the `preload` fn added by [loadable-components](https://loadable-components.com/docs/prefetching/). Since data is usually being fetched before the transition, the bundle loads in parallel leading to a stable page once the transition completes. 

#### Before: 

![flash](https://user-images.githubusercontent.com/236943/75523309-9f559380-59c0-11ea-981f-ab925f33ce96.gif)

#### After: 

![noflash](https://user-images.githubusercontent.com/236943/75521193-0c1a5f00-59bc-11ea-9ccb-b0c484821af3.gif)

I need to do one more "add tests" PR to wrap up this work; will address missing coverage there. 