### PR TITLE
[PUR-1818] Update header text for auction results page

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultHeader.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultHeader.tsx
@@ -1,9 +1,9 @@
-import { Box, Link, Sans, Serif } from "@artsy/palette"
+import { Box, Sans, Serif } from "@artsy/palette"
 import { AuctionResultHeader_artist } from "__generated__/AuctionResultHeader_artist.graphql"
+import { RouterLink } from "Artsy/Router/RouterLink"
 import React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
-import { data as sd } from "sharify"
 
 interface Props {
   artist: AuctionResultHeader_artist
@@ -21,17 +21,15 @@ const AuctionResultHeader: React.FC<Props> = props => {
         the auction and may not be indicative of the current gallery market. To
         get the best sense of value, pair the artist’s auction results with
         their{" "}
-        <Link href={`${sd.APP_URL}/artist/${artist.slug}/cv`}>
+        <RouterLink to={`/artist/${artist.slug}/cv`}>
           career highlights
-        </Link>{" "}
+        </RouterLink>{" "}
         like exhibition history, gallery representation, and presence in museum
         collections. For more information on how auction pricing differs from
         gallery pricing, check out{" "}
-        <Link
-          href={`${sd.APP_URL}/article/artsy-editorial-gallery-auction-house-buy`}
-        >
+        <RouterLink to={`/article/artsy-editorial-gallery-auction-house-buy`}>
           this article
-        </Link>
+        </RouterLink>
         .
       </Serif>
     </Box>

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultHeader.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionResultHeader.tsx
@@ -1,8 +1,9 @@
-import { Box, Sans, Serif } from "@artsy/palette"
+import { Box, Link, Sans, Serif } from "@artsy/palette"
 import { AuctionResultHeader_artist } from "__generated__/AuctionResultHeader_artist.graphql"
 import React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
+import { data as sd } from "sharify"
 
 interface Props {
   artist: AuctionResultHeader_artist
@@ -10,12 +11,28 @@ interface Props {
 
 const AuctionResultHeader: React.FC<Props> = props => {
   const { artist } = props
+
   return (
     <Box pb={2}>
       <Sans size="5t">Auction results</Sans>
       <Serif size="3" color="black100">
-        Filter past auction results to compare and evaluate {artist.name}'s
-        market.
+        Filter auction results to compare past lots by medium, size, and more.
+        Note that auction prices vary based on market specifics at the time of
+        the auction and may not be indicative of the current gallery market. To
+        get the best sense of value, pair the artist’s auction results with
+        their{" "}
+        <Link href={`${sd.APP_URL}/artist/${artist.slug}/cv`}>
+          career highlights
+        </Link>{" "}
+        like exhibition history, gallery representation, and presence in museum
+        collections. For more information on how auction pricing differs from
+        gallery pricing, check out{" "}
+        <Link
+          href={`${sd.APP_URL}/article/artsy-editorial-gallery-auction-house-buy`}
+        >
+          this article
+        </Link>
+        .
       </Serif>
     </Box>
   )
@@ -26,7 +43,7 @@ export const AuctionResultHeaderFragmentContainer = createFragmentContainer(
   {
     artist: graphql`
       fragment AuctionResultHeader_artist on Artist {
-        name
+        slug
       }
     `,
   }

--- a/src/Apps/__tests__/Fixtures/Artist/Routes/AuctionResultsFixture.ts
+++ b/src/Apps/__tests__/Fixtures/Artist/Routes/AuctionResultsFixture.ts
@@ -4,7 +4,6 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
   artist: {
     id: "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
     slug: "pablo-picasso",
-    name: "Pablo Picasso",
     auctionResultsConnection: {
       pageInfo: { hasNextPage: true, endCursor: "YXJyYXljb25uZWN0aW9uOjk=" },
       pageCursors: {

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -100,7 +100,7 @@ fragment ArtistAuctionResults_artist_3L8Kmx on Artist {
 }
 
 fragment AuctionResultHeader_artist on Artist {
-  name
+  slug
 }
 
 fragment AuctionResultsCount_results on AuctionResultConnection {
@@ -320,13 +320,6 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "slug",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
             "args": null,
             "storageKey": null
           },
@@ -575,7 +568,7 @@ return {
     "operationKind": "query",
     "name": "ArtistAuctionResultsQuery",
     "id": null,
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_3L8Kmx\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_3L8Kmx on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  name\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_3L8Kmx\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_3L8Kmx on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  slug\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/AuctionResultHeader_artist.graphql.ts
+++ b/src/__generated__/AuctionResultHeader_artist.graphql.ts
@@ -3,7 +3,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type AuctionResultHeader_artist = {
-    readonly name: string | null;
+    readonly slug: string;
     readonly " $refType": "AuctionResultHeader_artist";
 };
 export type AuctionResultHeader_artist$data = AuctionResultHeader_artist;
@@ -24,11 +24,11 @@ const node: ReaderFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "name",
+      "name": "slug",
       "args": null,
       "storageKey": null
     }
   ]
 };
-(node as any).hash = '3705a4553b3415bd32e1e992ed1f9d0f';
+(node as any).hash = 'f667052f3e1b95eb9b9c71a7cfff9078';
 export default node;

--- a/src/__generated__/AuctionResults_Test_Query.graphql.ts
+++ b/src/__generated__/AuctionResults_Test_Query.graphql.ts
@@ -13,7 +13,6 @@ export type AuctionResults_Test_QueryResponse = {
 export type AuctionResults_Test_QueryRawResponse = {
     readonly artist: ({
         readonly slug: string;
-        readonly name: string | null;
         readonly auctionResultsConnection: ({
             readonly totalCount: number | null;
             readonly pageInfo: {
@@ -143,7 +142,7 @@ fragment ArtistAuctionResults_artist on Artist {
 }
 
 fragment AuctionResultHeader_artist on Artist {
-  name
+  slug
 }
 
 fragment AuctionResultsCount_results on AuctionResultConnection {
@@ -277,13 +276,6 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "slug",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
             "args": null,
             "storageKey": null
           },
@@ -543,7 +535,7 @@ return {
     "operationKind": "query",
     "name": "AuctionResults_Test_Query",
     "id": null,
-    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  name\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query AuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  slug\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_AuctionResultsQuery.graphql.ts
+++ b/src/__generated__/routes_AuctionResultsQuery.graphql.ts
@@ -82,7 +82,7 @@ fragment ArtistAuctionResults_artist on Artist {
 }
 
 fragment AuctionResultHeader_artist on Artist {
-  name
+  slug
 }
 
 fragment AuctionResultsCount_results on AuctionResultConnection {
@@ -216,13 +216,6 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "slug",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
             "args": null,
             "storageKey": null
           },
@@ -482,7 +475,7 @@ return {
     "operationKind": "query",
     "name": "routes_AuctionResultsQuery",
     "id": null,
-    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  name\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query routes_AuctionResultsQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...AuctionResults_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  sale_date_text: saleDateText\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: 10, sort: DATE_DESC) {\n    ...AuctionResultsCount_results\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  slug\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment AuctionResults_artist on Artist {\n  ...ArtistAuctionResults_artist\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Update header text for auction results page
Jira Ticket: https://artsyproduct.atlassian.net/browse/PURCHASE-1818

Ran `yarn relay` to get the artists.slug graphql data for the text.

Here's what it looks like in storybooks:
<img width="1612" alt="Screen Shot 2020-03-12 at 12 42 17 PM" src="https://user-images.githubusercontent.com/12748344/76545622-7d4c1e80-6460-11ea-8958-b1ec27a7b843.png">





Kinda hardcoded the new copy with some dynamic links for `/cv` and the information article url. Any tips on doing this a little bit better?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.28.0-canary.3262.53966.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.28.0-canary.3262.53966.0
  # or 
  yarn add @artsy/reaction@25.28.0-canary.3262.53966.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
