### PR TITLE
[Clientside Nav] Add <NetworkTimeout /> & <NetworkOfflineMonitor /> components

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,13 +1,20 @@
 import { Box } from "@artsy/palette"
+import { NetworkOfflineMonitor } from "Artsy/Router/NetworkOfflineMonitor"
 import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { NavBar } from "Components/NavBar"
+import { Match } from "found"
 import { isFunction } from "lodash"
 import React, { useEffect } from "react"
 import createLogger from "Utils/logger"
 
 const logger = createLogger("Apps/Components/AppShell")
 
-export const AppShell = props => {
+interface AppShellProps {
+  children: React.ReactNode
+  match: Match
+}
+
+export const AppShell: React.FC<AppShellProps> = props => {
   const { children, match } = props
   const routeConfig = findCurrentRoute(match)
 
@@ -44,6 +51,8 @@ export const AppShell = props => {
       <Box>
         <Box>{children}</Box>
       </Box>
+
+      <NetworkOfflineMonitor />
     </Box>
   )
 }

--- a/src/Artsy/Router/NetworkOfflineMonitor.tsx
+++ b/src/Artsy/Router/NetworkOfflineMonitor.tsx
@@ -1,14 +1,15 @@
-import { ModalDialog } from "Components/Modal/ModalDialog"
+import { Banner, Box } from "@artsy/palette"
+import { debounce } from "lodash"
 import React, { useEffect, useState } from "react"
 
 export const NetworkOfflineMonitor: React.FC = () => {
   const [showOfflineModal, toggleOfflineModal] = useState(false)
 
   const setOffline = () => {
-    toggleOfflineModal(true)
+    debounce(() => toggleOfflineModal(true), 100)
   }
   const setOnline = () => {
-    toggleOfflineModal(false)
+    debounce(() => toggleOfflineModal(false), 100)
   }
 
   useEffect(() => {
@@ -26,13 +27,12 @@ export const NetworkOfflineMonitor: React.FC = () => {
   }
 
   return (
-    <ModalDialog
-      show={showOfflineModal}
-      heading="Your network is offline"
-      primaryCta={{
-        text: "Dismiss",
-        action: () => setOnline(),
-      }}
-    />
+    <Box position="fixed" top={58} width="100%" style={{ opacity: 0.9 }}>
+      <Banner
+        backgroundColor="black10"
+        textColor="black100"
+        message="Network offline"
+      />
+    </Box>
   )
 }

--- a/src/Artsy/Router/NetworkOfflineMonitor.tsx
+++ b/src/Artsy/Router/NetworkOfflineMonitor.tsx
@@ -1,0 +1,38 @@
+import { ModalDialog } from "Components/Modal/ModalDialog"
+import React, { useEffect, useState } from "react"
+
+export const NetworkOfflineMonitor: React.FC = () => {
+  const [showOfflineModal, toggleOfflineModal] = useState(false)
+
+  const setOffline = () => {
+    toggleOfflineModal(true)
+  }
+  const setOnline = () => {
+    toggleOfflineModal(false)
+  }
+
+  useEffect(() => {
+    window.addEventListener("offline", setOffline)
+    window.addEventListener("online", setOnline)
+
+    return () => {
+      window.removeEventListener("offline", setOffline)
+      window.removeEventListener("online", setOnline)
+    }
+  }, [])
+
+  if (!showOfflineModal) {
+    return null
+  }
+
+  return (
+    <ModalDialog
+      show={showOfflineModal}
+      heading="Your network is offline"
+      primaryCta={{
+        text: "Dismiss",
+        action: () => setOnline(),
+      }}
+    />
+  )
+}

--- a/src/Artsy/Router/NetworkTimeout.tsx
+++ b/src/Artsy/Router/NetworkTimeout.tsx
@@ -1,30 +1,30 @@
 import { ErrorModal } from "Components/Modal/ErrorModal"
 import React, { useEffect, useState } from "react"
 
-const RENDER_TIMEOUT = 12000
+const NETWORK_TIMEOUT_MS = 10000
 
 export const NetworkTimeout: React.FC = () => {
-  const [showModal, setShowModal] = useState(false)
+  const [showErrorModal, toggleErrorModal] = useState(false)
 
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (!showModal) {
-        setShowModal(true)
+      if (!showErrorModal) {
+        toggleErrorModal(true)
       }
-    }, RENDER_TIMEOUT)
+    }, NETWORK_TIMEOUT_MS)
 
     return () => {
       clearTimeout(timeout)
     }
   }, [])
 
