### PR TITLE
[Clientside Nav] Add more safety around network failures with fallback UI

### DIFF
--- a/src/Artsy/Router/Boot.tsx
+++ b/src/Artsy/Router/Boot.tsx
@@ -57,18 +57,18 @@ export class Boot extends React.Component<BootProps> {
     }
 
     return (
-      <ErrorBoundary>
+      <Theme>
         <HeadProvider headTags={headTags}>
           <StateProvider>
             <Artsy.SystemContextProvider {...contextProps}>
-              <MediaContextProvider onlyMatch={props.onlyMatchMediaQueries}>
-                <ResponsiveProvider
-                  mediaQueries={themeProps.mediaQueries}
-                  initialMatchingMediaQueries={
-                    props.onlyMatchMediaQueries as any
-                  }
-                >
-                  <Theme>
+              <ErrorBoundary>
+                <MediaContextProvider onlyMatch={props.onlyMatchMediaQueries}>
+                  <ResponsiveProvider
+                    mediaQueries={themeProps.mediaQueries}
+                    initialMatchingMediaQueries={
+                      props.onlyMatchMediaQueries as any
+                    }
+                  >
                     <Grid fluid>
                       <GlobalStyles suppressMultiMountWarning />
                       {children}
@@ -76,13 +76,13 @@ export class Boot extends React.Component<BootProps> {
                         <BreakpointVisualizer />
                       )}
                     </Grid>
-                  </Theme>
-                </ResponsiveProvider>
-              </MediaContextProvider>
+                  </ResponsiveProvider>
+                </MediaContextProvider>
+              </ErrorBoundary>
             </Artsy.SystemContextProvider>
           </StateProvider>
         </HeadProvider>
-      </ErrorBoundary>
+      </Theme>
     )
   }
 }

--- a/src/Artsy/Router/__tests__/Boot.test.tsx
+++ b/src/Artsy/Router/__tests__/Boot.test.tsx
@@ -1,6 +1,5 @@
 import { SystemContextConsumer } from "Artsy"
 import { Boot } from "Artsy/Router"
-import { ErrorBoundary } from "Components/ErrorBoundary"
 import { mount } from "enzyme"
 import React from "react"
 
@@ -55,21 +54,5 @@ describe("Boot", () => {
 
   it("injects Grid", () => {
     expect(mount(<Boot {...bootProps} />).find("Grid").length).toEqual(1)
-  })
-
-  it("catches errors with componentDidCatch", () => {
-    console.error = jest.fn()
-    const BrokenComponent = () => {
-      throw new Error("error message")
-      return <div>error</div>
-    }
-
-    jest.spyOn(ErrorBoundary.prototype, "componentDidCatch")
-    mount(
-      <Boot {...bootProps}>
-        <BrokenComponent />
-      </Boot>
-    )
-    expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
   })
 })

--- a/src/Artsy/Router/__tests__/buildClientApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildClientApp.test.tsx
@@ -6,6 +6,16 @@ import { mount } from "enzyme"
 import React from "react"
 import { graphql } from "react-relay"
 
