### PR TITLE
[Carousel] Fix alignment in image

### DIFF
--- a/src/Components/v2/Carousel.tsx
+++ b/src/Components/v2/Carousel.tsx
@@ -405,7 +405,11 @@ export class BaseCarousel extends React.Component<
             ref={c => (this.carouselRef = c)}
           >
             {carouselImages.map((slide, slideIndex) => {
-              return <div key={slideIndex}>{render(slide, slideIndex)}</div>
+              return (
+                <Box style={{ margin: "auto" }} key={slideIndex}>
+                  {render(slide, slideIndex)}
+                </Box>
+              )
             })}
           </FlickityCarousel>
         </CarouselContainer>


### PR DESCRIPTION
Fixes an alignment bug that [originated here](https://github.com/artsy/reaction/pull/3265) that only appears during SSR render / when JS is disabled. 