### PR TITLE
Move conversations behind lab feature flag

### DIFF
--- a/src/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/Components/NavBar/Menus/UserMenu.tsx
@@ -16,7 +16,7 @@ import {
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { data as sd } from "sharify"
-import { userIsAdmin } from "Utils/user"
+import { userHasLabFeature, userIsAdmin } from "Utils/user"
 import * as authentication from "../Utils/authentication"
 
 export const UserMenu: React.FC = () => {
@@ -57,7 +57,7 @@ export const UserMenu: React.FC = () => {
           <TagIcon mr={1} /> Purchases
         </MenuItem>
       )}
-      {isAdmin && (
+      {userHasLabFeature(user, "User Conversations View") && (
         <MenuItem href="/user/conversations">
           <TagIcon mr={1} /> Inquiries
         </MenuItem>

--- a/src/Components/NavBar/Menus/__tests__/UserMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/UserMenu.test.tsx
@@ -60,6 +60,22 @@ describe("UserMenu", () => {
     expect(authentication.logout).toHaveBeenCalledWith(mediator)
   })
 
+  describe("lab features", () => {
+    it("hides inquiries button if lab feature not enabled", () => {
+      const wrapper = getWrapper({
+        user: { type: "NotAdmin", lab_features: [] },
+      })
+      expect(wrapper.html()).not.toContain("Inquiries")
+    })
+
+    it("shows inquiries button if lab feature enabled", () => {
+      const wrapper = getWrapper({
+        user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
+      })
+      expect(wrapper.html()).toContain("Inquiries")
+    })
+  })
+
   describe("admin features", () => {
     it("hides admin button if not admin", () => {
       const wrapper = getWrapper({ user: { type: "NotAdmin" } })
@@ -79,16 +95,6 @@ describe("UserMenu", () => {
     it("shows purchases button if admin", () => {
       const wrapper = getWrapper({ user: { type: "Admin" } })
       expect(wrapper.html()).toContain("Purchases")
-    })
-
-    it("hides inquiries button if not admin", () => {
-      const wrapper = getWrapper({ user: { type: "NotAdmin" } })
-      expect(wrapper.html()).not.toContain("Inquiries")
-    })
-
-    it("shows inquiries button if admin", () => {
-      const wrapper = getWrapper({ user: { type: "Admin" } })
-      expect(wrapper.html()).toContain("Inquiries")
     })
 
     it("shows CMS button if admin", () => {


### PR DESCRIPTION
Fixes [PURCHASE-1820](https://artsyproduct.atlassian.net/browse/PURCHASE-1820)

This changes conversations from being available to admins to being behind a lab feature flag. This is necessary to test because it's somewhat impossible to submit an inquiry as an admin. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.27.0-canary.3241.53560.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.27.0-canary.3241.53560.0
  # or 
  yarn add @artsy/reaction@25.27.0-canary.3241.53560.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
