### PR TITLE
[FX-1758] add a fallback image when there is no headerImage

### DIFF
--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -62,6 +62,7 @@ export class CollectionApp extends Component<CollectionAppProps> {
       slug,
       headerImage,
       description,
+      fallbackHeaderImage,
       artworksConnection,
       descending_artworks,
       ascending_artworks,
@@ -74,13 +75,16 @@ export class CollectionApp extends Component<CollectionAppProps> {
       : `Buy, bid, and inquire on ${title} on Artsy.`
 
     const showCollectionHubs = collection.linkedCollections.length > 0
+
+    const socialImage =
+      headerImage || fallbackHeaderImage?.edges[0]?.node?.image?.resized.url
     return (
       <AppContainer>
         <FrameWithRecentlyViewed>
           <Title>{`${title} - For Sale on Artsy`}</Title>
           <Meta name="description" content={metadataDescription} />
           <Meta property="og:url" content={collectionHref} />
-          <Meta property="og:image" content={headerImage} />
+          <Meta property="og:image" content={socialImage} />
           <Meta property="og:description" content={metadataDescription} />
           <Meta property="twitter:description" content={metadataDescription} />
           <Link rel="canonical" href={collectionHref} />
@@ -193,6 +197,23 @@ export const CollectionRefetchContainer = createRefetchContainer(
         }
         linkedCollections {
           ...CollectionsHubRails_linkedCollections
+        }
+        fallbackHeaderImage: artworksConnection(
+          aggregations: $aggregations
+          includeMediumFilterInAggregation: true
+          size: 1
+          first: 1
+          sort: "-decayed_merch"
+        ) {
+          edges {
+            node {
+              image {
+                resized(width: 600) {
+                  url
+                }
+              }
+            }
+          }
         }
         artworksConnection(
           aggregations: $aggregations

--- a/src/Apps/Collect2/Routes/Collection/index.tsx
+++ b/src/Apps/Collect2/Routes/Collection/index.tsx
@@ -77,7 +77,10 @@ export class CollectionApp extends Component<CollectionAppProps> {
     const showCollectionHubs = collection.linkedCollections.length > 0
 
     const socialImage =
-      headerImage || fallbackHeaderImage?.edges[0]?.node?.image?.resized.url
+      headerImage ||
+      (fallbackHeaderImage?.edges &&
+        fallbackHeaderImage?.edges[0]?.node?.image?.resized.url)
+
     return (
       <AppContainer>
         <FrameWithRecentlyViewed>

--- a/src/__generated__/CollectionAppQuery.graphql.ts
+++ b/src/__generated__/CollectionAppQuery.graphql.ts
@@ -162,6 +162,19 @@ fragment Collection_collection_2Pwt5i on MarketingCollection {
   linkedCollections {
     ...CollectionsHubRails_linkedCollections
   }
+  fallbackHeaderImage: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 1, first: 1, sort: "-decayed_merch") {
+    edges {
+      node {
+        image {
+          resized(width: 600) {
+            url
+          }
+        }
+        id
+      }
+    }
+    id
+  }
   artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: "-decayed_merch") {
     ...Header_artworks
     ...SeoProductsForArtworks_artworks
@@ -835,17 +848,27 @@ v17 = [
 ],
 v18 = {
   "kind": "Literal",
+  "name": "first",
+  "value": 1
+},
+v19 = {
+  "kind": "Literal",
   "name": "includeMediumFilterInAggregation",
   "value": true
 },
-v19 = {
+v20 = {
+  "kind": "Literal",
+  "name": "size",
+  "value": 1
+},
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v20 = [
+v22 = [
   (v16/*: any*/),
   {
     "kind": "ScalarField",
@@ -862,7 +885,7 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v23 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
@@ -875,35 +898,35 @@ v21 = {
   ],
   "storageKey": "url(version:\"larger\")"
 },
-v22 = {
+v24 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "availability",
   "args": null,
   "storageKey": null
 },
-v23 = {
+v25 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v24 = {
+v26 = {
   "kind": "ScalarField",
   "alias": "is_acquireable",
   "name": "isAcquireable",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v27 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v26 = [
+v28 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -912,33 +935,28 @@ v26 = [
     "storageKey": null
   }
 ],
-v27 = [
+v29 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v28 = {
+v30 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v29 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 1
-},
-v30 = {
+v31 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v31 = {
+v32 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "aggregations",
@@ -982,11 +1000,6 @@ v31 = {
     }
   ]
 },
-v32 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 1
-},
 v33 = [
   {
     "kind": "ScalarField",
@@ -1029,7 +1042,7 @@ v34 = [
         "plural": false,
         "selections": [
           (v7/*: any*/),
-          (v22/*: any*/),
+          (v24/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1039,7 +1052,7 @@ v34 = [
             "concreteType": null,
             "plural": false,
             "selections": [
-              (v25/*: any*/),
+              (v27/*: any*/),
               {
                 "kind": "InlineFragment",
                 "type": "PriceRange",
@@ -1390,6 +1403,74 @@ return {
           },
           {
             "kind": "LinkedField",
+            "alias": "fallbackHeaderImage",
+            "name": "artworksConnection",
+            "storageKey": null,
+            "args": [
+              (v2/*: any*/),
+              (v18/*: any*/),
+              (v19/*: any*/),
+              (v20/*: any*/),
+              (v11/*: any*/)
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "resized",
+                            "storageKey": "resized(width:600)",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 600
+                              }
+                            ],
+                            "concreteType": "ResizedImageUrl",
+                            "plural": false,
+                            "selections": (v17/*: any*/)
+                          }
+                        ]
+                      },
+                      (v7/*: any*/)
+                    ]
+                  }
+                ]
+              },
+              (v7/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": null,
             "name": "artworksConnection",
             "storageKey": null,
@@ -1400,7 +1481,7 @@ return {
                 "name": "first",
                 "value": 20
               },
-              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "Literal",
                 "name": "size",
@@ -1429,7 +1510,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v19/*: any*/),
+                      (v21/*: any*/),
                       (v8/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -1454,7 +1535,7 @@ return {
                             ],
                             "concreteType": "ResizedImageUrl",
                             "plural": false,
-                            "selections": (v20/*: any*/)
+                            "selections": (v22/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1470,16 +1551,16 @@ return {
                             ],
                             "concreteType": "ResizedImageUrl",
                             "plural": false,
-                            "selections": (v20/*: any*/)
+                            "selections": (v22/*: any*/)
                           },
-                          (v21/*: any*/)
+                          (v23/*: any*/)
                         ]
                       },
                       (v7/*: any*/),
-                      (v22/*: any*/),
-                      (v4/*: any*/),
-                      (v23/*: any*/),
                       (v24/*: any*/),
+                      (v4/*: any*/),
+                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "is_price_range",
@@ -1496,16 +1577,16 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v25/*: any*/),
+                          (v27/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "type": "PriceRange",
-                            "selections": (v26/*: any*/)
+                            "selections": (v28/*: any*/)
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "Money",
-                            "selections": (v26/*: any*/)
+                            "selections": (v28/*: any*/)
                           }
                         ]
                       },
@@ -1522,7 +1603,7 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v27/*: any*/),
+                        "args": (v29/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": (v14/*: any*/)
@@ -1544,12 +1625,12 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v27/*: any*/),
+                        "args": (v29/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v28/*: any*/),
+                          (v30/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1568,7 +1649,7 @@ return {
                                 "concreteType": "Image",
                                 "plural": false,
                                 "selections": [
-                                  (v21/*: any*/)
+                                  (v23/*: any*/)
                                 ]
                               },
                               (v7/*: any*/)
@@ -1580,7 +1661,7 @@ return {
                             "name": "locations",
                             "storageKey": "locations(size:1)",
                             "args": [
-                              (v29/*: any*/)
+                              (v20/*: any*/)
                             ],
                             "concreteType": "Location",
                             "plural": true,
@@ -1654,7 +1735,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v8/*: any*/),
-                  (v30/*: any*/),
+                  (v31/*: any*/),
                   (v13/*: any*/),
                   {
                     "kind": "LinkedField",
@@ -1735,7 +1816,7 @@ return {
                   }
                 ]
               },
-              (v31/*: any*/),
+              (v32/*: any*/),
               (v7/*: any*/)
             ]
           },
@@ -1746,9 +1827,9 @@ return {
             "storageKey": null,
             "args": [
               (v2/*: any*/),
-              (v32/*: any*/),
               (v18/*: any*/),
-              (v29/*: any*/),
+              (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1766,9 +1847,9 @@ return {
             "storageKey": null,
             "args": [
               (v2/*: any*/),
-              (v32/*: any*/),
               (v18/*: any*/),
-              (v29/*: any*/),
+              (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1789,7 +1870,7 @@ return {
             "plural": false,
             "selections": [
               (v7/*: any*/),
-              (v31/*: any*/),
+              (v32/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1889,7 +1970,7 @@ return {
                     "selections": [
                       (v7/*: any*/),
                       (v8/*: any*/),
-                      (v19/*: any*/),
+                      (v21/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1928,7 +2009,7 @@ return {
                           }
                         ]
                       },
-                      (v30/*: any*/),
+                      (v31/*: any*/),
                       (v9/*: any*/),
                       {
                         "kind": "ScalarField",
@@ -1937,7 +2018,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v23/*: any*/),
+                      (v25/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "sale_message",
@@ -1957,12 +2038,12 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v27/*: any*/),
+                        "args": (v29/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
                           (v7/*: any*/),
-                          (v19/*: any*/),
+                          (v21/*: any*/),
                           (v13/*: any*/)
                         ]
                       },
@@ -1978,14 +2059,14 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v27/*: any*/),
+                        "args": (v29/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v19/*: any*/),
+                          (v21/*: any*/),
                           (v7/*: any*/),
-                          (v28/*: any*/)
+                          (v30/*: any*/)
                         ]
                       },
                       {
@@ -2077,7 +2158,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v26/*: any*/)
+                            "selections": (v28/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -2087,7 +2168,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v26/*: any*/)
+                            "selections": (v28/*: any*/)
                           },
                           (v7/*: any*/)
                         ]
@@ -2113,7 +2194,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v24/*: any*/),
+                      (v26/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "is_offerable",
@@ -2136,7 +2217,7 @@ return {
     "operationKind": "query",
     "name": "CollectionAppQuery",
     "id": null,
-    "text": "query CollectionAppQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections(size: 16) {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    image {\n      resized(width: 45, height: 45, version: \"square\") {\n        url\n      }\n    }\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query CollectionAppQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MERCHANDISABLE_ARTISTS, MEDIUM, MAJOR_PERIOD, TOTAL]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $priceRange: String\n  $sort: String\n  $slug: String!\n  $width: String\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2Pwt5i\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2Pwt5i on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections(size: 16) {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  fallbackHeaderImage: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 1, first: 1, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        image {\n          resized(width: 600) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, priceRange: $priceRange, first: 30, sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      href\n      slug\n      image {\n        small: resized(height: 160) {\n          url\n          width\n          height\n        }\n        large: resized(height: 220) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    image {\n      resized(width: 45, height: 45, version: \"square\") {\n        url\n      }\n    }\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Collection_collection.graphql.ts
+++ b/src/__generated__/Collection_collection.graphql.ts
@@ -18,6 +18,17 @@ export type Collection_collection = {
     readonly linkedCollections: ReadonlyArray<{
         readonly " $fragmentRefs": FragmentRefs<"CollectionsHubRails_linkedCollections">;
     }>;
+    readonly fallbackHeaderImage: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly image: {
+                    readonly resized: {
+                        readonly url: string | null;
+                    } | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly artworksConnection: {
         readonly aggregations: ReadonlyArray<{
             readonly slice: ArtworkAggregation | null;
@@ -58,18 +69,23 @@ var v0 = {
 },
 v1 = {
   "kind": "Literal",
-  "name": "includeMediumFilterInAggregation",
-  "value": true
+  "name": "first",
+  "value": 1
 },
 v2 = {
   "kind": "Literal",
-  "name": "first",
-  "value": 1
+  "name": "includeMediumFilterInAggregation",
+  "value": true
 },
 v3 = {
   "kind": "Literal",
   "name": "size",
   "value": 1
+},
+v4 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-decayed_merch"
 };
 return {
   "kind": "Fragment",
@@ -262,6 +278,80 @@ return {
     },
     {
       "kind": "LinkedField",
+      "alias": "fallbackHeaderImage",
+      "name": "artworksConnection",
+      "storageKey": null,
+      "args": [
+        (v0/*: any*/),
+        (v1/*: any*/),
+        (v2/*: any*/),
+        (v3/*: any*/),
+        (v4/*: any*/)
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "image",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "resized",
+                      "storageKey": "resized(width:600)",
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 600
+                        }
+                      ],
+                      "concreteType": "ResizedImageUrl",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "url",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
       "alias": null,
       "name": "artworksConnection",
       "storageKey": null,
@@ -272,17 +362,13 @@ return {
           "name": "first",
           "value": 20
         },
-        (v1/*: any*/),
+        (v2/*: any*/),
         {
           "kind": "Literal",
           "name": "size",
           "value": 20
         },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "-decayed_merch"
-        }
+        (v4/*: any*/)
       ],
       "concreteType": "FilterArtworksConnection",
       "plural": false,
@@ -356,8 +442,8 @@ return {
       "storageKey": null,
       "args": [
         (v0/*: any*/),
-        (v2/*: any*/),
         (v1/*: any*/),
+        (v2/*: any*/),
         (v3/*: any*/),
         {
           "kind": "Literal",
@@ -382,8 +468,8 @@ return {
       "storageKey": null,
       "args": [
         (v0/*: any*/),
-        (v2/*: any*/),
         (v1/*: any*/),
+        (v2/*: any*/),
         (v3/*: any*/),
         {
           "kind": "Literal",
@@ -504,5 +590,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'd3be9cd0f40b6d2577a580344d0f2713';
+(node as any).hash = '3c621efaa9767196511102dded3f9f2d';
 export default node;


### PR DESCRIPTION
Addresses: [FX-1758](https://artsyproduct.atlassian.net/browse/FX-1758)

**Problem:**
When links for collection pages are shared on social media the display appears with a small photo. This is because for most collection pages we don't have a header image and the meta data for the image gets pulled from the images in the artwork grid.

**Fix:**
This PR introduces a new fallback image that is a larger, resized version of the first image in the artwork grid. The logic checks for the headerImage first and if it's not present uses the resized image.