### PR TITLE
Add attribute to body when app is ready to be tested

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -30,9 +30,7 @@ export const AppShell = props => {
    * Let our end-to-end tests know that the app is hydrated and ready to go
    */
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      document.body.setAttribute("data-test-ready", "")
-    }
+    document.body.setAttribute("data-test-ready", "")
   }, [])
 
   return (

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -26,6 +26,15 @@ export const AppShell = props => {
     }
   }, [routeConfig])
 
+  /**
+   * Let our end-to-end tests know that the app is hydrated and ready to go
+   */
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      document.body.setAttribute("data-test-ready", "")
+    }
+  }, [])
+
   return (
     <Box width="100%">
       <Box pb={6}>


### PR DESCRIPTION
This adds a mechanism to tell cypress that we're ready to start testing. This is a mechanism we can use to avoid timing issues w/ rehydration. 

It will need to be followed up with an integrity update to check for this after page visits. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.25.0-canary.3233.53368.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.25.0-canary.3233.53368.0
  # or 
  yarn add @artsy/reaction@25.25.0-canary.3233.53368.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
