### PR TITLE
[ErrorBoundary] Add stack trace in development

### DIFF
--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -1,11 +1,13 @@
-import { Link } from "@artsy/palette"
+import { Box, Link } from "@artsy/palette"
 import React from "react"
+import { getENV } from "Utils/getENV"
 import { ModalDialog } from "./ModalDialog"
 
 interface ErrorModalProps {
   show?: boolean
   headerText?: string
   detailText?: string
+  errorStack?: string
   contactEmail?: string // Used in default detailText if none is specified.
   closeText?: string
   onClose?: () => void
@@ -31,11 +33,13 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
       onClose,
       headerText,
       detailText,
+      errorStack,
       contactEmail,
       closeText,
       ctaAction,
     } = this.props
     const emailAddress = contactEmail ? contactEmail : "support@artsy.net"
+    const showErrorStack = errorStack && getENV("NODE_ENV") !== "production"
 
     return (
       <ModalDialog
@@ -43,12 +47,20 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
         onClose={onClose}
         heading={headerText}
         detail={
-          detailText || (
-            <>
-              Something went wrong. Please try again or contact{" "}
-              <Link href={`mailto:${emailAddress}`}>{emailAddress}</Link>.
-            </>
-          )
+          <>
+            {detailText || (
+              <>
+                Something went wrong. Please try again or contact{" "}
+                <Link href={`mailto:${emailAddress}`}>{emailAddress}</Link>.
+              </>
+            )}
+
+            {showErrorStack && (
+              <Box py={3}>
+                <Box>{errorStack}</Box>
+              </Box>
+            )}
+          </>
         }
         primaryCta={{
           action: ctaAction || onClose,

--- a/src/Components/Modal/__tests__/ErrorModal.test.tsx
+++ b/src/Components/Modal/__tests__/ErrorModal.test.tsx
@@ -55,6 +55,13 @@ describe("ErrorModal", () => {
       )
     })
 
+    it("Renders error stack", () => {
+      props.errorStack = "An error stack"
+      const component = getWrapper(props)
+      const text = component.text()
+      expect(text).toContain("An error stack")
+    })
+
     it("Renders with a specified props for header, detail, and the close button", () => {
       props.headerText = "Custom header"
       props.detailText = "A custom error detail."

--- a/src/Components/__tests__/ErrorBoundary.test.tsx
+++ b/src/Components/__tests__/ErrorBoundary.test.tsx
@@ -37,6 +37,20 @@ describe("ErrorBoundary", () => {
     expect(ErrorBoundary.prototype.componentDidCatch).toHaveBeenCalled()
   })
 
+  it("updates `errorStack` state with stack trace", () => {
+    const ErrorComponent = () => {
+      throw new Error("throw error")
+      return null
+    }
+    const wrapper = mount(
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>
+    )
+    const state = wrapper.state() as any
+    expect(state.errorStack).toContain("Error: throw error")
+  })
+
   it("shows error modal when genericError is true", () => {
     const wrapper = mount(
       <ErrorBoundary>


### PR DESCRIPTION
Adds stack trace output in `development`. Formatting could likely be improved at a later date. 

<img width="620" alt="Screen Shot 2020-03-27 at 1 22 25 PM" src="https://user-images.githubusercontent.com/236943/77797637-a4911700-702e-11ea-8613-09f2bc3fa83f.png">
