### PR TITLE
Replace getENV with sd for now

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -9,8 +9,8 @@ import {
 import { ArtworkDetailsAdditionalInfo_artwork } from "__generated__/ArtworkDetailsAdditionalInfo_artwork.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { data as sd } from "sharify"
 
-import { getENV } from "Utils/getENV"
 import { RequestConditionReportQueryRenderer } from "./RequestConditionReport"
 
 export interface ArtworkDetailsAdditionalInfoProps {
@@ -44,7 +44,7 @@ export class ArtworkDetailsAdditionalInfo extends React.Component<
         title: "Condition",
         value:
           canRequestLotConditionsReport &&
-          getENV("ENABLE_REQUEST_CONDITION_REPORT") ? (
+          sd.ENABLE_REQUEST_CONDITION_REPORT ? (
             <RequestConditionReportQueryRenderer artworkID={internalID} />
           ) : (
             conditionDescription && conditionDescription.details


### PR DESCRIPTION
`sd` is a bit smarter than `getENV` since it converts `'false'` (the string) to `false` (the boolean.) Because this was only checking the presence of the value, the string value `'false'` was always evaluating to truthy regardless of what is set to it, causing the lot condition report feature to always be on for every sale.