### PR TITLE
Update yarn orb to track tests via circle again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@4.0.1
+  yarn: artsy/yarn@4.0.2
   codecov: codecov/codecov@1.0.5
   auto: artsy/auto@1.0.1
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ storybook_build
 .yalc
 yalc.lock
 coverage*
+reports*
 2


### PR DESCRIPTION
This upgrades our `yarn` orb to 4.0.2 which contains a change in where we look for jest test results. This _should_ fix our test results tracking so that we can get some performance data about our tests. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.22.2-canary.3215.52969.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.22.2-canary.3215.52969.0
  # or 
  yarn add @artsy/reaction@25.22.2-canary.3215.52969.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
