### PR TITLE
Revert "Only lint changed files"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,7 @@ workflows:
       - yarn/relay:
           requires:
             - yarn/workflow-queue
-      - yarn/run:
-          name: lint-changed
-          script: lint-changed
+      - yarn/lint:
           requires:
             - yarn/workflow-queue
       - yarn/type-check:
@@ -39,7 +37,7 @@ workflows:
           requires:
             - yarn/jest
             - yarn/relay
-            - lint-changed
+            - yarn/lint
             - yarn/type-check
             - yarn/update-cache
       - auto/publish:
@@ -51,6 +49,6 @@ workflows:
           requires:
             - yarn/jest
             - yarn/relay
-            - lint-changed
+            - yarn/lint
             - yarn/type-check
             - yarn/update-cache

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.2",
-    "@artsy/lint-changed": "^2.0.0",
     "@artsy/palette": "7.1.1",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.7.2",
@@ -295,15 +294,6 @@
     ],
     "*.json": [
       "yarn prettier-write --"
-    ]
-  },
-  "lint-changed": {
-    "*.@(ts|tsx)": [
-      "tslint -c tslint.json",
-      "yarn prettier -c"
-    ],
-    "*.json": [
-      "yarn prettier -c"
     ]
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,16 +17,6 @@
   resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-1.0.13.tgz#4bbbda274e74e0d63b471a36d72360d33d571598"
   integrity sha512-Gg/43i30aIqkryVE6eLhNe4j9G1fk41qIJqYfj/b+mv3bYCl8H9HSaedcM7exuh0RlexZGLMD2aYnugiobrpxQ==
 
-"@artsy/lint-changed@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/lint-changed/-/lint-changed-2.0.0.tgz#55b8536dc117f086c6cb74e49fd732844539af1c"
-  integrity sha512-ZHvm4g0dAy/51gyJrX43xs7FpvGRAeIQNc+/DFCMODtYtnwe4g3GS/TzAaQB+pWeSEm3+J7oAUfLVwFqURb6kA==
-  dependencies:
-    await-to-js "^2.1.1"
-    kleur "^3.0.3"
-    micromatch "^4.0.2"
-    p-each-series "^2.1.0"
-
 "@artsy/palette@7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-7.1.1.tgz#22a4088ddf4d0efe0af97aac40ecca849450b70c"
@@ -3876,11 +3866,6 @@ autosuggest-highlight@^3.1.1:
   dependencies:
     diacritic "0.0.2"
 
-await-to-js@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/await-to-js/-/await-to-js-2.1.1.tgz#c2093cd5a386f2bb945d79b292817bbc3f41b31b"
-  integrity sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -4618,7 +4603,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@^3.0.2:
+braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -10003,7 +9988,7 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-kleur@^3.0.2, kleur@^3.0.3:
+kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
@@ -10754,14 +10739,6 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
-
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -11625,11 +11602,6 @@ p-each-series@^1.0.0:
   dependencies:
     p-reduce "^1.0.0"
 
-p-each-series@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
-  integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -11946,11 +11918,6 @@ picomatch@^2.0.4:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
-
-picomatch@^2.0.5:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
-  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Reverts artsy/reaction#3220

cc @eessex going to revert until I can dig in further. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.24.3-canary.3228.53249.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.24.3-canary.3228.53249.0
  # or 
  yarn add @artsy/reaction@25.24.3-canary.3228.53249.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
