### PR TITLE
Type openAuthModal helpers

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -140,6 +140,7 @@ const RecommendedArtist: FC<RecommendedArtistProps & {
 
 const ArrowContainer = styled(Box)`
   align-self: flex-start;
+
   ${ArrowButton} {
     height: 60%;
   }

--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -132,7 +132,7 @@ export class SaveButton extends React.Component<SaveProps, SaveState> {
       openAuthModal(this.props.mediator, {
         contextModule: Schema.ContextModule.ArtworkPage,
         entity: {
-          id: this.props.artwork.id,
+          id: this.props.artwork.slug,
           name: this.props.artwork.title,
         },
         intent: AuthModalIntent.SaveArtwork,

--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -132,7 +132,7 @@ export class SaveButton extends React.Component<SaveProps, SaveState> {
       openAuthModal(this.props.mediator, {
         contextModule: Schema.ContextModule.ArtworkPage,
         entity: {
-          id: this.props.artwork.slug,
+          slug: this.props.artwork.slug,
           name: this.props.artwork.title,
         },
         intent: AuthModalIntent.SaveArtwork,

--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -12,6 +12,7 @@ import { MobileForgotPasswordForm } from "Components/Authentication/Mobile/Forgo
 import { MobileLoginForm } from "Components/Authentication/Mobile/LoginForm"
 import { MobileSignUpForm } from "Components/Authentication/Mobile/SignUpForm"
 import {
+  AfterSignUpAction,
   FormComponentType,
   InputValues,
   ModalOptions,
@@ -66,6 +67,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
         destination,
         redirectTo,
         intent,
+        title,
         trigger,
         triggerSeconds,
       },
@@ -79,7 +81,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
         action: "Auth impression",
         type,
         context_module: contextModule,
-        modal_copy: copy,
+        modal_copy: copy || title,
         trigger: trigger || "click",
         trigger_seconds: triggerSeconds,
         intent,
@@ -119,6 +121,17 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
     }
   }
 
+  getAfterSignupAction = (options: ModalOptions): AfterSignUpAction => {
+    const { afterSignUpAction, action, kind, objectId } = options
+    return (
+      afterSignUpAction || {
+        action,
+        kind,
+        objectId,
+      }
+    )
+  }
+
   render() {
     const {
       error,
@@ -135,10 +148,11 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
         accepted_terms_of_service: true,
         agreed_to_receive_emails: true,
         "signup-referer": options.signupReferer,
+        afterSignUpAction: this.getAfterSignupAction(options),
       },
-      options.redirectTo
+      options.redirectTo || options["redirect-to"]
         ? {
-            "redirect-to": options.redirectTo,
+            "redirect-to": options.redirectTo || options["redirect-to"],
           }
         : null,
       options.intent

--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -36,7 +36,7 @@ export interface FormProps {
   showRecaptchaDisclaimer?: boolean
 }
 
-interface AfterSignUpAction {
+export interface AfterSignUpAction {
   action: "save" | "follow" | "editorialSignup"
   objectId?: string
   kind?: "artist" | "artworks" | "gene" | "profile" | "show"
@@ -99,6 +99,21 @@ export interface ModalOptions {
    * The image rendered with the modal
    */
   image?: string
+  /**
+   * MOBILE ONLY
+   * Used to construct afterSignupAction from query params
+   */
+  kind?: AfterSignUpAction["kind"]
+  /**
+   * MOBILE ONLY
+   * Used to construct afterSignupAction from query params
+   */
+  action?: AfterSignUpAction["action"]
+  /**
+   * MOBILE ONLY
+   * Used to construct afterSignupAction from query params
+   */
+  objectId?: AfterSignUpAction["objectId"]
 }
 
 export type FormComponentType =

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -11,6 +11,7 @@ import { FollowButton } from "./Button"
 import { FollowButtonDeprecated } from "./ButtonDeprecated"
 import { FollowTrackingData } from "./Typings"
 
+import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import {
   commitMutation,
   createFragmentContainer,
@@ -25,7 +26,7 @@ interface Props
   artist?: FollowArtistButton_artist
   tracking?: TrackingProp
   trackingData?: FollowTrackingData
-  onOpenAuthModal?: (type: "register" | "login", config?: object) => void
+  onOpenAuthModal?: (type: ModalType, config?: ModalOptions) => void
 
   /**
    * FIXME: Default is true due to legacy code. If false, use new @artsy/palette
@@ -86,7 +87,7 @@ export class FollowArtistButton extends React.Component<Props, State> {
         intent: "follow artist",
         copy: "Sign up to follow artists",
       }
-      onOpenAuthModal("register", config)
+      onOpenAuthModal(ModalType.signup, config)
     }
   }
 

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -1,5 +1,6 @@
 import { FollowGeneButtonMutation } from "__generated__/FollowGeneButtonMutation.graphql"
 import * as Artsy from "Artsy"
+import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import { extend } from "lodash"
 import React from "react"
 import {
@@ -20,7 +21,7 @@ interface Props
   gene?: FollowGeneButton_gene
   tracking?: TrackingProp
   trackingData?: FollowTrackingData
-  onOpenAuthModal?: (type: "register" | "login", config?: object) => void
+  onOpenAuthModal?: (type: ModalType, config?: ModalOptions) => void
 }
 
 export class FollowGeneButton extends React.Component<Props> {
@@ -67,7 +68,7 @@ export class FollowGeneButton extends React.Component<Props> {
       this.trackFollow()
     } else {
       onOpenAuthModal &&
-        onOpenAuthModal("register", {
+        onOpenAuthModal(ModalType.signup, {
           contextModule: "intext tooltip",
           intent: "follow gene",
           copy: "Sign up to follow categories",

--- a/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowArtistButton.test.tsx
@@ -58,7 +58,7 @@ describe("FollowArtistButton", () => {
       component.find(FollowButtonDeprecated).simulate("click")
       const args = testProps.onOpenAuthModal.mock.calls[0]
 
-      expect(args[0]).toBe("register")
+      expect(args[0]).toBe("signup")
       expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow artist")
       expect(args[1].copy).toBe("Sign up to follow artists")

--- a/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
+++ b/src/Components/FollowButton/__tests__/FollowGeneButton.test.tsx
@@ -54,7 +54,7 @@ describe("FollowGeneButton", () => {
       component.find(FollowButtonDeprecated).simulate("click")
       const args = testProps.onOpenAuthModal.mock.calls[0]
 
-      expect(args[0]).toBe("register")
+      expect(args[0]).toBe("signup")
       expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow gene")
       expect(args[1].copy).toBe("Sign up to follow categories")

--- a/src/Components/Publishing/Article.tsx
+++ b/src/Components/Publishing/Article.tsx
@@ -1,6 +1,7 @@
 import { Theme } from "@artsy/palette"
 import React from "react"
 
+import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import { BannerWrapper } from "Components/Publishing/Banner/Banner"
 import { PixelTracker } from "Components/Publishing/Display/ExternalTrackers"
 import { EditorialFeature } from "Components/Publishing/EditorialFeature/EditorialFeature"
@@ -48,7 +49,7 @@ export interface ArticleProps {
   tracking?: TrackingProp
   closeViewer?: () => void
   viewerIsOpen?: boolean
-  onOpenAuthModal?: (type: "register" | "login", config: object) => void
+  onOpenAuthModal?: (type: ModalType, config: ModalOptions) => void
   onExpand?: () => void
   shouldAdRender?: boolean
 }

--- a/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/ArtistToolTip.test.tsx
@@ -89,7 +89,7 @@ describe("ArtistToolTip", () => {
       component.find(FollowArtistButton).simulate("click")
       const args = context.onOpenAuthModal.mock.calls[0]
 
-      expect(args[0]).toBe("register")
+      expect(args[0]).toBe("signup")
       expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow artist")
     })

--- a/src/Components/Publishing/ToolTip/__tests__/GeneToolTip.test.tsx
+++ b/src/Components/Publishing/ToolTip/__tests__/GeneToolTip.test.tsx
@@ -48,7 +48,7 @@ describe("GeneTooltip", () => {
       component.find(FollowGeneButton).simulate("click")
       const args = context.onOpenAuthModal.mock.calls[0]
 
-      expect(args[0]).toBe("register")
+      expect(args[0]).toBe("signup")
       expect(args[1].contextModule).toBe("intext tooltip")
       expect(args[1].intent).toBe("follow gene")
     })

--- a/src/Utils/__tests__/openAuthModal.test.ts
+++ b/src/Utils/__tests__/openAuthModal.test.ts
@@ -29,7 +29,7 @@ const partnerArgs: AuthModalOptions = {
 const artworkArgs: AuthModalOptions = {
   contextModule: Schema.ContextModule.ArtworkPage,
   entity: {
-    id: "andy-warhol-skull",
+    slug: "andy-warhol-skull",
     name: "Skull",
   },
   intent: AuthModalIntent.SaveArtwork,

--- a/src/Utils/__tests__/openAuthModal.test.ts
+++ b/src/Utils/__tests__/openAuthModal.test.ts
@@ -1,0 +1,124 @@
+import * as Schema from "Artsy/Analytics/Schema"
+import {
+  AuthModalIntent,
+  AuthModalOptions,
+  openAuthModal,
+} from "../openAuthModal"
+
+jest.mock("sharify", () => ({ data: jest.fn() }))
+const sd = require("sharify").data
+
+const artistArgs: AuthModalOptions = {
+  contextModule: Schema.ContextModule.ArtistPage,
+  entity: {
+    slug: "andy-warhol",
+    name: "Andy Warhol",
+  },
+  intent: AuthModalIntent.FollowArtist,
+}
+
+const partnerArgs: AuthModalOptions = {
+  contextModule: Schema.ContextModule.AboutTheWorkPartner,
+  entity: {
+    slug: "david-zwirner",
+    name: "David Zwirner",
+  },
+  intent: AuthModalIntent.FollowPartner,
+}
+
+const artworkArgs: AuthModalOptions = {
+  contextModule: Schema.ContextModule.ArtworkPage,
+  entity: {
+    id: "andy-warhol-skull",
+    name: "Skull",
+  },
+  intent: AuthModalIntent.SaveArtwork,
+}
+
+describe("openAuthModal", () => {
+  let mediator
+
+  beforeEach(() => {
+    mediator = {
+      trigger: jest.fn(),
+    }
+    window.location.assign = jest.fn()
+  })
+
+  describe("desktop", () => {
+    it("transforms args for following artists", () => {
+      openAuthModal(mediator, artistArgs)
+
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        afterSignUpAction: {
+          action: "follow",
+          kind: "artist",
+          objectId: "andy-warhol",
+        },
+        copy: "Sign up to follow Andy Warhol",
+        intent: "follow artist",
+        mode: "signup",
+      })
+    })
+
+    it("transforms args for following partners", () => {
+      openAuthModal(mediator, partnerArgs)
+
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        afterSignUpAction: {
+          action: "follow",
+          kind: "profile",
+          objectId: "david-zwirner",
+        },
+        copy: "Sign up to follow David Zwirner",
+        intent: "follow partner",
+        mode: "signup",
+      })
+    })
+
+    it("transforms args for saving artworks", () => {
+      openAuthModal(mediator, artworkArgs)
+
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        afterSignUpAction: {
+          action: "save",
+          kind: "artworks",
+          objectId: "andy-warhol-skull",
+        },
+        copy: "Sign up to save artworks",
+        intent: "save artwork",
+        mode: "signup",
+      })
+    })
+  })
+
+  describe("mobile", () => {
+    beforeEach(() => {
+      sd.IS_MOBILE = true
+    })
+
+    it("transforms args for following artists", () => {
+      openAuthModal(mediator, artistArgs)
+      expect(window.location.assign).toBeCalledWith(
+        "/sign_up?redirect-to=http://localhost/&action=follow&contextModule=Artist%20page&copy=Sign%20up%20to%20follow%20Andy%20Warhol&intent=follow%20artist&kind=artist&objectId=andy-warhol"
+      )
+      expect(mediator.trigger).not.toBeCalled()
+    })
+
+    it("transforms args for following partners", () => {
+      openAuthModal(mediator, partnerArgs)
+      expect(window.location.assign).toBeCalledWith(
+        "/sign_up?redirect-to=http://localhost/&action=follow&contextModule=About%20the%20Work%20%28Partner%29&copy=Sign%20up%20to%20follow%20David%20Zwirner&intent=follow%20partner&kind=profile&objectId=david-zwirner"
+      )
+      expect(mediator.trigger).not.toBeCalled()
+    })
+
+    it("transforms args for saving artworks", () => {
+      openAuthModal(mediator, artworkArgs)
+      expect(window.location.assign).toBeCalledWith(
+        "/sign_up?redirect-to=http://localhost/&action=save&contextModule=Artwork%20page&copy=Sign%20up%20to%20save%20artworks&intent=save%20artwork&kind=artworks&objectId=andy-warhol-skull"
+      )
+      expect(mediator.trigger).not.toBeCalled()
+    })
+  })
+})

--- a/src/Utils/openAuthModal.ts
+++ b/src/Utils/openAuthModal.ts
@@ -6,9 +6,8 @@ import { data as sd } from "sharify"
 
 export interface AuthModalOptions extends ModalOptions {
   entity: {
-    slug?: string
+    slug: string
     name: string
-    id?: string
   }
   contextModule: Schema.ContextModule
   intent: AuthModalIntent
@@ -94,7 +93,7 @@ function getMobileIntentToSaveArtwork({
     copy: `Sign up to save artworks`,
     intent,
     kind: "artworks",
-    objectId: entity.id,
+    objectId: entity.slug,
   }
 }
 
@@ -138,7 +137,7 @@ function getDesktopIntentToSaveArtwork({
     afterSignUpAction: {
       action: "save",
       kind: "artworks",
-      objectId: entity.id,
+      objectId: entity.slug,
     },
   }
 }

--- a/src/Utils/openAuthModal.ts
+++ b/src/Utils/openAuthModal.ts
@@ -1,42 +1,50 @@
 import * as Schema from "Artsy/Analytics/Schema"
 import { Mediator } from "Artsy/SystemContext"
+import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import { stringify } from "qs"
 import { data as sd } from "sharify"
 
-interface AuthReason {
+export interface AuthModalOptions extends ModalOptions {
   entity: {
-    id: string
+    slug?: string
     name: string
+    id?: string
   }
   contextModule: Schema.ContextModule
   intent: AuthModalIntent
 }
 
 export enum AuthModalIntent {
-  FollowArtist = "FollowArtist",
-  FollowPartner = "FollowPartner",
-  SaveArtwork = "SaveArtwork",
+  FollowArtist = "follow artist",
+  FollowPartner = "follow partner",
+  SaveArtwork = "save artwork",
 }
 
-export const openAuthModal = (mediator: Mediator, reason: AuthReason) => {
+export const openAuthModal = (
+  mediator: Mediator,
+  options: AuthModalOptions
+) => {
   let handled = false
 
   if (sd.IS_MOBILE) {
-    const intent = getMobileAuthIntent(reason)
+    const intent = getMobileAuthIntent(options)
     if (intent) {
       openMobileAuth(intent)
       handled = true
     }
   } else if (mediator) {
-    const intent = getDesktopAuthIntent(reason)
+    const intent = getDesktopAuthIntent(options)
     if (intent) {
-      openDesktopAuth(mediator, intent)
+      mediator.trigger("open:auth", {
+        mode: ModalType.signup,
+        ...intent,
+      })
       handled = true
     }
   }
 
   if (!handled) {
-    window.location.href = "/login"
+    window.location.assign("/login")
   }
 }
 
@@ -44,148 +52,92 @@ function openMobileAuth(intent) {
   const params = stringify(intent)
   const href = `/sign_up?redirect-to=${window.location}&${params}`
 
-  window.location.href = href
+  window.location.assign(href)
 }
 
-function openDesktopAuth(mediator, intent) {
-  mediator.trigger("open:auth", intent)
-}
-
-interface MobileIntent {
-  action: string
-  contextModule: Schema.ContextModule | string
-  intent: string
-  kind: string
-  objectId: string
-  signUpIntent: string
-  trigger: string
-  entityName: string
-}
-
-function getMobileAuthIntent(reason: AuthReason): MobileIntent {
-  switch (reason.intent) {
+function getMobileAuthIntent(options: AuthModalOptions): ModalOptions {
+  switch (options.intent) {
     case AuthModalIntent.FollowArtist:
-      return getMobileIntentToFollowArtist(reason)
     case AuthModalIntent.FollowPartner:
-      return getMobileIntentToFollowPartner(reason)
+      return getMobileIntentToFollow(options)
     case AuthModalIntent.SaveArtwork:
-      return getMobileIntentToSaveArtwork(reason)
+      return getMobileIntentToSaveArtwork(options)
     default:
       return undefined
   }
 }
 
-function getMobileIntentToFollowArtist({
+function getMobileIntentToFollow({
   contextModule,
   entity,
-}: AuthReason): MobileIntent {
+  intent,
+}: AuthModalOptions): ModalOptions {
+  const kind = intent === AuthModalIntent.FollowArtist ? "artist" : "profile"
   return {
     action: "follow",
     contextModule,
-    intent: "follow artist",
-    kind: "artist",
-    objectId: entity.id,
-    signUpIntent: "follow artist",
-    trigger: "click",
-    entityName: entity.name,
-  }
-}
-
-function getMobileIntentToFollowPartner({
-  contextModule,
-  entity,
-}: AuthReason): MobileIntent {
-  return {
-    action: "follow",
-    contextModule,
-    intent: "follow partner",
-    kind: "gallery",
-    objectId: entity.id,
-    signUpIntent: "follow partner",
-    trigger: "click",
-    entityName: entity.name,
+    copy: `Sign up to follow ${entity.name}`,
+    intent,
+    kind,
+    objectId: entity.slug,
   }
 }
 
 function getMobileIntentToSaveArtwork({
   contextModule,
   entity,
-}: AuthReason): MobileIntent {
+  intent,
+}: AuthModalOptions): ModalOptions {
   return {
     action: "save",
     contextModule,
-    intent: "save artwork",
-    kind: "artwork",
+    copy: `Sign up to save artworks`,
+    intent,
+    kind: "artworks",
     objectId: entity.id,
-    signUpIntent: "save artwork",
-    trigger: "click",
-    entityName: entity.name,
   }
 }
 
-interface DesktopIntent {
-  mode: string
-  copy: string
-  intent?: string
-  signupIntent: string
-  trigger?: string
-  afterSignUpAction: {
-    kind?: string
-    action: string
-    objectId: string
-  }
-}
-
-function getDesktopAuthIntent(reason: AuthReason): DesktopIntent {
-  switch (reason.intent) {
+function getDesktopAuthIntent(options: AuthModalOptions): ModalOptions {
+  switch (options.intent) {
     case AuthModalIntent.FollowArtist:
-      return getDesktopIntentToFollowArtist(reason)
     case AuthModalIntent.FollowPartner:
-      return getDesktopIntentToFollowPartner(reason)
+      return getDesktopIntentToFollow(options)
     case AuthModalIntent.SaveArtwork:
-      return getDesktopIntentToSaveArtwork(reason)
+      return getDesktopIntentToSaveArtwork(options)
     default:
       return undefined
   }
 }
 
-function getDesktopIntentToFollowArtist({ entity }: AuthReason): DesktopIntent {
-  return {
-    mode: "signup",
-    copy: `Sign up to follow ${entity.name}`,
-    signupIntent: "follow artist",
-    afterSignUpAction: {
-      kind: "artist",
-      action: "follow",
-      objectId: entity.id,
-    },
-  }
-}
-
-function getDesktopIntentToFollowPartner({
+export const getDesktopIntentToFollow = ({
   entity,
-}: AuthReason): DesktopIntent {
+  intent,
+}: AuthModalOptions): ModalOptions => {
+  const kind = intent === AuthModalIntent.FollowArtist ? "artist" : "profile"
   return {
-    mode: "signup",
+    mode: ModalType.signup,
     copy: `Sign up to follow ${entity.name}`,
-    signupIntent: "follow partner",
+    intent,
     afterSignUpAction: {
-      kind: "profile", // should this be "partner"?
       action: "follow",
-      objectId: entity.id,
+      kind,
+      objectId: entity.slug,
     },
   }
 }
 
-function getDesktopIntentToSaveArtwork({ entity }: AuthReason): DesktopIntent {
+function getDesktopIntentToSaveArtwork({
+  entity,
+  intent,
+}: AuthModalOptions): ModalOptions {
   return {
-    mode: "signup",
+    mode: ModalType.signup,
     copy: `Sign up to save artworks`,
-    intent: "save artwork",
-    signupIntent: "save artwork",
-    trigger: "click",
+    intent,
     afterSignUpAction: {
       action: "save",
+      kind: "artworks",
       objectId: entity.id,
     },
   }


### PR DESCRIPTION
Reopens #3239
Companion PR in Force: https://github.com/artsy/force/pull/5189

Updates the `openAuthModal` helper, which is used by follow and save buttons to construct `ModalOptions` for the Artist page. 

This PR is part of an effort to strictly type all arguments passed to mediator when opening auth modals. This is related to efforts to strictly type authentication analytics events. 
https://artsyproduct.atlassian.net/browse/PLATFORM-2286
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.27.6-canary.3252.53757.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.27.6-canary.3252.53757.0
  # or 
  yarn add @artsy/reaction@25.27.6-canary.3252.53757.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