+jest.mock("Components/NavBar", () => ({
+  NavBar: () => <div />,
+}))
+
+jest.mock("react-relay", () => ({
+  ReactRelayContext: {
+    Provider: ({ children }) => children,
+  },
+}))
+
 describe("buildClientApp", () => {
   it("resolves with a <ClientApp /> component", async () => {
     const { ClientApp } = await buildClientApp({
@@ -165,6 +175,7 @@ describe("buildClientApp", () => {
           ],
           context: { relayEnvironment },
         })
+
         mount(<ClientApp />)
       } catch (error) {
         expect(error.message).toMatch(/Oh noes/)

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,7 +1,5 @@
-import { ArtsyMarkIcon, Box } from "@artsy/palette"
-import { RouterLink } from "Artsy/Router/RouterLink"
+import { NavBar } from "Components/NavBar"
 import React from "react"
-import { data as sd } from "sharify"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
 import { ErrorModal } from "./Modal/ErrorModal"
@@ -57,12 +55,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
 /**
  * An error popup with the option to reload the page
  */
-const ErrorModalWithReload = ({ show }) => {
+const ErrorModalWithReload: React.FC<{ show: boolean }> = ({ show }) => {
   return (
-    <Box m={2}>
-      <RouterLink to={sd.APP_URL}>
-        <ArtsyMarkIcon height={40} width={40} />
-      </RouterLink>
+    <>
+      <NavBar />
       <ErrorModal
         show={show}
         detailText="Please check your network connection and try again."
@@ -71,6 +67,6 @@ const ErrorModalWithReload = ({ show }) => {
           location.reload()
         }}
       />
-    </Box>
+    </>
   )
 }

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,15 +1,27 @@
+import { ArtsyMarkIcon, Box } from "@artsy/palette"
+import { RouterLink } from "Artsy/Router/RouterLink"
 import React from "react"
+import { data as sd } from "sharify"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
+import { ErrorModal } from "./Modal/ErrorModal"
+
+const logger = createLogger()
 
 interface Props {
   children?: any
   onCatch?: () => void
 }
 
-const logger = createLogger()
+interface State {
+  asyncChunkLoadError: boolean
+}
 
-export class ErrorBoundary extends React.Component<Props> {
+export class ErrorBoundary extends React.Component<Props, State> {
+  state = {
+    asyncChunkLoadError: false,
+  }
+
   componentDidCatch(error, errorInfo) {
     logger.error(new ErrorWithMetadata(error.message, errorInfo))
 
@@ -18,7 +30,47 @@ export class ErrorBoundary extends React.Component<Props> {
     }
   }
 
+  static getDerivedStateFromError(error) {
+    /**
+     * Check to see if there's been a network error while asynchronously loading
+     * a dynamic webpack split chunk bundle. Can happen if a user is navigating
+     * between routes and their network connection goes out.
+     *
+     * @see https://reactjs.org/docs/code-splitting.html
+     */
+    if (error.message.match(/Loading chunk .* failed/)) {
+      return {
+        asyncChunkLoadError: true,
+      }
+    }
+  }
+
   render() {
+    if (this.state.asyncChunkLoadError) {
+      return <ErrorModalWithReload show={this.state.asyncChunkLoadError} />
+    }
+
     return this.props.children
   }
+}
+
+/**
+ * An error popup with the option to reload the page
+ */
+const ErrorModalWithReload = ({ show }) => {
+  return (
+    <Box m={2}>
+      <RouterLink to={sd.APP_URL}>
+        <ArtsyMarkIcon height={40} width={40} />
+      </RouterLink>
+      <ErrorModal
+        show={show}
+        detailText="Please check your network connection and try again."
+        closeText="Reload"
+        ctaAction={() => {
+          location.reload()
+        }}
+      />
+    </Box>
+  )
 }

--- a/src/Components/NavBar/MinimalNavBar.tsx
+++ b/src/Components/NavBar/MinimalNavBar.tsx
@@ -4,11 +4,16 @@ import { RouterLink } from "Artsy/Router/RouterLink"
 import React from "react"
 
 interface MinimalNavBarProps {
-  to: string
   children: React.ReactNode
+  logo?: React.ReactNode
+  to: string
 }
 
-export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
+export const MinimalNavBar: React.FC<MinimalNavBarProps> = ({
+  children,
+  logo = <ArtsyLogoBlackIcon />,
+  to,
+}) => {
   return (
     <Box
       zIndex={1000}
@@ -22,18 +27,18 @@ export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
       <AppContainer>
         <Box height={70} px={[2, 4]}>
           <RouterLink
-            to={props.to}
+            to={to}
             // TODO: figure out a minimal example of the underlying cause of this error
             // and submit an issue to TS 😓
             // @ts-ignore
             data-test="logoLink"
           >
-            <ArtsyLogoBlackIcon />
+            {logo}
           </RouterLink>
         </Box>
       </AppContainer>
 
-      {props.children}
+      {children}
     </Box>
   )
 }

--- a/src/Components/NavBar/MinimalNavBar.tsx
+++ b/src/Components/NavBar/MinimalNavBar.tsx
@@ -4,16 +4,11 @@ import { RouterLink } from "Artsy/Router/RouterLink"
 import React from "react"
 
 interface MinimalNavBarProps {
-  children: React.ReactNode
-  logo?: React.ReactNode
   to: string
+  children: React.ReactNode
 }
 
-export const MinimalNavBar: React.FC<MinimalNavBarProps> = ({
-  children,
-  logo = <ArtsyLogoBlackIcon />,
-  to,
-}) => {
+export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
   return (
     <Box
       zIndex={1000}
@@ -27,18 +22,18 @@ export const MinimalNavBar: React.FC<MinimalNavBarProps> = ({
       <AppContainer>
         <Box height={70} px={[2, 4]}>
           <RouterLink
-            to={to}
+            to={props.to}
             // TODO: figure out a minimal example of the underlying cause of this error
             // and submit an issue to TS 😓
             // @ts-ignore
             data-test="logoLink"
           >
-            {logo}
+            <ArtsyLogoBlackIcon />
           </RouterLink>
         </Box>
       </AppContainer>
 
-      {children}
+      {props.children}
     </Box>
   )
 }

--- a/src/Components/Payment/__tests__/PaymentForm.test.tsx
+++ b/src/Components/Payment/__tests__/PaymentForm.test.tsx
@@ -8,6 +8,7 @@ import { creatingCreditCardFailed } from "Apps/Order/Routes/__fixtures__/Mutatio
 jest.mock("react-relay", () => ({
   commitMutation: jest.fn(),
   createFragmentContainer: component => component,
+  createRefetchContainer: component => component,
 }))
 
 jest.mock("react-stripe-elements", () => ({

--- a/src/Components/__tests__/ErrorBoundary.test.tsx
+++ b/src/Components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,76 @@
+import { ErrorBoundary } from "Components/ErrorBoundary"
+import { mount } from "enzyme"
+import React from "react"
+
+jest.mock("Components/NavBar", () => ({
+  NavBar: () => <div />,
+}))
+
+describe("ErrorBoundary", () => {
+  const errorLog = console.error
+
+  beforeEach(() => {
+    console.error = jest.fn()
+  })
+
+  afterEach(() => {
+    console.error = errorLog
+  })
+
+  it("renders children if no error", () => {
+    const wrapper = mount(
+      <ErrorBoundary>
+        <div>found child</div>
+      </ErrorBoundary>
+    )
+
+    expect(wrapper.text()).toContain("found child")
+  })
+
+  it("calls componentDidCatch if error", () => {
+    jest.spyOn(ErrorBoundary.prototype, "componentDidCatch")
+    const ErrorComponent = () => {
+      throw new Error("throw error")
+      return null
+    }
+    expect(() => {
+      mount(
+        <ErrorBoundary>
+          <ErrorComponent />
+        </ErrorBoundary>
+      )
+      expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
+    }).toThrow()
+  })
+
+  it("shows error modal when asyncChunkLoadError is true", () => {
+    const wrapper = mount(
+      <ErrorBoundary>
+        <div>erroneous render</div>
+      </ErrorBoundary>
+    )
+
+    wrapper.setState({
+      asyncChunkLoadError: true,
+    })
+
+    wrapper.update()
+    expect(wrapper.text()).not.toContain("erroneous render")
+    expect(wrapper.find("ErrorModalWithReload").length).toEqual(1)
+  })
+
+  it("it only shows ErrorModalWithReload if error is related to failed chunks", () => {
+    expect(
+      ErrorBoundary.getDerivedStateFromError({
+        message: "generic error",
+      })
+    ).toEqual(undefined)
+    expect(
+      ErrorBoundary.getDerivedStateFromError({
+        message: "Loading chunk c3495.js failed",
+      })
+    ).toEqual({
+      asyncChunkLoadError: true,
+    })
+  })
+})


### PR DESCRIPTION
While browsing Sentry I've noticed [occasional errors](https://sentry.io/organizations/artsynet/issues/1564753432/?project=28316&query=is%3Aunresolved+chunk&statsPeriod=24h) appear that look like 

> Loading chunk 24 failed. (error: https://d1s2w0upia4e9w.cloudfront.net/assets/Routes-Works.22820.adcce79ed4f87e3fc6ed.js)

This typically happens when a user (often on a mobile phone) is navigating between routes and their network connection goes out, which leads to a split JS bundle failing to load. 

We've already [added retry support](https://github.com/artsy/force/pull/5186) on the Force side of things, which will re-try the request up to five times. However, that doesn't handle absolute failures, nor does it gracefully degrade with UI that can lead to a recovery.

According to React's [code splitting docs](https://reactjs.org/docs/code-splitting.html), the best way to handle this is within an Error boundary: 

> If the other module fails to load (for example, due to network failure), it will trigger an error. You can handle these errors to show a nice user experience and manage recovery with Error Boundaries. Once you’ve created your Error Boundary, you can use it anywhere above your lazy components to display an error state when there’s a network error.

Since we already have an error boundary at the root of our app we can listen for specific errors here and handle gracefully, prompting the user to reload the page via our standard `ErrorModal`. (In the future we can further flesh this out for other kinds of global errors.)

![retry](https://user-images.githubusercontent.com/236943/76709897-e087bc00-66bf-11ea-9990-0776dd7b0621.gif)
