### PR TITLE
gitignore node diagnostic reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yalc.lock
 coverage*
 reports*
 2
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ reports*
 2
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+report.*.json


### PR DESCRIPTION
#minor

This PR adds a line to gitignore node diagnostic reports. It is copied from https://gitignore.io/api/node.