### PR TITLE
[Bugfix] => Make `SEOProductsForCollections` safer

### DIFF
--- a/src/Apps/Collect2/Components/SeoProductsForCollections.tsx
+++ b/src/Apps/Collect2/Components/SeoProductsForCollections.tsx
@@ -18,10 +18,10 @@ export const getMaxMinPrice = (
   ascending_artworks: SeoProductsForCollections_ascending_artworks
 ) => {
   const leastExpensive = getPriceRange(
-    ascending_artworks.edges[0].node.listPrice
+    ascending_artworks.edges[0]?.node?.listPrice
   )
   const mostExpensive = getPriceRange(
-    descending_artworks.edges[0].node.listPrice
+    descending_artworks.edges[0]?.node?.listPrice
   )
 
   return {
@@ -33,7 +33,9 @@ export const getMaxMinPrice = (
 const getPriceRange = (
   listPrice: SeoProductsForCollections_ascending_artworks["edges"][0]["node"]["listPrice"]
 ) => {
-  if (!listPrice) return { min: undefined, max: undefined }
+  if (!listPrice) {
+    return { min: undefined, max: undefined }
+  }
 
   switch (listPrice.__typename) {
     case "PriceRange":


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/1529814294/?project=28316&query=is%3Aunresolved&statsPeriod=24h

See https://www.artsy.net/collection/faile-posters for error. 

Saw that there was unsafe object access; updated with optional chaining to make a bit safer. 