### PR TITLE
[Clientside Nav] Remove mobile loader test

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -24,7 +24,6 @@ import { Footer } from "Components/v2/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "Components/v2/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
-import { get } from "Utils/get"
 import { Media } from "Utils/Responsive"
 
 export interface Props {
@@ -122,9 +121,9 @@ export class ArtworkApp extends React.Component<Props> {
   }
 
   renderArtists() {
-    const artists = get(this.props, p => p.artwork.artists)
+    const artists = this.props.artwork?.artists
 
-    if (!artists.length) {
+    if (!artists?.length) {
       return null
     }
 

--- a/src/Artsy/Router/RenderStatus.tsx
+++ b/src/Artsy/Router/RenderStatus.tsx
@@ -7,7 +7,6 @@ import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
-import { Media } from "Utils/Responsive"
 import { NetworkTimeout } from "./NetworkTimeout"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
@@ -32,45 +31,16 @@ export const RenderPending = () => {
       <>
         <Renderer>{null}</Renderer>
 
-        {/*
-          FIXME: Remove when EXPERIMENTAL_APP_SHELL a/b test is complete
-        */}
-        <Media lessThan="md">
-          <Box
-            className="reactionPageLoader" // positional styling comes from Force body.styl
-            style={{
-              background: "#ffffff90",
-              position: "fixed",
-              width: "100%",
-              height: "100%",
-              left: 0,
-              top: -6,
-              zIndex: 1000,
-            }}
-          >
-            <PageLoader
-              showBackground={false}
-              style={{
-                top: "50vh",
-                position: "absolute",
-                left: 0,
-                zIndex: 1000,
-              }}
-            />
-          </Box>
-        </Media>
-        <Media greaterThanOrEqual="md">
-          <PageLoader
-            className="reactionPageLoader" // positional styling comes from Force body.styl
-            showBackground={false}
-            style={{
-              position: "fixed",
-              left: 0,
-              top: -6,
-              zIndex: 1000,
-            }}
-          />
-        </Media>
+        <PageLoader
+          className="reactionPageLoader" // positional styling comes from Force body.styl
+          showBackground={false}
+          style={{
+            position: "fixed",
+            left: 0,
+            top: -6,
+            zIndex: 1000,
+          }}
+        />
 
         <NetworkTimeout />
       </>


### PR DESCRIPTION
We have enough data now where we don't need to continue showing the loader in the middle of the screen on mobile. This removes that weirdness. 