### PR TITLE
[Consignments] Add ArtistConsignButton

### DIFF
--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -15,12 +15,31 @@ import {
   Image,
   Sans,
 } from "@artsy/palette"
+import { AnalyticsSchema, useTracking } from "Artsy"
 
 export interface ArtistConsignButtonProps {
   artist: ArtistConsignButton_artist
 }
 
-export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => {
+export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = ({
+  artist,
+}) => {
+  const tracking = useTracking()
+
+  const trackGetStartedClick = ({ destinationPath }) => {
+    tracking.trackEvent({
+      context_page: AnalyticsSchema.PageName.ArtistPage,
+      context_page_owner_id: artist.internalID,
+      context_page_owner_slug: artist.slug,
+      context_page_owner_type: AnalyticsSchema.OwnerType.Artist,
+      context_module: AnalyticsSchema.ContextModule.ArtistConsignment,
+      subject: AnalyticsSchema.Subject.GetStarted,
+      destination_path: destinationPath,
+    })
+  }
+
+  const props = { artist, trackGetStartedClick }
+
   return (
     <>
       <Media at="xs">
@@ -33,8 +52,13 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
   )
 }
 
-export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = props => {
-  const { artistHasOwnConsignRoute, imageURL, headline, consignLink } = getData(
+interface Tracking {
+  trackGetStartedClick: (props: { destinationPath: string }) => void
+}
+
+export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps &
+  Tracking> = props => {
+  const { artistHasOwnConsignRoute, imageURL, headline, consignURL } = getData(
     props
   )
 
@@ -57,7 +81,14 @@ export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = prop
           </Flex>
         </Flex>
         <Box>
-          <RouterLink to={consignLink}>
+          <RouterLink
+            to={consignURL}
+            onClick={() => {
+              props.trackGetStartedClick({
+                destinationPath: consignURL,
+              })
+            }}
+          >
             <Button variant="secondaryGray">Get started</Button>
           </RouterLink>
         </Box>
@@ -66,8 +97,9 @@ export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = prop
   )
 }
 
-export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps> = props => {
-  const { artistHasOwnConsignRoute, imageURL, headline, consignLink } = getData(
+export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps &
+  Tracking> = props => {
+  const { artistHasOwnConsignRoute, imageURL, headline, consignURL } = getData(
     props
   )
 
@@ -87,7 +119,14 @@ export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps> = prop
             </Sans>
           </Box>
           <Box>
-            <RouterLink to={consignLink}>
+            <RouterLink
+              to={consignURL}
+              onClick={() => {
+                props.trackGetStartedClick({
+                  destinationPath: consignURL,
+                })
+              }}
+            >
               <Button size="small" variant="secondaryGray">
                 Get started
               </Button>
@@ -108,13 +147,13 @@ function getData(props) {
   const headline = artistHasOwnConsignRoute
     ? `Sell your ${name}`
     : "Sell art from your collection"
-  const consignLink = artistHasOwnConsignRoute ? `${href}/consign` : "/consign"
+  const consignURL = artistHasOwnConsignRoute ? `${href}/consign` : "/consign"
 
   return {
     artistHasOwnConsignRoute,
     imageURL,
     headline,
-    consignLink,
+    consignURL,
   }
 }
 
@@ -123,6 +162,8 @@ export const ArtistConsignButtonFragmentContainer = createFragmentContainer(
   {
     artist: graphql`
       fragment ArtistConsignButton_artist on Artist {
+        internalID
+        slug
         name
         href
         image {

--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -34,13 +34,17 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
 }
 
 export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = props => {
-  const { isTop20, imageURL, headline, consignLink } = getData(props)
+  const { artistHasOwnConsignRoute, imageURL, headline, consignLink } = getData(
+    props
+  )
 
   return (
     <BorderBox p={1} width="100%">
       <Flex alignItems="center" width="100%" justifyContent="space-between">
         <Flex>
-          {isTop20 && imageURL && <Image src={imageURL} width={50} height={50} />}
+          {artistHasOwnConsignRoute && imageURL && (
+            <Image src={imageURL} width={50} height={50} />
+          )}
           <Flex flexDirection="column" justifyContent="center" pl={1}>
             <Sans size="3t" weight="medium">
               {headline}
@@ -63,12 +67,16 @@ export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = prop
 }
 
 export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps> = props => {
-  const { isTop20, imageURL, headline, consignLink } = getData(props)
+  const { artistHasOwnConsignRoute, imageURL, headline, consignLink } = getData(
+    props
+  )
 
   return (
     <BorderBox maxWidth={335} p={1}>
       <Flex alignItems="center">
-        {isTop20 && imageURL && <Image src={imageURL} width={75} height={66} />}
+        {artistHasOwnConsignRoute && imageURL && (
+          <Image src={imageURL} width={75} height={66} />
+        )}
         <Flex flexDirection="column" justifyContent="center" pl={1}>
           <Sans size="3t" weight="medium">
             {headline}
@@ -95,15 +103,15 @@ function getData(props) {
   const {
     artist: { href, name, image },
   } = props
-  const isTop20 = Boolean(getConsignmentData(href))
+  const artistHasOwnConsignRoute = Boolean(getConsignmentData(href))
   const imageURL = image?.cropped?.url
-  const headline = isTop20
+  const headline = artistHasOwnConsignRoute
     ? `Sell your ${name}`
     : "Sell art from your collection"
-  const consignLink = isTop20 ? `${href}/consign` : "/consign"
+  const consignLink = artistHasOwnConsignRoute ? `${href}/consign` : "/consign"
 
   return {
-    isTop20,
+    artistHasOwnConsignRoute,
     imageURL,
     headline,
     consignLink,

--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_artist.graphql"
+import { RouterLink } from "Artsy/Router/RouterLink"
+import { Media } from "Utils/Responsive"
+import { getConsignmentData } from "../Routes/Consign/Utils/getConsignmentData"
+
+import {
+  BorderBox,
+  Box,
+  Button,
+  color,
+  Flex,
+  Image,
+  Sans,
+} from "@artsy/palette"
+
+export interface ArtistConsignButtonProps {
+  artist: ArtistConsignButton_artist
+}
+
+export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => {
+  return (
+    <>
+      <Media at="xs">
+        <ArtistConsignButtonSmall {...props} />
+      </Media>
+      <Media greaterThan="xs">
+        <ArtistConsignButtonLarge {...props} />
+      </Media>
+    </>
+  )
+}
+
+export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = props => {
+  const { isTop20, imageURL, headline, consignLink } = getData(props)
+
+  return (
+    <BorderBox p={1} width="100%">
+      <Flex alignItems="center" width="100%" justifyContent="space-between">
+        <Flex>
+          {isTop20 && <Image src={imageURL} width={50} height={50} />}
+          <Flex flexDirection="column" justifyContent="center" pl={1}>
+            <Sans size="3t" weight="medium">
+              {headline}
+            </Sans>
+            <Box position="relative">
+              <Sans size="3t" color={color("black60")}>
+                Consign with Artsy
+              </Sans>
+            </Box>
+          </Flex>
+        </Flex>
+        <Box>
+          <RouterLink to={consignLink}>
+            <Button variant="secondaryGray">Get started</Button>
+          </RouterLink>
+        </Box>
+      </Flex>
+    </BorderBox>
+  )
+}
+
+export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps> = props => {
+  const { isTop20, imageURL, headline, consignLink } = getData(props)
+
+  return (
+    <BorderBox maxWidth={335} p={1}>
+      <Flex alignItems="center">
+        {isTop20 && <Image src={imageURL} width={75} height={66} />}
+        <Flex flexDirection="column" justifyContent="center" pl={1}>
+          <Sans size="3t" weight="medium">
+            {headline}
+          </Sans>
+          <Box top="-2px" position="relative">
+            <Sans size="3t" color={color("black60")}>
+              Consign with Artsy
+            </Sans>
+          </Box>
+          <Box>
+            <RouterLink to={consignLink}>
+              <Button size="small" variant="secondaryGray">
+                Get started
+              </Button>
+            </RouterLink>
+          </Box>
+        </Flex>
+      </Flex>
+    </BorderBox>
+  )
+}
+
+function getData(props) {
+  const {
+    artist: { href, name, image },
+  } = props
+  const isTop20 = Boolean(getConsignmentData(href))
+  const imageURL = image?.cropped?.url
+  const headline = isTop20
+    ? `Sell your ${name}`
+    : "Sell art from your collection"
+  const consignLink = isTop20 ? `${href}/consign` : "/consign"
+
+  return {
+    isTop20,
+    imageURL,
+    headline,
+    consignLink,
+  }
+}
+
+export const ArtistConsignButtonFragmentContainer = createFragmentContainer(
+  ArtistConsignButton,
+  {
+    artist: graphql`
+      fragment ArtistConsignButton_artist on Artist {
+        name
+        href
+        image {
+          cropped(width: 75, height: 66) {
+            url
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -40,7 +40,7 @@ export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps> = prop
     <BorderBox p={1} width="100%">
       <Flex alignItems="center" width="100%" justifyContent="space-between">
         <Flex>
-          {isTop20 && <Image src={imageURL} width={50} height={50} />}
+          {isTop20 && imageURL && <Image src={imageURL} width={50} height={50} />}
           <Flex flexDirection="column" justifyContent="center" pl={1}>
             <Sans size="3t" weight="medium">
               {headline}

--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -68,7 +68,7 @@ export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps> = prop
   return (
     <BorderBox maxWidth={335} p={1}>
       <Flex alignItems="center">
-        {isTop20 && <Image src={imageURL} width={75} height={66} />}
+        {isTop20 && imageURL && <Image src={imageURL} width={75} height={66} />}
         <Flex flexDirection="column" justifyContent="center" pl={1}>
           <Sans size="3t" weight="medium">
             {headline}

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -412,8 +412,8 @@ const renderAuctionHighlight = artist => {
 }
 
 const renderRepresentationStatus = artist => {
-  const { highlights } = artist
-  const { partnersConnection } = highlights
+  const { artistHightlights } = artist
+  const { partnersConnection } = artistHightlights
   if (
     partnersConnection &&
     partnersConnection.edges &&
@@ -442,7 +442,7 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
             defaultValue: ["blue-chip", "top-established", "top-emerging"]
           }
         ) {
-        highlights {
+        artistHightlights: highlights {
           partnersConnection(
             first: 10
             displayOnPartnerProfile: true

--- a/src/Apps/Artist/Components/__stories__/ArtistConsignButton.story.tsx
+++ b/src/Apps/Artist/Components/__stories__/ArtistConsignButton.story.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { storiesOf } from "storybook/storiesOf"
+
+import { ArtistConsignButtonQuery } from "__generated__/ArtistConsignButtonQuery.graphql"
+import { useSystemContext } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
+
+import {
+  ArtistConsignButtonFragmentContainer,
+  ArtistConsignButtonLarge,
+  ArtistConsignButtonProps,
+  ArtistConsignButtonSmall,
+} from "Apps/Artist/Components/ArtistConsignButton"
+
+export const ArtistConsignButtonQueryRenderer: React.FC<Partial<
+  ArtistConsignButtonProps
+> & {
+  artistID: string
+}> = ({ artistID }) => {
+  const { relayEnvironment } = useSystemContext()
+  return (
+    <QueryRenderer<ArtistConsignButtonQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query ArtistConsignButtonQuery($artistID: String!) @raw_response_type {
+          artist(id: $artistID) {
+            ...ArtistConsignButton_artist
+          }
+        }
+      `}
+      variables={{
+        artistID,
+      }}
+      render={renderWithLoadProgress(ArtistConsignButtonFragmentContainer)}
+    />
+  )
+}
+
+storiesOf("Apps/Artist/Components/ArtistConsignButton", module)
+  .add("Top 20", () => {
+    return <ArtistConsignButtonQueryRenderer artistID="alex-katz" />
+  })
+  .add("All others", () => {
+    return <ArtistConsignButtonQueryRenderer artistID="andy-warhol" />
+  })
+  .add("Large Button", () => {
+    return (
+      <ArtistConsignButtonLarge
+        artist={
+          {
+            name: "Alex Katz",
+            href: "/artist/alex-katz",
+            image: { cropped: { url: "https://via.placeholder.com/50x50" } },
+          } as any
+        }
+      />
+    )
+  })
+  .add("Small Button", () => {
+    return (
+      <ArtistConsignButtonSmall
+        artist={
+          {
+            name: "Alex Katz",
+            href: "/artist/alex-katz",
+            image: { cropped: { url: "https://via.placeholder.com/50x50" } },
+          } as any
+        }
+      />
+    )
+  })

--- a/src/Apps/Artist/Components/__stories__/ArtistConsignButton.story.tsx
+++ b/src/Apps/Artist/Components/__stories__/ArtistConsignButton.story.tsx
@@ -47,6 +47,7 @@ storiesOf("Apps/Artist/Components/ArtistConsignButton", module)
   .add("Large Button", () => {
     return (
       <ArtistConsignButtonLarge
+        trackGetStartedClick={(x: any) => x}
         artist={
           {
             name: "Alex Katz",
@@ -60,6 +61,7 @@ storiesOf("Apps/Artist/Components/ArtistConsignButton", module)
   .add("Small Button", () => {
     return (
       <ArtistConsignButtonSmall
+        trackGetStartedClick={(x: any) => x}
         artist={
           {
             name: "Alex Katz",

--- a/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
@@ -1,6 +1,7 @@
 import { Breakpoint } from "@artsy/palette"
 import { ArtistConsignButtonQueryRawResponse } from "__generated__/ArtistConsignButtonQuery.graphql"
 import { MockBoot, renderRelayTree } from "DevTools"
+import { cloneDeep } from "lodash"
 import React from "react"
 import { graphql } from "react-relay"
 import { ArtistConsignButtonFragmentContainer } from "../ArtistConsignButton"
@@ -53,22 +54,46 @@ describe("ArtistConsignButton", () => {
       },
     }
 
-    it("renders desktop version", async () => {
-      const wrapper = await getWrapper({ breakpoint: "md", response })
-      expect(wrapper.find("Image").length).toEqual(1)
-      expect(wrapper.text()).toContain("Sell your Alex Katz")
-      expect(wrapper.find("RouterLink").html()).toContain(
-        `href="/artist/alex-katz/consign"`
-      )
+    describe("desktop", () => {
+      it("renders properly", async () => {
+        const wrapper = await getWrapper({ breakpoint: "md", response })
+        expect(wrapper.find("Image").length).toEqual(1)
+        expect(wrapper.text()).toContain("Sell your Alex Katz")
+        expect(wrapper.find("RouterLink").html()).toContain(
+          `href="/artist/alex-katz/consign"`
+        )
+      })
+
+      it("guards against missing imageURL", async () => {
+        const responseWithoutImage = cloneDeep(response)
+        responseWithoutImage.artist.image = null
+        const wrapper = await getWrapper({
+          breakpoint: "md",
+          response: responseWithoutImage,
+        })
+        expect(wrapper.find("Image").length).toEqual(0)
+      })
     })
 
-    it("renders mobile version", async () => {
-      const wrapper = await getWrapper({ breakpoint: "xs", response })
-      expect(wrapper.find("Image").length).toEqual(1)
-      expect(wrapper.text()).toContain("Sell your Alex Katz")
-      expect(wrapper.find("RouterLink").html()).toContain(
-        `href="/artist/alex-katz/consign"`
-      )
+    describe("mobile", () => {
+      it("renders properly", async () => {
+        const wrapper = await getWrapper({ breakpoint: "xs", response })
+        expect(wrapper.find("Image").length).toEqual(1)
+        expect(wrapper.text()).toContain("Sell your Alex Katz")
+        expect(wrapper.find("RouterLink").html()).toContain(
+          `href="/artist/alex-katz/consign"`
+        )
+      })
+
+      it("guards against missing imageURL", async () => {
+        const responseWithoutImage = cloneDeep(response)
+        responseWithoutImage.artist.image = null
+        const wrapper = await getWrapper({
+          breakpoint: "md",
+          response: responseWithoutImage,
+        })
+        expect(wrapper.find("Image").length).toEqual(0)
+      })
     })
   })
 
@@ -87,18 +112,22 @@ describe("ArtistConsignButton", () => {
       },
     }
 
-    it("renders desktop version", async () => {
-      const wrapper = await getWrapper({ breakpoint: "md", response })
-      expect(wrapper.find("Image").length).toEqual(0)
-      expect(wrapper.text()).toContain("Sell art from your collection")
-      expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+    describe("desktop", () => {
+      it("renders properly", async () => {
+        const wrapper = await getWrapper({ breakpoint: "md", response })
+        expect(wrapper.find("Image").length).toEqual(0)
+        expect(wrapper.text()).toContain("Sell art from your collection")
+        expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+      })
     })
 
-    it("renders mobile version", async () => {
-      const wrapper = await getWrapper({ breakpoint: "xs", response })
-      expect(wrapper.find("Image").length).toEqual(0)
-      expect(wrapper.text()).toContain("Sell art from your collection")
-      expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+    describe("mobile", () => {
+      it("renders properly", async () => {
+        const wrapper = await getWrapper({ breakpoint: "xs", response })
+        expect(wrapper.find("Image").length).toEqual(0)
+        expect(wrapper.text()).toContain("Sell art from your collection")
+        expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+      })
     })
   })
 })

--- a/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
@@ -101,15 +101,4 @@ describe("ArtistConsignButton", () => {
       expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
     })
   })
-
-  // TODO: Functionality doesn't yet exist
-  xdescribe("Target Supply Button", () => {
-    it("renders desktop version", async () => {
-      //
-    })
-
-    it("renders mobile version", async () => {
-      //
-    })
-  })
 })

--- a/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
@@ -1,0 +1,115 @@
+import { Breakpoint } from "@artsy/palette"
+import { ArtistConsignButtonQueryRawResponse } from "__generated__/ArtistConsignButtonQuery.graphql"
+import { MockBoot, renderRelayTree } from "DevTools"
+import React from "react"
+import { graphql } from "react-relay"
+import { ArtistConsignButtonFragmentContainer } from "../ArtistConsignButton"
+
+jest.unmock("react-relay")
+
+describe("ArtistConsignButton", () => {
+  const getWrapper = async ({
+    breakpoint = "xs",
+    response,
+  }: {
+    breakpoint: Breakpoint
+    response: ArtistConsignButtonQueryRawResponse
+  }) => {
+    return await renderRelayTree({
+      Component: ({ artist }) => {
+        return (
+          <MockBoot breakpoint={breakpoint}>
+            <ArtistConsignButtonFragmentContainer artist={artist} />
+          </MockBoot>
+        )
+      },
+      query: graphql`
+        query ArtistConsignButton_Test_Query($artistID: String!)
+          @raw_response_type {
+          artist(id: $artistID) {
+            ...ArtistConsignButton_artist
+          }
+        }
+      `,
+      variables: {
+        artistID: "alex-katz",
+      },
+      mockData: response,
+    })
+  }
+
+  describe("Top 20 Button", () => {
+    const response = {
+      artist: {
+        name: "Alex Katz",
+        href: "/artist/alex-katz",
+        image: {
+          cropped: {
+            url:
+              "https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&width=75&height=66&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FbrHdWfNxoereaVk2VOneuw%2Flarge.jpg",
+          },
+        },
+        id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+      },
+    }
+
+    it("renders desktop version", async () => {
+      const wrapper = await getWrapper({ breakpoint: "md", response })
+      expect(wrapper.find("Image").length).toEqual(1)
+      expect(wrapper.text()).toContain("Sell your Alex Katz")
+      expect(wrapper.find("RouterLink").html()).toContain(
+        `href="/artist/alex-katz/consign"`
+      )
+    })
+
+    it("renders mobile version", async () => {
+      const wrapper = await getWrapper({ breakpoint: "xs", response })
+      expect(wrapper.find("Image").length).toEqual(1)
+      expect(wrapper.text()).toContain("Sell your Alex Katz")
+      expect(wrapper.find("RouterLink").html()).toContain(
+        `href="/artist/alex-katz/consign"`
+      )
+    })
+  })
+
+  describe("Default Button", () => {
+    const response = {
+      artist: {
+        name: "Andy Warhol",
+        href: "/artist/andy-warhol",
+        image: {
+          cropped: {
+            url:
+              "https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&width=75&height=66&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FbrHdWfNxoereaVk2VOneuw%2Flarge.jpg",
+          },
+        },
+        id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+      },
+    }
+
+    it("renders desktop version", async () => {
+      const wrapper = await getWrapper({ breakpoint: "md", response })
+      expect(wrapper.find("Image").length).toEqual(0)
+      expect(wrapper.text()).toContain("Sell art from your collection")
+      expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+    })
+
+    it("renders mobile version", async () => {
+      const wrapper = await getWrapper({ breakpoint: "xs", response })
+      expect(wrapper.find("Image").length).toEqual(0)
+      expect(wrapper.text()).toContain("Sell art from your collection")
+      expect(wrapper.find("RouterLink").html()).toContain(`href="/consign"`)
+    })
+  })
+
+  // TODO: Functionality doesn't yet exist
+  xdescribe("Target Supply Button", () => {
+    it("renders desktop version", async () => {
+      //
+    })
+
+    it("renders mobile version", async () => {
+      //
+    })
+  })
+})

--- a/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistHeader.test.tsx
@@ -131,7 +131,7 @@ describe("ArtistHeader", () => {
   it("hides auction record indicator when data is not present", async () => {
     const artist = {
       ...ArtistHeaderFixture,
-      highlights: { partnersConnection: null },
+      artistHightlights: { partnersConnection: null },
     }
     const wrapper = await getWrapper(artist)
     const html = wrapper.html()

--- a/src/Apps/Artist/__tests__/routes.test.tsx
+++ b/src/Apps/Artist/__tests__/routes.test.tsx
@@ -183,6 +183,11 @@ const overviewArtist: routes_ArtistTopLevelQueryRawResponse["artist"] = {
       edges: [],
     },
   },
+  artistHightlights: {
+    partnersConnection: {
+      edges: [],
+    },
+  },
   insights: [],
   name: "Juan Gris",
   nationality: "",

--- a/src/Apps/__tests__/Fixtures/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/__tests__/Fixtures/Artist/Components/ArtistHeader.tsx
@@ -29,7 +29,7 @@ export const ArtistHeaderFixture = {
     auction_lots: true,
     artworks: true,
   },
-  highlights: {
+  artistHightlights: {
     partnersConnection: {
       edges: [
         {

--- a/src/Artsy/Analytics/Schema/Values.ts
+++ b/src/Artsy/Analytics/Schema/Values.ts
@@ -251,6 +251,11 @@ export enum Subject {
   ConsignLearnMore = "learn more",
 
   /**
+   * Artist Page
+   */
+  GetStarted = "Get Started",
+
+  /**
    * Artwork Page
    */
   Classification = "Classification info",
@@ -292,6 +297,7 @@ export enum ContextModule {
   /**
    * Artist page
    */
+  ArtistConsignment = "ArtistConsignment",
   ArtistPage = "Artist page",
   AboutTheWork = "About the work",
   AboutTheWorkPartner = "About the Work (Partner)",

--- a/src/__generated__/ArtistConsignButtonQuery.graphql.ts
+++ b/src/__generated__/ArtistConsignButtonQuery.graphql.ts
@@ -12,6 +12,8 @@ export type ArtistConsignButtonQueryResponse = {
 };
 export type ArtistConsignButtonQueryRawResponse = {
     readonly artist: ({
+        readonly internalID: string;
+        readonly slug: string;
         readonly name: string | null;
         readonly href: string | null;
         readonly image: ({
@@ -41,6 +43,8 @@ query ArtistConsignButtonQuery(
 }
 
 fragment ArtistConsignButton_artist on Artist {
+  internalID
+  slug
   name
   href
   image {
@@ -111,6 +115,20 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "internalID",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "slug",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "name",
             "args": null,
             "storageKey": null
@@ -177,7 +195,7 @@ return {
     "operationKind": "query",
     "name": "ArtistConsignButtonQuery",
     "id": null,
-    "text": "query ArtistConsignButtonQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
+    "text": "query ArtistConsignButtonQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistConsignButtonQuery.graphql.ts
+++ b/src/__generated__/ArtistConsignButtonQuery.graphql.ts
@@ -1,0 +1,186 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistConsignButtonQueryVariables = {
+    artistID: string;
+};
+export type ArtistConsignButtonQueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistConsignButton_artist">;
+    } | null;
+};
+export type ArtistConsignButtonQueryRawResponse = {
+    readonly artist: ({
+        readonly name: string | null;
+        readonly href: string | null;
+        readonly image: ({
+            readonly cropped: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type ArtistConsignButtonQuery = {
+    readonly response: ArtistConsignButtonQueryResponse;
+    readonly variables: ArtistConsignButtonQueryVariables;
+    readonly rawResponse: ArtistConsignButtonQueryRawResponse;
+};
+
+
+
+/*
+query ArtistConsignButtonQuery(
+  $artistID: String!
+) {
+  artist(id: $artistID) {
+    ...ArtistConsignButton_artist
+    id
+  }
+}
+
+fragment ArtistConsignButton_artist on Artist {
+  name
+  href
+  image {
+    cropped(width: 75, height: 66) {
+      url
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistConsignButtonQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistConsignButton_artist",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistConsignButtonQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "name",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "href",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cropped",
+                "storageKey": "cropped(height:66,width:75)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 66
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 75
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistConsignButtonQuery",
+    "id": null,
+    "text": "query ArtistConsignButtonQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'f2c53ccf39a1be9bf8279a2588a08b2b';
+export default node;

--- a/src/__generated__/ArtistConsignButton_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistConsignButton_Test_Query.graphql.ts
@@ -1,0 +1,186 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistConsignButton_Test_QueryVariables = {
+    artistID: string;
+};
+export type ArtistConsignButton_Test_QueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistConsignButton_artist">;
+    } | null;
+};
+export type ArtistConsignButton_Test_QueryRawResponse = {
+    readonly artist: ({
+        readonly name: string | null;
+        readonly href: string | null;
+        readonly image: ({
+            readonly cropped: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type ArtistConsignButton_Test_Query = {
+    readonly response: ArtistConsignButton_Test_QueryResponse;
+    readonly variables: ArtistConsignButton_Test_QueryVariables;
+    readonly rawResponse: ArtistConsignButton_Test_QueryRawResponse;
+};
+
+
+
+/*
+query ArtistConsignButton_Test_Query(
+  $artistID: String!
+) {
+  artist(id: $artistID) {
+    ...ArtistConsignButton_artist
+    id
+  }
+}
+
+fragment ArtistConsignButton_artist on Artist {
+  name
+  href
+  image {
+    cropped(width: 75, height: 66) {
+      url
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistConsignButton_Test_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistConsignButton_artist",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistConsignButton_Test_Query",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "name",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "href",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cropped",
+                "storageKey": "cropped(height:66,width:75)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 66
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 75
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistConsignButton_Test_Query",
+    "id": null,
+    "text": "query ArtistConsignButton_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'b38a3cd19b52d087ec99c55c9aeb0597';
+export default node;

--- a/src/__generated__/ArtistConsignButton_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistConsignButton_Test_Query.graphql.ts
@@ -12,6 +12,8 @@ export type ArtistConsignButton_Test_QueryResponse = {
 };
 export type ArtistConsignButton_Test_QueryRawResponse = {
     readonly artist: ({
+        readonly internalID: string;
+        readonly slug: string;
         readonly name: string | null;
         readonly href: string | null;
         readonly image: ({
@@ -41,6 +43,8 @@ query ArtistConsignButton_Test_Query(
 }
 
 fragment ArtistConsignButton_artist on Artist {
+  internalID
+  slug
   name
   href
   image {
@@ -111,6 +115,20 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "internalID",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "slug",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "name",
             "args": null,
             "storageKey": null
@@ -177,7 +195,7 @@ return {
     "operationKind": "query",
     "name": "ArtistConsignButton_Test_Query",
     "id": null,
-    "text": "query ArtistConsignButton_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
+    "text": "query ArtistConsignButton_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistConsignButton_artist\n    id\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistConsignButton_artist.graphql.ts
+++ b/src/__generated__/ArtistConsignButton_artist.graphql.ts
@@ -3,6 +3,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistConsignButton_artist = {
+    readonly internalID: string;
+    readonly slug: string;
     readonly name: string | null;
     readonly href: string | null;
     readonly image: {
@@ -27,6 +29,20 @@ const node: ReaderFragment = {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -83,5 +99,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '6e7d1acc55f65bdb49a761446150dd24';
+(node as any).hash = '4b90a122b0fb76a52ec3d2cda5b5ace6';
 export default node;

--- a/src/__generated__/ArtistConsignButton_artist.graphql.ts
+++ b/src/__generated__/ArtistConsignButton_artist.graphql.ts
@@ -1,0 +1,87 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistConsignButton_artist = {
+    readonly name: string | null;
+    readonly href: string | null;
+    readonly image: {
+        readonly cropped: {
+            readonly url: string | null;
+        } | null;
+    } | null;
+    readonly " $refType": "ArtistConsignButton_artist";
+};
+export type ArtistConsignButton_artist$data = ArtistConsignButton_artist;
+export type ArtistConsignButton_artist$key = {
+    readonly " $data"?: ArtistConsignButton_artist$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistConsignButton_artist">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistConsignButton_artist",
+  "type": "Artist",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "href",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "cropped",
+          "storageKey": "cropped(height:66,width:75)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 66
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 75
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "url",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '6e7d1acc55f65bdb49a761446150dd24';
+export default node;

--- a/src/__generated__/ArtistHeader_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeader_Test_Query.graphql.ts
@@ -10,7 +10,7 @@ export type ArtistHeader_Test_QueryResponse = {
 };
 export type ArtistHeader_Test_QueryRawResponse = {
     readonly artist: ({
-        readonly highlights: ({
+        readonly artistHightlights: ({
             readonly partnersConnection: ({
                 readonly edges: ReadonlyArray<({
                     readonly node: ({
@@ -78,7 +78,7 @@ query ArtistHeader_Test_Query {
 }
 
 fragment ArtistHeader_artist on Artist {
-  highlights {
+  artistHightlights: highlights {
     partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
       edges {
         node {
@@ -204,7 +204,7 @@ return {
         "selections": [
           {
             "kind": "LinkedField",
-            "alias": null,
+            "alias": "artistHightlights",
             "name": "highlights",
             "storageKey": null,
             "args": null,
@@ -528,7 +528,7 @@ return {
     "operationKind": "query",
     "name": "ArtistHeader_Test_Query",
     "id": null,
-    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"cecily-brown\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
+    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"cecily-brown\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  artistHightlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -3,7 +3,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistHeader_artist = {
-    readonly highlights: {
+    readonly artistHightlights: {
         readonly partnersConnection: {
             readonly edges: ReadonlyArray<{
                 readonly node: {
@@ -85,7 +85,7 @@ return {
   "selections": [
     {
       "kind": "LinkedField",
-      "alias": null,
+      "alias": "artistHightlights",
       "name": "highlights",
       "storageKey": null,
       "args": null,
@@ -393,5 +393,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'aa217d83bdfddc9bba710789717e44e6';
+(node as any).hash = 'ae811fc1342c868c7f512c4e371c7a38';
 export default node;

--- a/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
@@ -117,7 +117,7 @@ export type routes_ArtistTopLevelQueryRawResponse = {
                 }) | null;
             }) | null> | null;
         }) | null;
-        readonly highlights: ({
+        readonly artistHightlights: ({
             readonly partnersConnection: ({
                 readonly edges: ReadonlyArray<({
                     readonly node: ({
@@ -170,6 +170,20 @@ export type routes_ArtistTopLevelQueryRawResponse = {
                         readonly slug: string;
                         readonly id: string | null;
                     }) | null;
+                }) | null> | null;
+            }) | null;
+        }) | null;
+        readonly highlights: ({
+            readonly partnersConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly categories: ReadonlyArray<({
+                            readonly slug: string;
+                            readonly id: string | null;
+                        }) | null> | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly id: string | null;
                 }) | null> | null;
             }) | null;
         }) | null;
@@ -248,7 +262,7 @@ fragment ArtistApp_artist on Artist {
 }
 
 fragment ArtistHeader_artist on Artist {
-  highlights {
+  artistHightlights: highlights {
     partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
       edges {
         node {
@@ -657,6 +671,53 @@ v21 = {
 v22 = [
   (v2/*: any*/),
   (v21/*: any*/)
+],
+v23 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "partnersConnection",
+    "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)",
+    "args": (v9/*: any*/),
+    "concreteType": "PartnerArtistConnection",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "edges",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "PartnerArtistEdge",
+        "plural": true,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "node",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "categories",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PartnerCategory",
+                "plural": true,
+                "selections": (v22/*: any*/)
+              },
+              (v21/*: any*/)
+            ]
+          },
+          (v21/*: any*/)
+        ]
+      }
+    ]
+  }
 ];
 return {
   "kind": "Request",
@@ -1100,59 +1161,13 @@ return {
           },
           {
             "kind": "LinkedField",
-            "alias": null,
+            "alias": "artistHightlights",
             "name": "highlights",
             "storageKey": null,
             "args": null,
             "concreteType": "ArtistHighlights",
             "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "partnersConnection",
-                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)",
-                "args": (v9/*: any*/),
-                "concreteType": "PartnerArtistConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "edges",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "PartnerArtistEdge",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "node",
-                        "storageKey": null,
-                        "args": null,
-                        "concreteType": "Partner",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "categories",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "PartnerCategory",
-                            "plural": true,
-                            "selections": (v22/*: any*/)
-                          },
-                          (v21/*: any*/)
-                        ]
-                      },
-                      (v21/*: any*/)
-                    ]
-                  }
-                ]
-              }
-            ]
+            "selections": (v23/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -1389,6 +1404,16 @@ return {
               }
             ]
           },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "highlights",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ArtistHighlights",
+            "plural": false,
+            "selections": (v23/*: any*/)
+          },
           (v10/*: any*/),
           (v11/*: any*/)
         ]
@@ -1399,7 +1424,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistTopLevelQuery",
     "id": null,
-    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: true) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  name\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n",
+    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: true) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  name\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  artistHightlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Addresses 
- https://artsyproduct.atlassian.net/browse/CSGN-90
- https://artsyproduct.atlassian.net/browse/CSGN-92

![consignbutton](https://user-images.githubusercontent.com/236943/77599279-6f1aeb00-6ec1-11ea-96a3-5291ef42e495.gif)

Adds a new responsive `ArtistConsignButton` that covers two cases: "Top 20", and everything else.

We're not implementing "Target Supply" version yet because we don't yet know how to get data from RedShift over to Metaphysics. 