### PR TITLE
Adds social_embed section type to ad insertion logic

### DIFF
--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -309,11 +309,12 @@ export class Sections extends Component<Props, State> {
        *  section (on Features) and after the 2nd text + image_collection OR image_set on Standard Articles.
        * */
 
-      // calculate if a section is a text + image set/collection
+      // calculate if a section is a text + image set/collection/social_embed
       if (
         prevSection?.type === "text" &&
         (sectionItem.type === "image_collection" ||
-          sectionItem.type === "image_set")
+          sectionItem.type === "image_set" ||
+          sectionItem.type === "social_embed")
       ) {
         textAndImageSection++
       }


### PR DESCRIPTION
Social Embed sections types were missing from the logic that determines if an ad should be rendered in a standard article section, this PR addresses that.

After fix:
![Screen Shot 2020-03-23 at 12 05 21 PM](https://user-images.githubusercontent.com/10385964/77337071-cae94680-6cfe-11ea-889f-6b8e4f0cbb95.png)

Before fix:
![Screen Shot 2020-03-23 at 12 07 45 PM](https://user-images.githubusercontent.com/10385964/77337189-f10ee680-6cfe-11ea-932d-3e164760ba83.png)
