### PR TITLE
[Search] Visual QA

### DIFF
--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -12,7 +12,7 @@ import { Footer } from "Components/v2/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "Components/v2/RecentlyViewed"
 
 import { RouterState, withRouter } from "found"
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { TrackingProp } from "react-tracking"
 import { get } from "Utils/get"
@@ -26,11 +26,17 @@ export interface Props extends RouterState {
 const TotalResults: React.SFC<{ count: number; term: string }> = ({
   count,
   term,
-}) => (
-  <Serif size="5">
-    {count.toLocaleString()} Result{count > 1 ? "s" : ""} for "{term}"
-  </Serif>
-)
+}) => {
+  const formatResults = () =>
+    `${count.toLocaleString()} Result${count > 1 ? "s" : ""} for "${term}"`
+  const [results, setResults] = useState(formatResults())
+
+  useEffect(() => {
+    setResults(formatResults())
+  }, [count])
+
+  return <Serif size="5">{results}</Serif>
+}
 
 @track({
   context_page: Schema.PageName.SearchPage,

--- a/src/Components/Search/SearchBar.tsx
+++ b/src/Components/Search/SearchBar.tsx
@@ -364,6 +364,17 @@ export class SearchBar extends Component<Props, State> {
         ) {
           event.preventDefault()
         }
+
+        // Clear input after submit
+        if (this.enableExperimentalAppShell) {
+          if (event.key === "Enter") {
+            setTimeout(() => {
+              this.setState({
+                term: "",
+              })
+            })
+          }
+        }
       },
     }
 


### PR DESCRIPTION
Fixes a few visual qa items on search:

In the new app shell when performing a search the query stays in the input, since there's no longer a hard jump between pages to clear it out. Now it clears on enter: 

![input](https://user-images.githubusercontent.com/236943/75603194-2b2ef480-5a81-11ea-8494-8d388ceb1af4.gif)

The search title is a function of url bar state. Now, when transitioning away from the page the url changes and the title updates, but before a full page transition. This ensures that things only update when changed: 

Before: 

![title-before](https://user-images.githubusercontent.com/236943/75603218-4e59a400-5a81-11ea-98a4-b6059e5e932d.gif)

After: 

![title-after](https://user-images.githubusercontent.com/236943/75603220-531e5800-5a81-11ea-9c53-509fbabb107e.gif)
