### PR TITLE
[Carousel] Remove error boundary

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -1,5 +1,4 @@
 import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
-import { ErrorBoundary } from "Components/ErrorBoundary"
 import React, { Fragment } from "react"
 import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
@@ -391,51 +390,32 @@ export class BaseCarousel extends React.Component<
     }
 
     return (
-      <ErrorBoundary
-        onCatch={() => {
-          /**
-           * If an error occurs when mounting / unmounting flickity, reload page.
-           *
-           * FIXME: Figure out how to diagnose `Failed to execute ‘removeChild’
-           * on ‘Node’: The node to be removed is not a child of this node.` error
-           *
-           * NOTE: To hack-fix error, apply a random `key={Math.random()} on
-           * offending container, or ensure component isn't rerendering needlessly.
-           */
-          console.warn(
-            "------------------ RELOAD carousel",
-            window.location.href
-          )
-          window.location.reload()
-        }}
+      <Flex
+        flexDirection="row"
+        position="relative"
+        justifyContent="space-around"
+        alignItems="center"
+        height={height}
       >
-        <Flex
-          flexDirection="row"
-          position="relative"
-          justifyContent="space-around"
-          alignItems="center"
-          height={height}
-        >
-          {this.renderLeftArrow()}
+        {this.renderLeftArrow()}
 
-          <CarouselContainer height={height} isMounted={isMounted}>
-            <FlickityCarousel
-              isMounted={isMounted}
-              ref={c => (this.carouselRef = c)}
-            >
-              {carouselImages.map((slide, slideIndex) => {
-                return (
-                  <Fragment key={slideIndex}>
-                    {render(slide, slideIndex)}
-                  </Fragment>
-                )
-              })}
-            </FlickityCarousel>
-          </CarouselContainer>
+        <CarouselContainer height={height} isMounted={isMounted}>
+          <FlickityCarousel
+            isMounted={isMounted}
+            ref={c => (this.carouselRef = c)}
+          >
+            {carouselImages.map((slide, slideIndex) => {
+              return (
+                <Fragment key={slideIndex}>
+                  {render(slide, slideIndex)}
+                </Fragment>
+              )
+            })}
+          </FlickityCarousel>
+        </CarouselContainer>
 
-          {this.renderRightArrow()}
-        </Flex>
-      </ErrorBoundary>
+        {this.renderRightArrow()}
+      </Flex>
     )
   }
 }


### PR DESCRIPTION
@sweir27 - caught a reload bug issue, which I tracked down [to here](https://sentry.io/organizations/artsynet/issues/1514677136/?project=28316&query=is%3Aunresolved+flickity&sort=freq&statsPeriod=14d). 

In a super alpha version of the shell I noticed an issue with flickity, and to be safe I added this guard that was never removed, and I haven't seen the issue reappear in many months. However, when some bad MP data came through to the carousel, it would catch in the error boundary and trigger a reload, versus failing back to error page which we now have in place. 

https://github.com/artsy/reaction/pull/3208 fixed the data issue. 

