### PR TITLE
[Artist] Visual QA

### DIFF
--- a/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
+++ b/src/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
@@ -41,7 +41,6 @@ export const ArtistCollectionsRailContent: React.SFC<Props> = passedProps => {
           }
         `}
         render={renderWithLoadProgress(ArtistCollectionsRail, passedProps)}
-        cacheConfig={{ force: true }}
       />
     </Box>
   )

--- a/src/Apps/Collect2/collectRoutes.tsx
+++ b/src/Apps/Collect2/collectRoutes.tsx
@@ -16,7 +16,6 @@ export const collectRoutes: RouteConfig[] = [
     prepare: () => {
       CollectApp.preload()
     },
-    fetchIndicator: "overlay",
     prepareVariables: initializeVariablesWithFilterState,
     query: graphql`
       query collectRoutes_ArtworkFilterQuery(
@@ -81,7 +80,6 @@ export const collectRoutes: RouteConfig[] = [
     prepare: () => {
       CollectionsApp.preload()
     },
-    fetchIndicator: "overlay",
     query: graphql`
       query collectRoutes_MarketingCollectionsAppQuery {
         marketingCategories @principalField {
@@ -97,7 +95,6 @@ export const collectRoutes: RouteConfig[] = [
       CollectionApp.preload()
     },
     prepareVariables: initializeVariablesWithFilterState,
-    fetchIndicator: "overlay",
     query: CollectionAppQuery,
   },
 ]


### PR DESCRIPTION
Noticed that on the artist "Works" tab the layout is unstable due to the collections rail always making a request even though the data has already been fetched, which also applies if there's no rail for a given artist, leading to a loading state to empty content. This fixes both things and ensures a stable layout.

Wondering if there was a deliberate reason for forcing a refetch every time? 

(Note that we have a relay cache expiration of 15 minutes, so unless the collections rail has rapidly changing results we should be ok.) 

### Before: 

![before](https://user-images.githubusercontent.com/236943/75603829-34bb5b00-5a87-11ea-9656-fb5c87ffafe2.gif)

### After: 

![after](https://user-images.githubusercontent.com/236943/75603848-6502f980-5a87-11ea-93ea-4ac5642e2fd1.gif)

