### PR TITLE
Update NetworkTimeout language

### DIFF
--- a/src/Artsy/Router/NetworkTimeout.tsx
+++ b/src/Artsy/Router/NetworkTimeout.tsx
@@ -33,6 +33,7 @@ export const NetworkTimeout: React.FC = () => {
 
   return (
     <ErrorModal
+      headerText="Network timeout"
       show={showErrorModal}
       closeText="Retry"
       ctaAction={() => {

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,4 +1,3 @@
-import { NavBar } from "Components/NavBar"
 import React from "react"
 import { ErrorWithMetadata } from "Utils/errors"
 import createLogger from "Utils/logger"
@@ -79,7 +78,6 @@ const ErrorModalWithReload: React.FC<{ message?: string; show: boolean }> = ({
 }) => {
   return (
     <>
-      <NavBar />
       <ErrorModal
         show={show}
         detailText={message}

--- a/src/Components/__tests__/ErrorBoundary.test.tsx
+++ b/src/Components/__tests__/ErrorBoundary.test.tsx
@@ -2,10 +2,6 @@ import { ErrorBoundary } from "Components/ErrorBoundary"
 import { mount } from "enzyme"
 import React from "react"
 
-jest.mock("Components/NavBar", () => ({
-  NavBar: () => <div />,
-}))
-
 describe("ErrorBoundary", () => {
   const errorLog = console.error
 


### PR DESCRIPTION
Updates the language on the network timeout to be something a bit more specific:
"An error occurred" => "Network timeout"

Also removes the faux nav from the ErrorBoundary state as it conflicts with a few different scenarios (app sections that don't have a nav, etc). 