### PR TITLE
Update attribute to follow pre-established testing patterns

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -30,7 +30,7 @@ export const AppShell = props => {
    * Let our end-to-end tests know that the app is hydrated and ready to go
    */
   useEffect(() => {
-    document.body.setAttribute("data-test-ready", "")
+    document.body.setAttribute("data-test", "AppReady")
   }, [])
 
   return (


### PR DESCRIPTION
Fixes something I [forgot to commit](https://github.com/artsy/reaction/pull/3233/files#r388025165) earlier. 

Essentially when we're writing tests with crypress we have a pattern of adding attributes like `data-test="SomeThing"` whereas I have historically (in past jobs) just added boolean attributes like `data-test-some-thing`. 

This updates the selector to follow our established conventions.  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.26.1-canary.3236.53413.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.26.1-canary.3236.53413.0
  # or 
  yarn add @artsy/reaction@25.26.1-canary.3236.53413.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
