### PR TITLE
Update remaining mediator calls

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -14,9 +14,11 @@ import { Mediator, SystemContext } from "Artsy"
 import React, { SFC, useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
+import { openAuthModal } from "Utils/openAuthModal"
 import { Media } from "Utils/Responsive"
 
 import { Box, Button, Flex, Image, Separator, Spacer } from "@artsy/palette"
+import { ModalType } from "Components/Authentication/Types"
 import { useTracking } from "react-tracking"
 import { get } from "Utils/get"
 
@@ -319,8 +321,8 @@ const renderPricing = (salePrice, user, mediator, size) => {
         mb={buttonMargin}
         onClick={() => {
           mediator &&
-            mediator.trigger("open:auth", {
-              mode: "register",
+            openAuthModal(mediator, {
+              mode: ModalType.login,
               copy: "Log in to see full auction records — for free",
             })
         }}
@@ -353,8 +355,8 @@ const renderEstimate = (estimatedPrice, user, mediator, size) => {
       <Link
         onClick={() => {
           mediator &&
-            mediator.trigger("open:auth", {
-              mode: "register",
+            openAuthModal(mediator, {
+              mode: ModalType.signup,
               copy: "Sign up to see full auction records — for free",
             })
         }}
@@ -387,8 +389,8 @@ const renderRealizedPrice = (estimatedPrice, user, mediator, size) => {
       <Link
         onClick={() => {
           mediator &&
-            mediator.trigger("open:auth", {
-              mode: "register",
+            openAuthModal(mediator, {
+              mode: ModalType.signup,
               copy: "Sign up to see full auction records — for free",
             })
         }}

--- a/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -20,6 +20,7 @@ import {
 import { SystemQueryRenderer as QueryRenderer } from "Artsy/Relay/SystemQueryRenderer"
 import { ErrorModal } from "Components/Modal/ErrorModal"
 import createLogger from "Utils/logger"
+import { openAuthModal } from "Utils/openAuthModal"
 
 import { RequestConditionReport_artwork } from "__generated__/RequestConditionReport_artwork.graphql"
 import { RequestConditionReport_me } from "__generated__/RequestConditionReport_me.graphql"
@@ -28,6 +29,7 @@ import {
   RequestConditionReportMutationResponse,
 } from "__generated__/RequestConditionReportMutation.graphql"
 import { RequestConditionReportQuery } from "__generated__/RequestConditionReportQuery.graphql"
+import { ModalType } from "Components/Authentication/Types"
 
 const logger = createLogger(
   "Apps/Artwork/Components/ArtworkDetails/RequestConditionReport"
@@ -93,14 +95,14 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
   }
 
   const handleLoginClick = () => {
+    // TODO: do we need this tracking?
     trackEvent({
       action_type: Schema.ActionType.Click,
       subject: Schema.Subject.Login,
       sale_artwork_id: artwork.saleArtwork.internalID,
     })
-
-    mediator.trigger("open:auth", {
-      mode: "login",
+    openAuthModal(mediator, {
+      mode: ModalType.login,
       redirectTo: location.href,
     })
   }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -16,6 +16,7 @@ import { ArtworkSidebarCommercialOrderMutation } from "__generated__/ArtworkSide
 import { Mediator, SystemContext } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
+import { ModalType } from "Components/Authentication/Types"
 import { ErrorModal } from "Components/Modal/ErrorModal"
 import currency from "currency.js"
 import { Router } from "found"
@@ -29,6 +30,7 @@ import {
 import { ErrorWithMetadata } from "Utils/errors"
 import { get } from "Utils/get"
 import createLogger from "Utils/logger"
+import { openAuthModal } from "Utils/openAuthModal"
 import { ArtworkSidebarSizeInfoFragmentContainer as SizeInfo } from "./ArtworkSidebarSizeInfo"
 
 type EditionSet = ArtworkSidebarCommercial_artwork["edition_sets"][0]
@@ -249,8 +251,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         }
       })
     } else {
-      mediator.trigger("open:auth", {
-        mode: "login",
+      openAuthModal(mediator, {
+        mode: ModalType.login,
         redirectTo: location.href,
       })
     }
@@ -338,8 +340,8 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         }
       })
     } else {
-      mediator.trigger("open:auth", {
-        mode: "login",
+      openAuthModal(mediator, {
+        mode: ModalType.login,
         redirectTo: location.href,
       })
     }


### PR DESCRIPTION
Moves all remaining auth modal triggers to use `openAuthModal` helper. Follow up to #3264 