### PR TITLE
Update openseadragon to try to fix some mobile bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "luxon": "^1.15",
     "memoize-one": "^4.0.3",
     "numeral": "^2.0.4",
-    "openseadragon": "^2.3.1",
+    "openseadragon": "^2.4.2",
     "prop-types": "^15.5.10",
     "qs": "^6.5.0",
     "rc-slider": "^8.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11549,10 +11549,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-openseadragon@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.3.1.tgz#efdcfee19d8b3c46d00d7f7dda787c7057f68364"
-  integrity sha1-79z+4Z2LPEbQDX992nh8cFf2g2Q=
+openseadragon@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.2.tgz#f25d833d0ab9941599d65a3e2b44bec546c9f15c"
+  integrity sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==
 
 opentracing@>=0.14.1:
   version "0.14.3"


### PR DESCRIPTION
We're seeing some [issues](https://sentry.io/organizations/artsynet/issues/932987046/?project=28316&query=is%3Aunresolved&sort=freq&statsPeriod=24h) on mobile related to openseadragon. This update hopefully includes some bug fixes that'll help reduce the occurrences of those errors. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.27.14-canary.3260.53895.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.27.14-canary.3260.53895.0
  # or 
  yarn add @artsy/reaction@25.27.14-canary.3260.53895.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
