### PR TITLE
Prepopulate email input from URL query string on forgot password page

### DIFF
--- a/src/Components/Authentication/FormSwitcher.tsx
+++ b/src/Components/Authentication/FormSwitcher.tsx
@@ -132,6 +132,19 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
     )
   }
 
+  getEmailValue = (): string => {
+    const { values } = this.props
+    const isClient = typeof window !== "undefined"
+    let email
+
+    if (isClient) {
+      const searchQuery = window.location.search.slice(1)
+      email = qs.parse(searchQuery).email as string
+    }
+
+    return email || values.email || ""
+  }
+
   render() {
     const {
       error,
@@ -180,8 +193,9 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
     }
 
     const { handleSubmit, onBackButtonClicked, values } = this.props
+
     const defaultValues = {
-      email: values.email || "",
+      email: this.getEmailValue(),
       password: values.password || "",
       name: values.name || "",
       accepted_terms_of_service: values.accepted_terms_of_service || false,

--- a/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@artsy/palette"
+import QuickInput from "Components/QuickInput"
 import { mount } from "enzyme"
 import React from "react"
 import { ForgotPasswordForm } from "../Desktop/ForgotPasswordForm"
@@ -46,6 +47,20 @@ describe("FormSwitcher", () => {
     it("forgot password form", () => {
       const wrapper = getWrapper({ type: ModalType.forgot })
       expect(wrapper.find(ForgotPasswordForm).length).toEqual(1)
+    })
+
+    it("prepopulates email input from URL query string", () => {
+      window.history.replaceState(
+        {},
+        "Reset your password",
+        "/forgot?email=user@example.com"
+      )
+
+      const wrapper = getWrapper({ type: ModalType.forgot })
+
+      expect(wrapper.find(ForgotPasswordForm).length).toEqual(1)
+      expect(wrapper.html()).toContain("user@example.com")
+      expect(wrapper.find(QuickInput).prop("value")).toEqual("user@example.com")
     })
   })
 


### PR DESCRIPTION
Links to the reset password page will often include a query param including the target user's email address. This commit uses that value to prepopulate the reset password form, simplifying the experience.

Co-authored-by: @anandaroop 

jira :lock: : https://artsyproduct.atlassian.net/browse/TRUST-92