### PR TITLE
Add Integrity-ready flag to boot

### DIFF
--- a/src/Artsy/Router/Boot.tsx
+++ b/src/Artsy/Router/Boot.tsx
@@ -44,6 +44,9 @@ export class Boot extends React.Component<BootProps> {
     if (env === "production") {
       Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
     }
+
+    // Let our end-to-end tests know that the app is hydrated and ready to go
+    document.body.setAttribute("data-test", "AppReady")
   }
 
   render() {


### PR DESCRIPTION
Follow up to https://github.com/artsy/reaction/pull/3233, which expands coverage a bit for all kinds of components / pages that use `<Boot>`. 