### PR TITLE
[Search] Fix tab UI spacing

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -64,7 +64,7 @@ export class NavigationTabs extends React.Component<Props> {
         }}
         key={to}
       >
-        <Flex>
+        <Flex mr={[0, 2]}>
           {text}
           {count != null && (
             <Sans ml={0.5} size="3t" weight="regular">


### PR DESCRIPTION
Somewhere the spacing between the tabs in the search bar disappeared: 

Before: 
<img width="324" alt="Screen Shot 2020-03-17 at 11 51 00 PM" src="https://user-images.githubusercontent.com/236943/76933372-2c965480-68aa-11ea-8ac7-488e525b3bec.png">

After: 
<img width="298" alt="Screen Shot 2020-03-17 at 11 52 04 PM" src="https://user-images.githubusercontent.com/236943/76933447-53ed2180-68aa-11ea-8165-2991c1bb5e55.png">

#trivial 