### PR TITLE
Move conversations app to be behind lab feature instead of admin flag

### DIFF
--- a/src/Apps/Conversation/ConversationApp.tsx
+++ b/src/Apps/Conversation/ConversationApp.tsx
@@ -1,4 +1,3 @@
-import { ConversationApp_me } from "__generated__/ConversationApp_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationsFragmentContainer as Conversations } from "Apps/Conversation/Components/Conversations"
 import { SystemContext } from "Artsy"
@@ -6,7 +5,8 @@ import { ErrorPage } from "Components/ErrorPage"
 import React, { useContext } from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
-import { userIsAdmin } from "Utils/user"
+import { userHasLabFeature } from "Utils/user"
+import { ConversationApp_me } from "__generated__/ConversationApp_me.graphql"
 
 interface ConversationAppProps {
   me: ConversationApp_me
@@ -15,8 +15,8 @@ interface ConversationAppProps {
 export const ConversationApp: React.FC<ConversationAppProps> = props => {
   const { me } = props
   const { user } = useContext(SystemContext)
-  const isAdmin = userIsAdmin(user)
-  if (isAdmin) {
+  const isEnabled = userHasLabFeature(user, "User Conversations View")
+  if (isEnabled) {
     return (
       <AppContainer>
         <Title>My Inquiries | Artsy</Title>
@@ -24,7 +24,7 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
       </AppContainer>
     )
   } else {
-    // not an admin
+    // not allowed to see this view
     return <ErrorPage code={404} />
   }
 }

--- a/src/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/Apps/Conversation/Routes/Conversation/index.tsx
@@ -1,12 +1,12 @@
 import { BorderBox, Flex, Title } from "@artsy/palette"
-import { Conversation_me } from "__generated__/Conversation_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationFragmentContainer as Conversation } from "Apps/Conversation/Components/Conversation"
 import { SystemContext } from "Artsy"
 import { ErrorPage } from "Components/ErrorPage"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { userIsAdmin } from "Utils/user"
+import { userHasLabFeature } from "Utils/user"
+import { Conversation_me } from "__generated__/Conversation_me.graphql"
 
 interface ConversationRouteProps {
   me: Conversation_me
@@ -16,8 +16,8 @@ interface ConversationRouteProps {
 export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
   const { me } = props
   const { user } = useContext(SystemContext)
-  const isAdmin = userIsAdmin(user)
-  if (isAdmin) {
+  const isEnabled = userHasLabFeature(user, "User Conversations View")
+  if (isEnabled) {
     return (
       <AppContainer>
         <Title>My Inquiries | Artsy</Title>
@@ -29,7 +29,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
       </AppContainer>
     )
   } else {
-    // not an admin
+    // not allowed to see this view
     return <ErrorPage code={404} />
   }
 }

--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -1,13 +1,13 @@
-import {
-  ConversationAppTestQueryRawResponse,
-  ConversationAppTestQueryResponse,
-} from "__generated__/ConversationAppTestQuery.graphql"
 import { MockedConversation } from "Apps/__tests__/Fixtures/Conversation"
 import { SystemContextProvider } from "Artsy"
 import { MockBoot, renderRelayTree } from "DevTools"
 import React from "react"
 import { HeadProvider } from "react-head"
 import { graphql } from "react-relay"
+import {
+  ConversationAppTestQueryRawResponse,
+  ConversationAppTestQueryResponse,
+} from "__generated__/ConversationAppTestQuery.graphql"
 import { ConversationAppFragmentContainer } from "../ConversationApp"
 
 jest.unmock("react-relay")
@@ -49,8 +49,11 @@ const render = (me: ConversationAppTestQueryRawResponse["me"], user: User) =>
   })
 
 describe("Conversation app", () => {
-  describe("User with admin privilages", () => {
-    const userType = { type: "Admin" }
+  describe("User with feature enabled", () => {
+    const userType = {
+      type: "NotAdmin",
+      lab_features: ["User Conversations View"],
+    }
     describe("having previous conversations", () => {
       it("renders conversations with view details button", async () => {
         // TODO: revisit mocking and remove `artist_names` alias from PurchseHistory
@@ -82,7 +85,7 @@ describe("Conversation app", () => {
       })
     })
   })
-  describe("User without admin privilages", () => {
+  describe("User without the feature enabled", () => {
     it("gives error", async () => {
       const mockMe = {
         id: "111",


### PR DESCRIPTION
This is the over half of the work needed to move the inquiries view from behind admin to behind the lab feature flag. 

I didn't realize it was gated both in the menu and in the app. 