### PR TITLE
Ensure year created check doesn't error on nulls

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -21,8 +21,8 @@ export const YearCreated: React.FC = () => {
     createdBeforeYear,
   } = filterContext?.filters
   if (
-    typeof earliestCreatedYear === undefined ||
-    typeof latestCreatedYear === undefined
+    typeof earliestCreatedYear !== "number" ||
+    typeof latestCreatedYear !== "number"
   ) {
     console.error("Couldn't display year created filter due to missing data")
     return null


### PR DESCRIPTION
The original logic check here was checking for an `undefined` type but those results could be `null` too. 

I updated the logic to check for a `number` which is the _exact_ type we're expecting. 