### PR TITLE
Switch props.router.push back to window.locaion.assign for idv flow

### DIFF
--- a/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
+++ b/src/Apps/IdentityVerification/IdentityVerificationApp/index.tsx
@@ -5,7 +5,6 @@ import { AppContainer } from "Apps/Components/AppContainer"
 import * as Schema from "Artsy/Analytics/Schema"
 import { ErrorPage } from "Components/ErrorPage"
 import { ErrorModal } from "Components/Modal/ErrorModal"
-import { Router } from "found"
 import React, { useState } from "react"
 import { Title as HeadTitle } from "react-head"
 import {
@@ -23,10 +22,9 @@ const logger = createLogger("IdentityVerificationApp.tsx")
 interface Props {
   me: IdentityVerificationApp_me
   relay: RelayProp
-  router: Router
 }
 
-const IdentityVerificationApp: React.FC<Props> = ({ me, relay, router }) => {
+const IdentityVerificationApp: React.FC<Props> = ({ me, relay }) => {
   const { identityVerification } = me
   const [requesting, setRequesting] = useState(false)
   const [showErrorModal, setShowErrorModal] = useState(false)
@@ -108,7 +106,7 @@ const IdentityVerificationApp: React.FC<Props> = ({ me, relay, router }) => {
   }
 
   const handleMutationSuccess = (identityVerificationFlowUrl: string) => {
-    router.push(identityVerificationFlowUrl)
+    window.location.assign(identityVerificationFlowUrl)
   }
 
   const handleMutationError = (error: Error) => {

--- a/src/Apps/IdentityVerification/__tests__/IdentityVerificationApp.test.tsx
+++ b/src/Apps/IdentityVerification/__tests__/IdentityVerificationApp.test.tsx
@@ -132,9 +132,7 @@ describe("IdentityVerification route", () => {
         const page = await env.buildPage()
 
         await page.clickStartVerification()
-        expect(env.routes.mockPushRoute).toHaveBeenCalledWith(
-          "www.identity.biz"
-        )
+        expect(window.location.assign).toHaveBeenCalledWith("www.identity.biz")
       })
 
       it("user sees an error modal if the mutation fails", async () => {


### PR DESCRIPTION
This is due to a failure to direct the user to the identity verification
flow, probably because that `push()` function is intended for navigating
programatically within the found router on the same domain.

[Bug report on slack](https://artsy.slack.com/archives/CA3D02SDN/p1585152180005500) 🔒 