### PR TITLE
Add year created filter reset link

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -1,4 +1,5 @@
 import { Flex, LargeSelect, Spacer, Toggle } from "@artsy/palette"
+import { FilterResetLink } from "Components/FilterResetLink"
 import React, { useMemo } from "react"
 import { useAuctionResultsFilterContext } from "../../AuctionResultsFilterContext"
 
@@ -26,13 +27,29 @@ export const YearCreated: React.FC = () => {
     console.error("Couldn't display year created filter due to missing data")
     return null
   }
+  const hasChanges =
+    earliestCreatedYear !== createdAfterYear ||
+    latestCreatedYear !== createdBeforeYear
   const fullDateRange = useMemo(
     () => buildDateRange(earliestCreatedYear, latestCreatedYear),
     [earliestCreatedYear, latestCreatedYear]
   )
+  const resetFilter = useMemo(
+    () => () => {
+      filterContext.setFilter("createdAfterYear", earliestCreatedYear)
+      filterContext.setFilter("createdBeforeYear", latestCreatedYear)
+    },
+    [earliestCreatedYear, latestCreatedYear]
+  )
 
   return (
-    <Toggle label="Year Created" expanded>
+    <Toggle
+      label="Year Created"
+      expanded
+      renderSecondaryAction={() => (
+        <FilterResetLink onReset={resetFilter} hasChanges={hasChanges} />
+      )}
+    >
       <Flex>
         <LargeSelect
           title="Earliest"

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -4,6 +4,7 @@ import { AuctionResultsRouteFragmentContainer as AuctionResultsRoute } from "App
 import { MockBoot, renderRelayTree } from "DevTools"
 import { ReactWrapper } from "enzyme"
 import React from "react"
+import { act } from "react-dom/test-utils"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { Breakpoint } from "Utils/Responsive"
@@ -85,7 +86,7 @@ describe("AuctionResults", () => {
     })
 
     describe("user interactions", () => {
-      const defualtRelayParams = {
+      const defaultRelayParams = {
         first: 10,
         after: null,
         artistID: "pablo-picasso",
@@ -111,7 +112,7 @@ describe("AuctionResults", () => {
           expect(refetchSpy).toHaveBeenCalledTimes(1)
           expect(refetchSpy.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-              ...defualtRelayParams,
+              ...defaultRelayParams,
               after: "YXJyYXljb25uZWN0aW9uOjk=",
             })
           )
@@ -135,19 +136,19 @@ describe("AuctionResults", () => {
 
               expect(refetchSpy.mock.calls[0][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   categories: ["Work on Paper"],
                 })
               )
               expect(refetchSpy.mock.calls[1][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   categories: ["Work on Paper", "Sculpture"],
                 })
               )
               expect(refetchSpy.mock.calls[2][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   categories: ["Sculpture"],
                 })
               )
@@ -191,19 +192,19 @@ describe("AuctionResults", () => {
 
               expect(refetchSpy.mock.calls[0][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   organizations: ["Christie's"],
                 })
               )
               expect(refetchSpy.mock.calls[1][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   organizations: ["Christie's", "Phillips"],
                 })
               )
               expect(refetchSpy.mock.calls[2][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   organizations: ["Phillips"],
                 })
               )
@@ -228,19 +229,19 @@ describe("AuctionResults", () => {
 
               expect(refetchSpy.mock.calls[0][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   sizes: ["MEDIUM"],
                 })
               )
               expect(refetchSpy.mock.calls[1][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   sizes: ["MEDIUM", "LARGE"],
                 })
               )
               expect(refetchSpy.mock.calls[2][0]).toEqual(
                 expect.objectContaining({
-                  ...defualtRelayParams,
+                  ...defaultRelayParams,
                   sizes: ["LARGE"],
                 })
               )
@@ -267,6 +268,30 @@ describe("AuctionResults", () => {
             })
           })
         })
+        describe("year created filter", () => {
+          const value = v => ({ target: { value: `${v}` } })
+          it("triggers relay refetch with created years and tracks events", () => {
+            const filter = wrapper.find("YearCreated")
+            const selects = filter.find("select")
+
+            act(() => {
+              selects.at(0).simulate("change", value(1900))
+              selects.at(1).simulate("change", value(1960))
+            })
+
+            expect(refetchSpy).toHaveBeenCalledTimes(2)
+
+            expect(refetchSpy.mock.calls[1][0]).toEqual(
+              expect.objectContaining({
+                ...defaultRelayParams,
+                createdAfterYear: 1900,
+                createdBeforeYear: 1960,
+                earliestCreatedYear: 1881,
+                latestCreatedYear: 1973,
+              })
+            )
+          })
+        })
       })
 
       describe("sort", () => {
@@ -282,7 +307,7 @@ describe("AuctionResults", () => {
             expect(refetchSpy).toHaveBeenCalledTimes(1)
             expect(refetchSpy.mock.calls[0][0]).toEqual(
               expect.objectContaining({
-                ...defualtRelayParams,
+                ...defaultRelayParams,
                 sort: "ESTIMATE_AND_DATE_DESC",
               })
             )

--- a/src/Components/FilterResetLink.tsx
+++ b/src/Components/FilterResetLink.tsx
@@ -1,0 +1,32 @@
+import { Link, Sans } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+
+const FadingLink = styled(Link)`
+  transition: opacity 75ms;
+`
+
+interface FilterResetLinkProps {
+  /** Reset link should only appear if there are changes to the filter */
+  hasChanges: boolean
+  onReset: () => void
+}
+
+export const FilterResetLink: React.FC<FilterResetLinkProps> = props => {
+  return (
+    <FadingLink
+      style={{ opacity: props.hasChanges ? 1 : 0 }}
+      href="#"
+      color="black60"
+      onClick={e => {
+        e.preventDefault()
+        if (!props.hasChanges) return
+
+        props?.onReset()
+        e.stopPropagation()
+      }}
+    >
+      <Sans size="1">Reset</Sans>
+    </FadingLink>
+  )
+}


### PR DESCRIPTION
Fixes [1841](https://artsyproduct.atlassian.net/browse/PURCHASE-1841)

Adds a `Reset` link to the year created filter to easily reset it back to the defaults. 

<img width="344" alt="image" src="https://user-images.githubusercontent.com/3087225/77353481-6c7c9200-6d17-11ea-92f1-90a5b7e89401.png">

Based on some feedback Sam C. I added a short fade in animation. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.36.0-canary.3302.55170.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@25.36.0-canary.3302.55170.0
  # or 
  yarn add @artsy/reaction@25.36.0-canary.3302.55170.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
