### PR TITLE
Mobile nav menu analytics

### DIFF
--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -288,6 +288,7 @@ export enum ContextModule {
   HeaderMoreDropdown = "HeaderMoreDropdown",
   HeaderUserDropdown = "HeaderUserDropdown",
   HeaderActivityDropdown = "HeaderActivityDropdown",
+  HeaderArtworksDropdown = "HeaderArtworksDropdown",
 
   /**
    * Artist page

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -289,6 +289,7 @@ export enum ContextModule {
   HeaderUserDropdown = "HeaderUserDropdown",
   HeaderActivityDropdown = "HeaderActivityDropdown",
   HeaderArtworksDropdown = "HeaderArtworksDropdown",
+  HeaderArtistsDropdown = "HeaderArtistsDropdown",
 
   /**
    * Artist page

--- a/src/Components/NavBar/Menus/MobileLink.tsx
+++ b/src/Components/NavBar/Menus/MobileLink.tsx
@@ -1,9 +1,12 @@
+import { AnalyticsSchema } from "Artsy"
+import { useTracking } from "Artsy/Analytics"
 import React, { useState } from "react"
 import styled from "styled-components"
 
 import { Box, color, Link, Sans } from "@artsy/palette"
 
 interface MobileLinkProps {
+  contextModule?: string
   children: React.ReactNode
   href?: string
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void
@@ -12,10 +15,22 @@ interface MobileLinkProps {
 export const MobileLink: React.FC<MobileLinkProps> = ({
   href,
   children,
+  contextModule,
   ...props
 }) => {
   const [isPressed, setPressed] = useState(false)
   const bg = isPressed ? "black5" : "white100"
+  const { trackEvent } = useTracking()
+
+  const handleClickTracking = (linkHref: string) => {
+    trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
+      context_module: contextModule,
+      flow: "Header",
+      subject: children.toString(),
+      destination_path: linkHref,
+    })
+  }
 
   return (
     <MobileLinkContainer
@@ -28,7 +43,11 @@ export const MobileLink: React.FC<MobileLinkProps> = ({
     >
       <Box>
         {href ? (
-          <Link href={href} underlineBehavior="none">
+          <Link
+            href={href}
+            underlineBehavior="none"
+            onClick={() => handleClickTracking(href)}
+          >
             <Sans size={["5t", "6"]} color={color("black60")}>
               {children}
             </Sans>

--- a/src/Components/NavBar/Menus/MobileLink.tsx
+++ b/src/Components/NavBar/Menus/MobileLink.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components"
 import { Box, color, Link, Sans } from "@artsy/palette"
 
 interface MobileLinkProps {
-  contextModule?: string
+  contextModule?: any
   children: React.ReactNode
   href?: string
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void
@@ -21,13 +21,14 @@ export const MobileLink: React.FC<MobileLinkProps> = ({
   const [isPressed, setPressed] = useState(false)
   const bg = isPressed ? "black5" : "white100"
   const { trackEvent } = useTracking()
+  const text = children.toString()
 
   const handleClickTracking = (linkHref: string) => {
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,
       context_module: contextModule,
       flow: "Header",
-      subject: children.toString(),
+      subject: text,
       destination_path: linkHref,
     })
   }

--- a/src/Components/NavBar/Menus/MobileLink.tsx
+++ b/src/Components/NavBar/Menus/MobileLink.tsx
@@ -15,7 +15,7 @@ interface MobileLinkProps {
 export const MobileLink: React.FC<MobileLinkProps> = ({
   href,
   children,
-  contextModule,
+  contextModule = AnalyticsSchema.ContextModule.Header,
   ...props
 }) => {
   const [isPressed, setPressed] = useState(false)

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -33,46 +33,13 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
             <MobileSubmenuLink menu={(artists as MenuLinkData).menu}>
               {(artists as MenuLinkData).menu.title}
             </MobileSubmenuLink>
-            <MobileLink
-              href="/auctions"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Auctions
-            </MobileLink>
-            <MobileLink
-              href="/articles"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Editorial
-            </MobileLink>
-            <MobileLink
-              href="/galleries"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Galleries
-            </MobileLink>
-            <MobileLink
-              href="/fairs"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Fairs
-            </MobileLink>
-            <MobileLink
-              href="/shows"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Shows
-            </MobileLink>
-            <MobileLink
-              href="/institutions"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
-              Museums
-            </MobileLink>
-            <MobileLink
-              href="/gallery-partnerships"
-              contextModule={AnalyticsSchema.ContextModule.Header}
-            >
+            <MobileLink href="/auctions">Auctions</MobileLink>
+            <MobileLink href="/articles">Editorial</MobileLink>
+            <MobileLink href="/galleries">Galleries</MobileLink>
+            <MobileLink href="/fairs">Fairs</MobileLink>
+            <MobileLink href="/shows">Shows</MobileLink>
+            <MobileLink href="/institutions">Museums</MobileLink>
+            <MobileLink href="/gallery-partnerships">
               Partner with Artsy
             </MobileLink>
             {user ? <LoggedInLinks /> : <AuthenticateLinks />}
@@ -103,7 +70,7 @@ export const AnimatingMenuWrapper = styled.div<{
 
   top: 0;
   left: 0; /* might be simpler to just animate this instead of the transform3d business */
-  padding: 1em;
+  padding: 1em 20px;
 
   transform: translate3d(${p => (p.isOpen ? "0" : "100%")}, 0, 0);
   transition: transform 0.15s;
@@ -134,7 +101,6 @@ export const BackLink = () => {
   return (
     <Box
       position="absolute"
-      top="-6px"
       onClick={e => {
         e.preventDefault()
         trackEvent({
@@ -149,10 +115,10 @@ export const BackLink = () => {
       <ChevronIcon
         direction="left"
         color={color("black100")}
-        height="10px"
-        width="10px"
-        top="7px"
-        left="5px"
+        height="14px"
+        width="14px"
+        top="5px"
+        left="-2px"
       />
     </Box>
   )
@@ -220,9 +186,9 @@ export const MobileSubmenuLink = ({ children, menu }) => {
         <ChevronIcon
           direction="right"
           color={color("black60")}
-          height="10px"
-          width="10px"
-          top="7px"
+          height="14px"
+          width="14px"
+          top="6px"
           left="5px"
         />
       </Flex>
@@ -241,13 +207,11 @@ const AuthenticateLinks = () => {
       <Separator my={1} color={color("black10")} />
       <MobileLink
         href={"/sign_up?intent=signup&trigger=click&contextModule=Header"}
-        contextModule={AnalyticsSchema.ContextModule.Header}
       >
         Sign Up
       </MobileLink>
       <MobileLink
         href={"/log_in?intent=signup&trigger=click&contextModule=Header"}
-        contextModule={AnalyticsSchema.ContextModule.Header}
       >
         Login
       </MobileLink>
@@ -259,18 +223,8 @@ const LoggedInLinks = () => {
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
-      <MobileLink
-        href="/works-for-you"
-        contextModule={AnalyticsSchema.ContextModule.Header}
-      >
-        Works for you
-      </MobileLink>
-      <MobileLink
-        href="/user/edit"
-        contextModule={AnalyticsSchema.ContextModule.Header}
-      >
-        Account
-      </MobileLink>
+      <MobileLink href="/works-for-you">Works for you</MobileLink>
+      <MobileLink href="/user/edit">Account</MobileLink>
     </Box>
   )
 }

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -19,19 +19,7 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
   const {
     links: [artworks, artists],
   } = props.menuData
-
   const { user } = useSystemContext()
-  const { trackEvent } = useTracking()
-
-  const handleClickTracking = (href: string, text: string) => {
-    trackEvent({
-      action_type: AnalyticsSchema.ActionType.Click,
-      context_module: AnalyticsSchema.ContextModule.Header,
-      flow: "Header",
-      subject: text,
-      destination_path: href,
-    })
-  }
 
   return (
     <NavigatorContextProvider>
@@ -47,60 +35,43 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
             </MobileSubmenuLink>
             <MobileLink
               href="/auctions"
-              onClick={() => {
-                handleClickTracking("/auctions", "Auctions")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Auctions
             </MobileLink>
             <MobileLink
               href="/articles"
-              onClick={() => {
-                handleClickTracking("/articles", "Editorial")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Editorial
             </MobileLink>
             <MobileLink
               href="/galleries"
-              onClick={() => {
-                handleClickTracking("/galleries", "Galleries")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Galleries
             </MobileLink>
             <MobileLink
               href="/fairs"
-              onClick={() => {
-                handleClickTracking("/fairs", "Fairs")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Fairs
             </MobileLink>
             <MobileLink
               href="/shows"
-              onClick={() => {
-                handleClickTracking("/shows", "Shows")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Shows
             </MobileLink>
             <MobileLink
               href="/institutions"
-              onClick={() => {
-                handleClickTracking("/institutions", "Museums")
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Museums
             </MobileLink>
             <MobileLink
               href="/gallery-partnerships"
-              onClick={() => {
-                handleClickTracking(
-                  "/gallery-partnerships",
-                  "Partner with Artsy"
-                )
-              }}
+              contextModule={AnalyticsSchema.ContextModule.Header}
             >
               Partner with Artsy
             </MobileLink>
@@ -202,7 +173,6 @@ const getContextModule = () => {
 
 const NavLink = ({ link }) => {
   const isSubMenu = !!link.menu
-  const { trackEvent } = useTracking()
   const contextModule = getContextModule()
 
   if (isSubMenu) {
@@ -215,18 +185,7 @@ const NavLink = ({ link }) => {
   } else {
     return (
       <React.Fragment key={link.href}>
-        <MobileLink
-          href={link.href}
-          onClick={() => {
-            trackEvent({
-              action_type: AnalyticsSchema.ActionType.Click,
-              context_module: contextModule,
-              flow: "Header",
-              subject: link.text,
-              destination_path: link.href,
-            })
-          }}
-        >
+        <MobileLink href={link.href} contextModule={contextModule}>
           {link.text}
         </MobileLink>
         {link.dividerBelow && <Separator my={1} color={color("black10")} />}
@@ -277,38 +236,18 @@ export const MobileSubmenuLink = ({ children, menu }) => {
 }
 
 const AuthenticateLinks = () => {
-  const { trackEvent } = useTracking()
-
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
       <MobileLink
         href={"/sign_up?intent=signup&trigger=click&contextModule=Header"}
-        onClick={() => {
-          trackEvent({
-            action_type: AnalyticsSchema.ActionType.Click,
-            context_module: AnalyticsSchema.ContextModule.Header,
-            flow: "Header",
-            subject: "Sign Up",
-            destination_path:
-              "/sign_up?intent=signup&trigger=click&contextModule=Header",
-          })
-        }}
+        contextModule={AnalyticsSchema.ContextModule.Header}
       >
         Sign Up
       </MobileLink>
       <MobileLink
         href={"/log_in?intent=signup&trigger=click&contextModule=Header"}
-        onClick={() => {
-          trackEvent({
-            action_type: AnalyticsSchema.ActionType.Click,
-            context_module: AnalyticsSchema.ContextModule.Header,
-            flow: "Header",
-            subject: "Login",
-            destination_path:
-              "/log_in?intent=signup&trigger=click&contextModule=Header",
-          })
-        }}
+        contextModule={AnalyticsSchema.ContextModule.Header}
       >
         Login
       </MobileLink>
@@ -317,38 +256,18 @@ const AuthenticateLinks = () => {
 }
 
 const LoggedInLinks = () => {
-  const { trackEvent } = useTracking()
-
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
       <MobileLink
         href="/works-for-you"
-        onClick={() => {
-          trackEvent({
-            action_type: AnalyticsSchema.ActionType.Click,
-            context_module:
-              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
-            flow: "Header",
-            subject: "Works for you",
-            destination_path: "/works-for-you",
-          })
-        }}
+        contextModule={AnalyticsSchema.ContextModule.Header}
       >
-        Works for you{" "}
+        Works for you
       </MobileLink>
       <MobileLink
         href="/user/edit"
-        onClick={() => {
-          trackEvent({
-            action_type: AnalyticsSchema.ActionType.Click,
-            context_module:
-              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
-            flow: "Header",
-            subject: "Account",
-            destination_path: "/user/edit",
-          })
-        }}
+        contextModule={AnalyticsSchema.ContextModule.Header}
       >
         Account
       </MobileLink>

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -1,6 +1,6 @@
 import { Box, ChevronIcon, color, Flex, Sans, Separator } from "@artsy/palette"
 import { AnalyticsSchema, useSystemContext } from "Artsy"
-import { track, useTracking } from "Artsy/Analytics"
+import { useTracking } from "Artsy/Analytics"
 import React from "react"
 import styled from "styled-components"
 import { MenuData, MenuLinkData } from "../menuData"
@@ -221,6 +221,13 @@ export const MobileSubmenuLink = ({ children, menu }) => {
         py={0.5}
         flexDirection="row"
         onClick={() => {
+          trackEvent({
+            context_module:
+              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            flow: "Header",
+            subject: menu.text,
+            destination_path: menu.text,
+          })
           push(menu.title)
         }}
       >

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -287,8 +287,7 @@ const AuthenticateLinks = () => {
         onClick={() => {
           trackEvent({
             action_type: AnalyticsSchema.ActionType.Click,
-            context_module:
-              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            context_module: AnalyticsSchema.ContextModule.Header,
             flow: "Header",
             subject: "Sign Up",
             destination_path:
@@ -303,8 +302,7 @@ const AuthenticateLinks = () => {
         onClick={() => {
           trackEvent({
             action_type: AnalyticsSchema.ActionType.Click,
-            context_module:
-              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            context_module: AnalyticsSchema.ContextModule.Header,
             flow: "Header",
             subject: "Login",
             destination_path:

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -25,7 +25,8 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
 
   const handleClickTracking = (href: string, text: string) => {
     trackEvent({
-      context_module: AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+      action_type: AnalyticsSchema.ActionType.Click,
+      context_module: AnalyticsSchema.ContextModule.Header,
       flow: "Header",
       subject: text,
       destination_path: href,
@@ -154,33 +155,55 @@ const Menu = ({ isOpen, title, links, showBacknav = true }) => {
   )
 }
 
-const BackLink = () => {
+export const BackLink = () => {
+  const { trackEvent } = useTracking()
   const { pop } = useNavigation()
+  const contextModule = getContextModule()
+
   return (
-    <Box position="absolute" top="-6px">
-      <a
-        href="#"
-        onClick={e => {
-          e.preventDefault()
-          pop()
-        }}
-      >
-        <ChevronIcon
-          direction="left"
-          color={color("black100")}
-          height="10px"
-          width="10px"
-          top="7px"
-          left="5px"
-        />
-      </a>
+    <Box
+      position="absolute"
+      top="-6px"
+      onClick={e => {
+        e.preventDefault()
+        trackEvent({
+          action_type: AnalyticsSchema.ActionType.Click,
+          context_module: contextModule,
+          flow: "Header",
+          subject: "Back link",
+        })
+        pop()
+      }}
+    >
+      <ChevronIcon
+        direction="left"
+        color={color("black100")}
+        height="10px"
+        width="10px"
+        top="7px"
+        left="5px"
+      />
     </Box>
   )
+}
+
+const getContextModule = () => {
+  const { path } = useNavigation()
+  let contextModule
+  if (path[0] === "Artworks") {
+    contextModule = AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+  } else if (path[0] === "Artists") {
+    contextModule = AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+  } else {
+    contextModule = AnalyticsSchema.ContextModule.Header
+  }
+  return contextModule
 }
 
 const NavLink = ({ link }) => {
   const isSubMenu = !!link.menu
   const { trackEvent } = useTracking()
+  const contextModule = getContextModule()
 
   if (isSubMenu) {
     return (
@@ -196,8 +219,8 @@ const NavLink = ({ link }) => {
           href={link.href}
           onClick={() => {
             trackEvent({
-              context_module:
-                AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+              action_type: AnalyticsSchema.ActionType.Click,
+              context_module: contextModule,
               flow: "Header",
               subject: link.text,
               destination_path: link.href,
@@ -215,20 +238,21 @@ const NavLink = ({ link }) => {
 export const MobileSubmenuLink = ({ children, menu }) => {
   const { trackEvent } = useTracking()
   const { path, push } = useNavigation()
+  const contextModule = getContextModule()
+
   return (
     <li>
       <Flex
         py={0.5}
         flexDirection="row"
         onClick={() => {
-          trackEvent({
-            context_module:
-              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
-            flow: "Header",
-            subject: menu.text,
-            destination_path: menu.text,
-          })
           push(menu.title)
+          trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
+            context_module: contextModule,
+            flow: "Header",
+            subject: menu.title,
+          })
         }}
       >
         <Sans size={["5t", "6"]} color={color("black60")}>
@@ -262,6 +286,7 @@ const AuthenticateLinks = () => {
         href={"/sign_up?intent=signup&trigger=click&contextModule=Header"}
         onClick={() => {
           trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
             context_module:
               AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
             flow: "Header",
@@ -277,6 +302,7 @@ const AuthenticateLinks = () => {
         href={"/log_in?intent=signup&trigger=click&contextModule=Header"}
         onClick={() => {
           trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
             context_module:
               AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
             flow: "Header",
@@ -302,6 +328,7 @@ const LoggedInLinks = () => {
         href="/works-for-you"
         onClick={() => {
           trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
             context_module:
               AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
             flow: "Header",
@@ -316,6 +343,7 @@ const LoggedInLinks = () => {
         href="/user/edit"
         onClick={() => {
           trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
             context_module:
               AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
             flow: "Header",

--- a/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/NewMobileNavMenu.tsx
@@ -1,5 +1,6 @@
 import { Box, ChevronIcon, color, Flex, Sans, Separator } from "@artsy/palette"
-import { useSystemContext } from "Artsy"
+import { AnalyticsSchema, useSystemContext } from "Artsy"
+import { track, useTracking } from "Artsy/Analytics"
 import React from "react"
 import styled from "styled-components"
 import { MenuData, MenuLinkData } from "../menuData"
@@ -20,6 +21,16 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
   } = props.menuData
 
   const { user } = useSystemContext()
+  const { trackEvent } = useTracking()
+
+  const handleClickTracking = (href: string, text: string) => {
+    trackEvent({
+      context_module: AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+      flow: "Header",
+      subject: text,
+      destination_path: href,
+    })
+  }
 
   return (
     <NavigatorContextProvider>
@@ -33,13 +44,63 @@ export const NewMobileNavMenu: React.FC<Props> = props => {
             <MobileSubmenuLink menu={(artists as MenuLinkData).menu}>
               {(artists as MenuLinkData).menu.title}
             </MobileSubmenuLink>
-            <MobileLink href="/auctions">Auctions</MobileLink>
-            <MobileLink href="/articles">Editorial</MobileLink>
-            <MobileLink href="/galleries">Galleries</MobileLink>
-            <MobileLink href="/fairs">Fairs</MobileLink>
-            <MobileLink href="/shows">Shows</MobileLink>
-            <MobileLink href="/institutions">Museums</MobileLink>
-            <MobileLink href="/gallery-partnerships">
+            <MobileLink
+              href="/auctions"
+              onClick={() => {
+                handleClickTracking("/auctions", "Auctions")
+              }}
+            >
+              Auctions
+            </MobileLink>
+            <MobileLink
+              href="/articles"
+              onClick={() => {
+                handleClickTracking("/articles", "Editorial")
+              }}
+            >
+              Editorial
+            </MobileLink>
+            <MobileLink
+              href="/galleries"
+              onClick={() => {
+                handleClickTracking("/galleries", "Galleries")
+              }}
+            >
+              Galleries
+            </MobileLink>
+            <MobileLink
+              href="/fairs"
+              onClick={() => {
+                handleClickTracking("/fairs", "Fairs")
+              }}
+            >
+              Fairs
+            </MobileLink>
+            <MobileLink
+              href="/shows"
+              onClick={() => {
+                handleClickTracking("/shows", "Shows")
+              }}
+            >
+              Shows
+            </MobileLink>
+            <MobileLink
+              href="/institutions"
+              onClick={() => {
+                handleClickTracking("/institutions", "Museums")
+              }}
+            >
+              Museums
+            </MobileLink>
+            <MobileLink
+              href="/gallery-partnerships"
+              onClick={() => {
+                handleClickTracking(
+                  "/gallery-partnerships",
+                  "Partner with Artsy"
+                )
+              }}
+            >
               Partner with Artsy
             </MobileLink>
             {user ? <LoggedInLinks /> : <AuthenticateLinks />}
@@ -119,6 +180,8 @@ const BackLink = () => {
 
 const NavLink = ({ link }) => {
   const isSubMenu = !!link.menu
+  const { trackEvent } = useTracking()
+
   if (isSubMenu) {
     return (
       <React.Fragment key={link.menu.title}>
@@ -129,7 +192,20 @@ const NavLink = ({ link }) => {
   } else {
     return (
       <React.Fragment key={link.href}>
-        <MobileLink href={link.href}>{link.text}</MobileLink>
+        <MobileLink
+          href={link.href}
+          onClick={() => {
+            trackEvent({
+              context_module:
+                AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+              flow: "Header",
+              subject: link.text,
+              destination_path: link.href,
+            })
+          }}
+        >
+          {link.text}
+        </MobileLink>
         {link.dividerBelow && <Separator my={1} color={color("black10")} />}
       </React.Fragment>
     )
@@ -137,6 +213,7 @@ const NavLink = ({ link }) => {
 }
 
 export const MobileSubmenuLink = ({ children, menu }) => {
+  const { trackEvent } = useTracking()
   const { path, push } = useNavigation()
   return (
     <li>
@@ -169,16 +246,38 @@ export const MobileSubmenuLink = ({ children, menu }) => {
 }
 
 const AuthenticateLinks = () => {
+  const { trackEvent } = useTracking()
+
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
       <MobileLink
         href={"/sign_up?intent=signup&trigger=click&contextModule=Header"}
+        onClick={() => {
+          trackEvent({
+            context_module:
+              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            flow: "Header",
+            subject: "Sign Up",
+            destination_path:
+              "/sign_up?intent=signup&trigger=click&contextModule=Header",
+          })
+        }}
       >
         Sign Up
       </MobileLink>
       <MobileLink
         href={"/log_in?intent=signup&trigger=click&contextModule=Header"}
+        onClick={() => {
+          trackEvent({
+            context_module:
+              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            flow: "Header",
+            subject: "Login",
+            destination_path:
+              "/log_in?intent=signup&trigger=click&contextModule=Header",
+          })
+        }}
       >
         Login
       </MobileLink>
@@ -187,11 +286,39 @@ const AuthenticateLinks = () => {
 }
 
 const LoggedInLinks = () => {
+  const { trackEvent } = useTracking()
+
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
-      <MobileLink href="/works-for-you">Works for you </MobileLink>
-      <MobileLink href="/user/edit">Account</MobileLink>
+      <MobileLink
+        href="/works-for-you"
+        onClick={() => {
+          trackEvent({
+            context_module:
+              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            flow: "Header",
+            subject: "Works for you",
+            destination_path: "/works-for-you",
+          })
+        }}
+      >
+        Works for you{" "}
+      </MobileLink>
+      <MobileLink
+        href="/user/edit"
+        onClick={() => {
+          trackEvent({
+            context_module:
+              AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+            flow: "Header",
+            subject: "Account",
+            destination_path: "/user/edit",
+          })
+        }}
+      >
+        Account
+      </MobileLink>
     </Box>
   )
 }

--- a/src/Components/NavBar/Menus/__tests__/MobileLink.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MobileLink.test.tsx
@@ -1,0 +1,41 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
+import { mount } from "enzyme"
+import React from "react"
+import { MobileLink } from "../MobileLink"
+
+jest.mock("Artsy/Analytics/useTracking")
+
+describe("", () => {
+  const trackEvent = jest.fn()
+  const getWrapper = () => {
+    return mount(
+      <MobileLink href="/auctions" contextModule="Header">
+        Auctions
+      </MobileLink>
+    )
+  }
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("tracks MobileLink clicks", () => {
+    const mobileLink = getWrapper().find("Link")
+
+    mobileLink.first().simulate("click")
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      action_type: "Click",
+      context_module: "Header",
+      flow: "Header",
+      subject: "Auctions",
+      destination_path: "/auctions",
+    })
+  })
+})

--- a/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
@@ -1,7 +1,6 @@
 import { SystemContextProvider } from "Artsy"
 import { mount } from "enzyme"
 import React from "react"
-
 import { menuData, SimpleLinkData } from "../../menuData"
 import { MobileLink } from "../MobileLink"
 import {
@@ -9,6 +8,12 @@ import {
   MobileSubmenuLink,
   NewMobileNavMenu,
 } from "../NewMobileNavMenu"
+
+jest.mock("Artsy/Analytics/useTracking", () => ({
+  useTracking: () => ({
+    trackEvent: x => x,
+  }),
+}))
 
 describe("MobileNavMenu", () => {
   const getWrapper = props => {

--- a/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
@@ -1,21 +1,20 @@
 import { SystemContextProvider } from "Artsy"
+import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount } from "enzyme"
 import React from "react"
 import { menuData, SimpleLinkData } from "../../menuData"
 import { MobileLink } from "../MobileLink"
 import {
   AnimatingMenuWrapper,
+  BackLink,
   MobileSubmenuLink,
   NewMobileNavMenu,
 } from "../NewMobileNavMenu"
 
-jest.mock("Artsy/Analytics/useTracking", () => ({
-  useTracking: () => ({
-    trackEvent: x => x,
-  }),
-}))
+jest.mock("Artsy/Analytics/useTracking")
 
 describe("MobileNavMenu", () => {
+  const trackEvent = jest.fn()
   const getWrapper = props => {
     return mount(
       <SystemContextProvider user={props.user}>
@@ -23,6 +22,16 @@ describe("MobileNavMenu", () => {
       </SystemContextProvider>
     )
   }
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   describe("nav structure", () => {
     it("renders the correct items when logged out", () => {
@@ -59,6 +68,68 @@ describe("MobileNavMenu", () => {
       linkText = linkContainer.text()
       expect(linkText).toContain("Sign Up")
       expect(linkText).not.toContain("Works for you")
+    })
+  })
+
+  describe("Analytics tracking", () => {
+    it("tracks back button click", () => {
+      const wrapper = mount(
+        <SystemContextProvider user={null}>
+          <NewMobileNavMenu isOpen menuData={menuData} />
+        </SystemContextProvider>
+      )
+
+      const backLink = wrapper.find(BackLink)
+      backLink.first().simulate("click")
+      expect(trackEvent).toBeCalledWith({
+        action_type: "Click",
+        context_module: "Header",
+        flow: "Header",
+        subject: "Back link",
+      })
+    })
+
+    it("tracks MobileSubmenuLink click", () => {
+      const wrapper = mount(
+        <SystemContextProvider user={null}>
+          <NewMobileNavMenu isOpen menuData={menuData} />
+        </SystemContextProvider>
+      )
+
+      const mobileSubmenuLinks = wrapper
+        .find(MobileSubmenuLink)
+        .first()
+        .find("Flex")
+      mobileSubmenuLinks.first().simulate("click")
+      expect(trackEvent).toHaveBeenCalledWith({
+        action_type: "Click",
+        context_module: "Header",
+        flow: "Header",
+        subject: "Artworks",
+      })
+    })
+
+    it("tracks MobileLink clicks", () => {
+      const animatingMenuWrapper = mount(
+        <SystemContextProvider user={null}>
+          <NewMobileNavMenu isOpen menuData={menuData} />
+        </SystemContextProvider>
+      ).find(AnimatingMenuWrapper)
+
+      const openWrapper = animatingMenuWrapper.filterWhere(
+        element => element.props().isOpen
+      )
+      const linkContainer = openWrapper.find("ul").at(0)
+      const mobileLinks = linkContainer.children(MobileLink)
+      mobileLinks.first().simulate("click")
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        action_type: "Click",
+        context_module: "Header",
+        flow: "Header",
+        subject: "Auctions",
+        destination_path: "/auctions",
+      })
     })
   })
 })

--- a/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/NewMobileNavMenu.test.tsx
@@ -108,28 +108,5 @@ describe("MobileNavMenu", () => {
         subject: "Artworks",
       })
     })
-
-    it("tracks MobileLink clicks", () => {
-      const animatingMenuWrapper = mount(
-        <SystemContextProvider user={null}>
-          <NewMobileNavMenu isOpen menuData={menuData} />
-        </SystemContextProvider>
-      ).find(AnimatingMenuWrapper)
-
-      const openWrapper = animatingMenuWrapper.filterWhere(
-        element => element.props().isOpen
-      )
-      const linkContainer = openWrapper.find("ul").at(0)
-      const mobileLinks = linkContainer.children(MobileLink)
-      mobileLinks.first().simulate("click")
-
-      expect(trackEvent).toHaveBeenCalledWith({
-        action_type: "Click",
-        context_module: "Header",
-        flow: "Header",
-        subject: "Auctions",
-        destination_path: "/auctions",
-      })
-    })
   })
 })


### PR DESCRIPTION
Addresses: [FX-1829](https://artsyproduct.atlassian.net/browse/FX-1829)

This PR adds analytics tracking to mobile nav menu.

<img width="557" alt="Screen Shot 2020-03-19 at 10 02 12 PM" src="https://user-images.githubusercontent.com/5201004/77130255-93904680-6a2d-11ea-8fbf-057d4fecc036.png">

<img width="633" alt="Screen Shot 2020-03-19 at 10 02 34 PM" src="https://user-images.githubusercontent.com/5201004/77130256-97bc6400-6a2d-11ea-9167-d0ee2126d057.png">

<img width="689" alt="Screen Shot 2020-03-19 at 10 04 02 PM" src="https://user-images.githubusercontent.com/5201004/77130259-9ab75480-6a2d-11ea-8653-851b93ac9c58.png">
