### PR TITLE
[ErrorBoundary] Add generic error handler

### DIFF
--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -13,11 +13,13 @@ interface Props {
 
 interface State {
   asyncChunkLoadError: boolean
+  genericError: boolean
 }
 
 export class ErrorBoundary extends React.Component<Props, State> {
   state = {
     asyncChunkLoadError: false,
+    genericError: false,
   }
 
   componentDidCatch(error, errorInfo) {
@@ -41,11 +43,27 @@ export class ErrorBoundary extends React.Component<Props, State> {
         asyncChunkLoadError: true,
       }
     }
+
+    return {
+      genericError: true,
+    }
   }
 
   render() {
-    if (this.state.asyncChunkLoadError) {
-      return <ErrorModalWithReload show={this.state.asyncChunkLoadError} />
+    const { asyncChunkLoadError, genericError } = this.state
+
+    switch (true) {
+      case asyncChunkLoadError: {
+        return (
+          <ErrorModalWithReload
+            message="Please check your network connection and try again."
+            show={asyncChunkLoadError}
+          />
+        )
+      }
+      case genericError: {
+        return <ErrorModalWithReload show={genericError} />
+      }
     }
 
     return this.props.children
@@ -55,13 +73,16 @@ export class ErrorBoundary extends React.Component<Props, State> {
 /**
  * An error popup with the option to reload the page
  */
-const ErrorModalWithReload: React.FC<{ show: boolean }> = ({ show }) => {
+const ErrorModalWithReload: React.FC<{ message?: string; show: boolean }> = ({
+  message,
+  show,
+}) => {
   return (
     <>
       <NavBar />
       <ErrorModal
         show={show}
-        detailText="Please check your network connection and try again."
+        detailText={message}
         closeText="Reload"
         ctaAction={() => {
           location.reload()

--- a/src/Components/__tests__/ErrorBoundary.test.tsx
+++ b/src/Components/__tests__/ErrorBoundary.test.tsx
@@ -33,14 +33,28 @@ describe("ErrorBoundary", () => {
       throw new Error("throw error")
       return null
     }
-    expect(() => {
-      mount(
-        <ErrorBoundary>
-          <ErrorComponent />
-        </ErrorBoundary>
-      )
-      expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
-    }).toThrow()
+    mount(
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>
+    )
+    expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
+  })
+
+  it("shows error modal when genericError is true", () => {
+    const wrapper = mount(
+      <ErrorBoundary>
+        <div>erroneous render</div>
+      </ErrorBoundary>
+    )
+
+    wrapper.setState({
+      genericError: true,
+    })
+
+    wrapper.update()
+    expect(wrapper.text()).not.toContain("erroneous render")
+    expect(wrapper.find("ErrorModalWithReload").length).toEqual(1)
   })
 
   it("shows error modal when asyncChunkLoadError is true", () => {
@@ -64,7 +78,9 @@ describe("ErrorBoundary", () => {
       ErrorBoundary.getDerivedStateFromError({
         message: "generic error",
       })
-    ).toEqual(undefined)
+    ).toEqual({
+      genericError: true,
+    })
     expect(
       ErrorBoundary.getDerivedStateFromError({
         message: "Loading chunk c3495.js failed",


### PR DESCRIPTION
This adds a generic error handler for catch-alls runtime errors. I realized we needed this when working in storybooks and hitting a syntax error and thinking things through: if `getDerivedStateFromError` is present, then it will rerender the component for a fallback, but if theres an error, it will call `getDerivedStateFromError`, which will rerender -- etc. So this adds more safety for all other cases, which should be in place anyway. 