### PR TITLE
the Address Form component should respect country selection for Euro only shipping

### DIFF
--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -120,7 +120,8 @@ export class AddressForm extends React.Component<
             </Serif>
             <CountrySelect
               selected={
-                lockCountryToOrigin || lockCountriesToEU
+                lockCountryToOrigin ||
+                (lockCountriesToEU && !this.state.address.country)
                   ? this.props.shippingCountry
                   : this.state.address.country
               }
@@ -128,11 +129,13 @@ export class AddressForm extends React.Component<
               disabled={lockCountryToOrigin}
               euShippingOnly={lockCountriesToEU}
             />
-            {lockCountryToOrigin && (
+            {(lockCountryToOrigin || lockCountriesToEU) && (
               <>
                 <Spacer m={0.5} />
                 <Sans size="2" color="black60">
-                  Domestic shipping only.
+                  {lockCountriesToEU
+                    ? "Continental Europe shipping only."
+                    : "Domestic shipping only."}
                 </Sans>
               </>
             )}

--- a/src/Components/__stories__/AddressForm.story.tsx
+++ b/src/Components/__stories__/AddressForm.story.tsx
@@ -39,25 +39,37 @@ class TypicalAddressForm extends React.Component<
   }
 }
 
-storiesOf("Apps/Order/Components", module).add("AddressForm", () => {
-  return (
-    <>
-      <Section title="Blank">
+storiesOf("Components/AddressForm", module)
+  .add("Blank", () => {
+    return (
+      <Section>
         <Flex flexDirection="column">
           <TypicalAddressForm />
         </Flex>
       </Section>
-      <Section title="BlankDomesticOnly">
+    )
+  })
+  .add("Blank DomesticOnly", () => {
+    return (
+      <Section>
         <Flex flexDirection="column">
           <TypicalAddressForm shippingCountry="US" domesticOnly />
         </Flex>
       </Section>
-      <Section title="BlankDomesticEUOnly">
+    )
+  })
+  .add("Blank DomesticEUOnly", () => {
+    return (
+      <Section>
         <Flex flexDirection="column">
           <TypicalAddressForm shippingCountry="DE" domesticOnly euOrigin />
         </Flex>
       </Section>
-      <Section title="Filled out">
+    )
+  })
+  .add("Filled out", () => {
+    return (
+      <Section>
         <Flex flexDirection="column">
           <TypicalAddressForm
             address={{
@@ -73,6 +85,5 @@ storiesOf("Apps/Order/Components", module).add("AddressForm", () => {
           />
         </Flex>
       </Section>
-    </>
-  )
-})
+    )
+  })


### PR DESCRIPTION
The issue here is that when the Form loads technically there is nothing selected. But once the user starts interacting with country select - we need to let this interaction manage the state. The fact that we just set selected to whatever was passes as origin country broke this state interaction.


Hope that fixes this issue: https://artsyproduct.atlassian.net/browse/GALL-2703

Also @lilyfromseattle I think moved the AddressForm to the general components from Order. So I reshuffled the story a bit as well.