### PR TITLE
[FX-1828] Update typography and spacing in mobile menu

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu.tsx
@@ -8,8 +8,8 @@ import {
   Flex,
   Link,
   MenuIcon,
+  Sans,
   Separator,
-  Serif,
   space,
 } from "@artsy/palette"
 
@@ -44,7 +44,7 @@ export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
   }
 
   return (
-    <MobileNavContainer py={[1, 4]} flexDirection="column" onClick={trackClick}>
+    <MobileNavContainer py={1} flexDirection="column" onClick={trackClick}>
       <MobileLink href="/collect">Artworks</MobileLink>
       <MobileLink href="/auctions">Auctions</MobileLink>
       <MobileLink href="/galleries">Galleries</MobileLink>
@@ -55,7 +55,7 @@ export const MobileNavMenu: React.FC<MobileNavMenuProps> = props => {
       <MobileLink href="/institutions">Museums</MobileLink>
 
       <Box px={2}>
-        <Separator my={[1, 4]} />
+        <Separator my={1} />
       </Box>
 
       {isLoggedIn ? (
@@ -107,10 +107,10 @@ const MobileLink: React.FC<MobileLinkProps> = ({
       <Box px={2} py={[0, 0.5]}>
         {href ? (
           <Link href={href} underlineBehavior="none">
-            <Serif size={["4", "8"]}>{children}</Serif>
+            <Sans size={["5t", "6"]}>{children}</Sans>
           </Link>
         ) : (
-          <Serif size={["4", "8"]}>{children}</Serif>
+          <Sans size={["5t", "6"]}>{children}</Sans>
         )}
       </Box>
     </MobileLinkContainer>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1828

I picked off some of the purely visual work from the [parent ticket](https://artsyproduct.atlassian.net/browse/FX-1702).

The Figma designs include updates to typography (Unica) and spacing (tighter padding overall, and around the horizontal dividers.

Here's what that looks like:

## Before

![before](https://user-images.githubusercontent.com/140521/75565675-5fbc9500-5a1c-11ea-96e0-ddef385c5edb.png)

## After

![after](https://user-images.githubusercontent.com/140521/75565680-61865880-5a1c-11ea-8eb3-1450e8f9d31a.png)
