### PR TITLE
Attempt to fix Flickity error

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -1,5 +1,5 @@
 import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
-import React, { Fragment } from "react"
+import React from "react"
 import styled from "styled-components"
 import { left, LeftProps, right, RightProps } from "styled-system"
 import { Media } from "Utils/Responsive"
@@ -405,11 +405,7 @@ export class BaseCarousel extends React.Component<
             ref={c => (this.carouselRef = c)}
           >
             {carouselImages.map((slide, slideIndex) => {
-              return (
-                <Fragment key={slideIndex}>
-                  {render(slide, slideIndex)}
-                </Fragment>
-              )
+              return <div key={slideIndex}>{render(slide, slideIndex)}</div>
             })}
           </FlickityCarousel>
         </CarouselContainer>


### PR DESCRIPTION
Still trying to fix the unreproducible  
```
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node
```
error around flickity as seen in this [sentry](https://sentry.io/organizations/artsynet/issues/1497212332/?project=28316&query=removeChild&statsPeriod=24h) ticket. 

This [stack overflow](https://stackoverflow.com/a/54882016/1038901) comment made me think we might be using a fragment somewhere in the carousel around images, and indeed we were. 

🤞 