### PR TITLE
Adds hooks to login modals for integration tests

### DIFF
--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -60,7 +60,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
           }
 
           return (
-            <Form onSubmit={handleSubmit}>
+            <Form onSubmit={handleSubmit} data-test-login-form>
               <QuickInput
                 block
                 error={touched.email && errors.email}

--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -60,7 +60,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
           }
 
           return (
-            <Form onSubmit={handleSubmit} data-test-login-form>
+            <Form onSubmit={handleSubmit} data-test="LoginForm">
               <QuickInput
                 block
                 error={touched.email && errors.email}

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -128,7 +128,7 @@ class MobileLoginFormWithSystemContext extends Component<
           const { currentStep, isLastStep } = wizard
 
           return (
-            <MobileContainer>
+            <MobileContainer data-test-login-form>
               <ProgressIndicator percentComplete={wizard.progressPercentage} />
               <MobileInnerWrapper>
                 <BackButton

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -128,7 +128,7 @@ class MobileLoginFormWithSystemContext extends Component<
           const { currentStep, isLastStep } = wizard
 
           return (
-            <MobileContainer data-test-login-form>
+            <MobileContainer data-test="LoginForm">
               <ProgressIndicator percentComplete={wizard.progressPercentage} />
               <MobileInnerWrapper>
                 <BackButton


### PR DESCRIPTION
This adds hooks to our auth modals for more reliable detection during integration testing. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.25.0-canary.3234.53369.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.25.0-canary.3234.53369.0
  # or 
  yarn add @artsy/reaction@25.25.0-canary.3234.53369.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
