### PR TITLE
Make hide grids function a bit safer

### DIFF
--- a/src/Apps/Artwork/Components/OtherWorks/index.tsx
+++ b/src/Apps/Artwork/Components/OtherWorks/index.tsx
@@ -20,7 +20,7 @@ export interface OtherWorksContextProps {
  * Check to see if a connection's edges have a length; if false hide the grid.
  */
 export function hideGrid(artworksConnection): boolean {
-  return Boolean(get(artworksConnection, p => !p.edges.length))
+  return Boolean(get(artworksConnection, p => !p?.edges.length))
 }
 
 const populatedGrids = (grids: OtherWorks_artwork["contextGrids"]) => {


### PR DESCRIPTION
Noticed there was an elastic search data issue at https://staging.artsy.net/artwork/chip-hughes-untitled and digging in, saw that we could add a bit more safety. See [this thread](https://artsy.slack.com/archives/C9YNS4X32/p1583767239172700).

Also noticed here that this revealed a bug in the `get` function itself -- if the initial object being passed in is null, then it will still error out, versus being safe all the way through the chain. (Right now, any _subsequent_ properties can be null / undefined). Either way, we can now use optional chaining so get is no longer nececessary. 