### PR TITLE
Updates size on 3rd display ad on standard desktop

### DIFF
--- a/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
+++ b/src/Components/Publishing/Layouts/__tests__/StandardLayout.test.tsx
@@ -133,14 +133,14 @@ describe("Standard Article", () => {
         .find(DisplayAd)
         .at(1)
         .props().adDimension
-    ).toBe("970x250")
+    ).toBe("300x250")
 
     expect(
       article
         .find(DisplayAd)
         .at(1)
         .props().adUnit
-    ).toBe("Desktop_TopLeaderboard")
+    ).toBe("Desktop_RightRail1")
 
     expect(
       article
@@ -188,7 +188,7 @@ describe("Standard Article", () => {
         .find(DisplayAd)
         .at(1)
         .props().adUnit
-    ).toBe("Mobile_InContentMR2")
+    ).toBe("Desktop_RightRail1")
 
     expect(
       article

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -207,9 +207,7 @@ export class Sections extends Component<Props, State> {
     const { isMobile } = this.props
 
     if (isStandard) {
-      return isMobile
-        ? AdUnit.Mobile_InContentMR2
-        : AdUnit.Desktop_TopLeaderboard
+      return AdUnit.Desktop_RightRail1
     }
 
     if (index === indexAtFirstAd) {
@@ -257,10 +255,11 @@ export class Sections extends Component<Props, State> {
   getAdDimension(isStandard: boolean): AdDimension {
     const { isMobile, isSponsored } = this.props
 
+    if (isStandard) {
+      return AdDimension.Desktop_RightRail1
+    }
+
     if (isMobile) {
-      if (isStandard) {
-        return AdDimension.Mobile_InContentMR2
-      }
       if (isSponsored) {
         return AdDimension.Mobile_Sponsored_Feature_InContentLeaderboard1
       }
@@ -360,7 +359,7 @@ export class Sections extends Component<Props, State> {
         indexAtFirstAd = indexAtFirstAd === null ? index : indexAtFirstAd // only set this value once; after the index where 1st ad injection is found
 
         ad = (
-          <AdWrapper mt={marginTop} isStandardArticle={isStandardArticle}>
+          <AdWrapper mt={marginTop} layout={articleType}>
             <DisplayAd
               adUnit={this.getAdUnit(
                 placementCount,
@@ -487,7 +486,7 @@ export const StyledSections = styled.div<{ layout: string }>`
     ${layout === "feature" ? "margin: 30px auto 0 auto" : ""}
   `}
 `
-const AdWrapper = styled(Box)<{ isStandardArticle: boolean }>`
-  width: ${p => (p.isStandardArticle ? "101vw" : "100vw")};
-  margin-left: ${p => (p.isStandardArticle ? "-4vw" : "calc(-50vw + 50%)")};
+const AdWrapper = styled(Box)<{ layout: string }>`
+  width: ${p => (p.layout === "standard" ? "100%" : "100vw")};
+  margin-left: ${p => (p.layout === "standard" ? "0" : "calc(-50vw + 50%)")};
 `

--- a/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Sections.test.tsx
@@ -284,7 +284,7 @@ describe("Sections", () => {
 
       const ad = ads.at(0).props()
 
-      expect(ad.adUnit).toBe("Mobile_InContentMR2")
+      expect(ad.adUnit).toBe("Desktop_RightRail1")
       expect(ad.adDimension).toBe("300x250")
     })
   })

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -679,8 +679,8 @@ exports[`Sections snapshots tests renders properly 1`] = `
 
 .c23 {
   margin-top: calc(100% - 96%);
-  width: 101vw;
-  margin-left: -4vw;
+  width: 100%;
+  margin-left: 0;
 }
 
 @media screen and (min-width:40em) {
@@ -1674,7 +1674,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
             style={
               Object {
                 "height": 250,
-                "width": 970,
+                "width": 300,
               }
             }
           />


### PR DESCRIPTION
The 3rd ad on Standard Articles should be 300x250 on mobile and desktop. This PR updates that from 970-250 on desktop.

https://artsyproduct.atlassian.net/browse/FX-1837

Desktop:
![Screen Shot 2020-03-20 at 5 18 26 PM](https://user-images.githubusercontent.com/10385964/77208785-f12a9e80-6ad2-11ea-9f81-edc37e03ee8d.png)


Mobile:
![Screen Shot 2020-03-20 at 5 59 51 PM](https://user-images.githubusercontent.com/10385964/77209466-b164b680-6ad4-11ea-8e6f-3b3b69afb6da.png)
![Screen Shot 2020-03-20 at 6 00 02 PM](https://user-images.githubusercontent.com/10385964/77209467-b1fd4d00-6ad4-11ea-88e6-4301c684499d.png)
![Screen Shot 2020-03-20 at 6 00 08 PM](https://user-images.githubusercontent.com/10385964/77209468-b1fd4d00-6ad4-11ea-8ba8-707169ad17d7.png)