-  if (!showModal) {
+  if (!showErrorModal) {
     return null
   }
 
   return (
     <ErrorModal
-      show={showModal}
+      show={showErrorModal}
       closeText="Retry"
       ctaAction={() => {
         location.reload()

--- a/src/Artsy/Router/NetworkTimeout.tsx
+++ b/src/Artsy/Router/NetworkTimeout.tsx
@@ -1,0 +1,34 @@
+import { ErrorModal } from "Components/Modal/ErrorModal"
+import React, { useEffect, useState } from "react"
+
+const RENDER_TIMEOUT = 12000
+
+export const NetworkTimeout: React.FC = () => {
+  const [showModal, setShowModal] = useState(false)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (!showModal) {
+        setShowModal(true)
+      }
+    }, RENDER_TIMEOUT)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [])
+
+  if (!showModal) {
+    return null
+  }
+
+  return (
+    <ErrorModal
+      show={showModal}
+      closeText="Retry"
+      ctaAction={() => {
+        location.reload()
+      }}
+    />
+  )
+}

--- a/src/Artsy/Router/NetworkTimeout.tsx
+++ b/src/Artsy/Router/NetworkTimeout.tsx
@@ -1,5 +1,9 @@
 import { ErrorModal } from "Components/Modal/ErrorModal"
 import React, { useEffect, useState } from "react"
+import { ErrorWithMetadata } from "Utils/errors"
+import createLogger from "Utils/logger"
+
+const logger = createLogger("Artsy/Router/NetworkTimeout")
 
 const NETWORK_TIMEOUT_MS = 10000
 
@@ -9,6 +13,11 @@ export const NetworkTimeout: React.FC = () => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (!showErrorModal) {
+        logger.error(
+          new ErrorWithMetadata(
+            `[Router/NetworkTimeout] Error: Network request timed out after ${NETWORK_TIMEOUT_MS}ms`
+          )
+        )
         toggleErrorModal(true)
       }
     }, NETWORK_TIMEOUT_MS)

--- a/src/Artsy/Router/RenderStatus.tsx
+++ b/src/Artsy/Router/RenderStatus.tsx
@@ -8,6 +8,7 @@ import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
 import { Media } from "Utils/Responsive"
+import { NetworkTimeout } from "./NetworkTimeout"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
@@ -70,6 +71,8 @@ export const RenderPending = () => {
             }}
           />
         </Media>
+
+        <NetworkTimeout />
       </>
     )
   } else {

--- a/src/Artsy/Router/buildAppRoutes.tsx
+++ b/src/Artsy/Router/buildAppRoutes.tsx
@@ -1,4 +1,4 @@
-import { RouteConfig, Router, withRouter } from "found"
+import { Match, RouteConfig, Router, withRouter } from "found"
 import { flatten } from "lodash"
 import React, { useEffect } from "react"
 
@@ -19,6 +19,8 @@ export function buildAppRoutes(routeList: RouteList[]): RouteConfig[] {
   const routes = getActiveRoutes(routeList)
 
   const Component: React.FC<{
+    children: React.ReactNode
+    match: Match
     router: Router
   }> = props => {
     const { router, setRouter } = useSystemContext()


### PR DESCRIPTION
Addresses 
- https://artsyproduct.atlassian.net/browse/PLATFORM-2283
- https://artsyproduct.atlassian.net/browse/PLATFORM-2284

### `<NetworkTimeout />`
This adds a new component to our routing framework that will appear if a request is taking longer than 10 seconds, showing our standard ErrorDialog component and prompting the user to retry, which will reload the page. 

![alert](https://user-images.githubusercontent.com/236943/76054898-fca09600-5f26-11ea-83a1-6ba59b9bd8af.gif)

--- 

### `<NetworkOfflineMonitor />`

Also added a `NetworkOfflineMonitor` component that will check if the network is offline, and shows a Banner alerting the user: 

![offline](https://user-images.githubusercontent.com/236943/76594621-df377300-64b6-11ea-9f05-1acac30d8409.gif)


(Can test this via chrome dev tools.) 