### PR TITLE
Fix broken pagination on auction results page

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -41,7 +41,14 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 }) => {
   const filterContext = useAuctionResultsFilterContext()
 
-  const { sort, organizations, categories, sizes } = filterContext.filters
+  const {
+    sort,
+    organizations,
+    categories,
+    sizes,
+    createdAfterYear,
+    createdBeforeYear,
+  } = filterContext.filters
 
   const loadNext = () => {
     const { hasNextPage, endCursor } = pageInfo
@@ -65,6 +72,8 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
         categories,
         sizes,
         sort,
+        createdBeforeYear,
+        createdAfterYear,
       },
       null,
       error => {


### PR DESCRIPTION
Fixes [PURCHASE-1844](https://artsyproduct.atlassian.net/browse/PURCHASE-1844)

When adding the year created filter I forgot to pass the new those new parameters to the refetch container which caused pagination to break. 

We should follow up on Monday with a test. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.34.5-canary.3295.55024.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.34.5-canary.3295.55024.0
  # or 
  yarn add @artsy/reaction@25.34.5-canary.3295.55024.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
