### PR TITLE
[Consignments] Remove shuffle on recently sold

### DIFF
--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Sans, Spacer } from "@artsy/palette"
-import { shuffle } from "lodash"
 import React from "react"
 
 import { Consign_artworksByInternalID } from "__generated__/Consign_artworksByInternalID.graphql"
@@ -33,7 +32,7 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
             flexWrap="wrap"
             alignItems="center"
           >
-            {shuffle(artworksByInternalID).map((artwork, key) => {
+            {artworksByInternalID.map((artwork, key) => {
               const artworkData = artistConsignment.artworks.find(
                 consignmentArtwork => {
                   return consignmentArtwork.internalID === artwork.internalID


### PR DESCRIPTION
Little SSR edgecase -- if `shuffle` is used, it will execute once on the server, and then once more on the client, leading to dom mismatch. Need to think this through a bit better. 