### PR TITLE
[HotFix] Comment out NewsNav date

### DIFF
--- a/src/Components/Publishing/Nav/NewsNav.tsx
+++ b/src/Components/Publishing/Nav/NewsNav.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import colors from "../../../Assets/Colors"
 import { pMedia } from "../../Helpers"
-import { NewsDateHeader, NewsText } from "../News/NewsDateHeader"
+import { /*NewsDateHeader*/ NewsText } from "../News/NewsDateHeader"
 
 interface Props {
   date?: string
@@ -10,11 +10,12 @@ interface Props {
 }
 
 export const NewsNav: React.SFC<Props> = props => {
-  const { date, positionTop } = props
+  const { /*date*/ positionTop } = props
   return (
     <NewsNavContainer positionTop={positionTop}>
       <MaxWidthContainer>
-        {date && <NewsDateHeader date={date} />}
+        {/* FIXME: Reenable once date update bug is resolved */}
+        {/* {date && <NewsDateHeader date={date} />} */}
         <Title>News</Title>
       </MaxWidthContainer>
     </NewsNavContainer>
@@ -22,11 +23,13 @@ export const NewsNav: React.SFC<Props> = props => {
 }
 
 const Title = styled(NewsText)`
-  position: absolute;
-  left: 30px;
-  ${pMedia.sm`
+  text-align: center;
+  /* FIXME: Uncomment once date update bug is resolved */
+  /* position: absolute; */
+  /* left: 30px; */
+  /* ${pMedia.sm`
     left: 20px;
-  `};
+  `}; */
 `
 
 const MaxWidthContainer = styled.div`

--- a/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
+++ b/src/Components/Publishing/Nav/__tests__/__snapshots__/NewsNav.test.tsx.snap
@@ -6,15 +6,7 @@ exports[`NewsNav renders NewsNav 1`] = `
   -webkit-font-smoothing: antialiased;
   font-size: 25px;
   line-height: 1.1em;
-}
-
-.c3 {
-  font-family: Unica77LLWebMedium,Arial,serif;
-  -webkit-font-smoothing: antialiased;
-  font-size: 25px;
-  line-height: 1.1em;
-  position: absolute;
-  left: 30px;
+  text-align: center;
 }
 
 .c1 {
@@ -57,21 +49,6 @@ exports[`NewsNav renders NewsNav 1`] = `
 }
 
 @media (max-width:720px) {
-  .c3 {
-    font-family: Unica77LLWebMedium,Arial,serif;
-    -webkit-font-smoothing: antialiased;
-    font-size: 16px;
-    line-height: 1.1em;
-  }
-}
-
-@media (max-width:720px) {
-  .c3 {
-    left: 20px;
-  }
-}
-
-@media (max-width:720px) {
   .c1 {
     min-height: 16px;
   }
@@ -85,11 +62,6 @@ exports[`NewsNav renders NewsNav 1`] = `
   >
     <div
       className="c2"
-    >
-      Jun 29, 2017
-    </div>
-    <div
-      className="c3"
     >
       News
     </div>


### PR DESCRIPTION
This is a hotfix for the /news page, where date updates on the top nav are preventing users from scrolling past the point of the last fetch: 

![scrollbug](https://user-images.githubusercontent.com/236943/77949682-3a6db180-727c-11ea-9352-582bde15304c.gif)


Updates so that only the word "News" appears, as the dates still show in the articles themselves. 

--- 

#### What it looks like with this fix: 

<img width="929" alt="Screen Shot 2020-03-30 at 11 52 40 AM" src="https://user-images.githubusercontent.com/236943/77950190-0050df80-727d-11ea-87f6-93406dc2e4db.png">

#### Mobile 

<img width="336" alt="Screen Shot 2020-03-30 at 11 54 30 AM" src="https://user-images.githubusercontent.com/236943/77950387-40b05d80-727d-11ea-8d0d-6a129485940d.png">

![scrollfix](https://user-images.githubusercontent.com/236943/77950602-9422ab80-727d-11ea-8286-823822e1346b.gif)
