### PR TITLE
Update AB test name to CLIENT_NAVIGATION_V4

### DIFF
--- a/src/Apps/Auction/__tests__/routes.test.ts
+++ b/src/Apps/Auction/__tests__/routes.test.ts
@@ -16,11 +16,11 @@ describe("Auction/routes", () => {
   // FIXME: Remove after A/B test runs
   beforeEach(() => {
     // @ts-ignore
-    window.sd = { CLIENT_NAVIGATION_V3: "experiment" }
+    window.sd = { CLIENT_NAVIGATION_V4: "experiment" }
   })
   beforeEach(() => {
     // @ts-ignore
-    delete window.sd.CLIENT_NAVIGATION_V3
+    delete window.sd.CLIENT_NAVIGATION_V4
   })
 
   async function render(

--- a/src/Apps/Auction/routes.tsx
+++ b/src/Apps/Auction/routes.tsx
@@ -131,7 +131,7 @@ function handleRedirect(redirect: Redirect, location: Location) {
     if (typeof window !== "undefined") {
       // FIXME: Remove after A/B test completes
       // @ts-ignore
-      if (window.sd.CLIENT_NAVIGATION_V3 === "experiment") {
+      if (window.sd.CLIENT_NAVIGATION_V4 === "experiment") {
         // This path will only ever be reached on the client
         // Perform a hard jump to login page as it doesn't exist within router
         if (redirect.path.includes("/log_in?")) {

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -51,7 +51,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             }
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-            if (sd.CLIENT_NAVIGATION_V3 === "experiment") {
+            if (sd.CLIENT_NAVIGATION_V4 === "experiment") {
               if (referrer) {
                 trackingData.referrer = sd.APP_URL + referrer
               }
@@ -71,8 +71,8 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           }
 
           // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-          if (sd.CLIENT_NAVIGATION_V3) {
-            trackExperimentViewed("client_navigation_v3")
+          if (sd.CLIENT_NAVIGATION_V4) {
+            trackExperimentViewed("client_navigation_v4")
           }
 
           // Reset timers that track time on page since we're tracking each order

--- a/typings/sharify.d.ts
+++ b/typings/sharify.d.ts
@@ -20,7 +20,7 @@ declare module "sharify" {
       readonly APP_URL: string
       readonly ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test
       readonly ARTIST_COLLECTIONS_RAIL_IDS: string[]
-      readonly CLIENT_NAVIGATION_V3: "experiment" | "control" // TODO: Remove after A/B test.
+      readonly CLIENT_NAVIGATION_V4: "experiment" | "control" // TODO: Remove after A/B test.
       readonly CMS_URL: string
       readonly ENABLE_PRICE_TRANSPARENCY: string
       readonly ENABLE_REQUEST_CONDITION_REPORT: string


### PR DESCRIPTION
Updates client-side A/B test name from `CLIENT_NAVIGATION_V3` to `CLIENT_NAVIGATION_V4` just so we can be sure that the data is consistent, accounting for a mid-day deploy on Thursday after test was released. 