### PR TITLE
Video meta bug

### DIFF
--- a/src/Components/Publishing/ArticleMeta.tsx
+++ b/src/Components/Publishing/ArticleMeta.tsx
@@ -95,7 +95,7 @@ export const ArticleMeta: React.SFC<{
         </>
       )}
 
-      {keywords.length && (
+      {keywords.length > 0 && (
         <>
           <meta property="news_keywords" content={keywords} />
           <meta name="keywords" content={keywords} />

--- a/src/Components/Publishing/__tests__/ArticleMeta.test.tsx
+++ b/src/Components/Publishing/__tests__/ArticleMeta.test.tsx
@@ -228,6 +228,14 @@ describe("ArticleMeta", () => {
         "art, community"
       )
     })
+
+    it("does not render keyword meta tags if no keywords", () => {
+      props.article.keywords = []
+      const component = getWrapper()
+      expect(component.find("[name='keywords']")).toHaveLength(0)
+      expect(component.find("[property='news_keywords']")).toHaveLength(0)
+      expect(component.find("[property='article:tag']")).toHaveLength(0)
+    })
   })
 
   it("renders a single author", () => {


### PR DESCRIPTION
This PR fixes a bug in the article meta tags causing a the text 0 to render at the top of video editorial series pages. 

https://artsyproduct.atlassian.net/browse/FX-1875

The Bug:
<img width="1090" alt="Screen Shot 2020-03-25 at 12 27 43 PM" src="https://user-images.githubusercontent.com/10385964/77586427-8dcab300-6ebc-11ea-8c4d-2c1b1441e00e.png">


The Fix:
![Screen Shot 2020-03-25 at 5 15 51 PM](https://user-images.githubusercontent.com/10385964/77586529-bd79bb00-6ebc-11ea-8513-b5f5f66c2845.png)
