### PR TITLE
[Artist] Add ConsignButton to Artist/Overview page

### DIFF
--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -63,37 +63,40 @@ export const ArtistConsignButtonLarge: React.FC<ArtistConsignButtonProps &
   )
 
   return (
-    <BorderBox p={1} width="100%">
-      <Flex alignItems="center" width="100%" justifyContent="space-between">
-        <Flex>
-          {artistHasOwnConsignRoute && imageURL && (
-            <Image src={imageURL} width={50} height={50} />
-          )}
-          <Flex flexDirection="column" justifyContent="center" pl={1}>
-            <Sans size="3t" weight="medium">
-              {headline}
-            </Sans>
-            <Box position="relative">
-              <Sans size="3t" color={color("black60")}>
-                Consign with Artsy
+    <RouterLink
+      to={consignURL}
+      style={{
+        textDecoration: "none",
+      }}
+      onClick={() => {
+        props.trackGetStartedClick({
+          destinationPath: consignURL,
+        })
+      }}
+    >
+      <BorderBox p={1} width="100%">
+        <Flex alignItems="center" width="100%" justifyContent="space-between">
+          <Flex>
+            {artistHasOwnConsignRoute && imageURL && (
+              <Image src={imageURL} width={50} height={50} />
+            )}
+            <Flex flexDirection="column" justifyContent="center" pl={1}>
+              <Sans size="3t" weight="medium">
+                {headline}
               </Sans>
-            </Box>
+              <Box position="relative">
+                <Sans size="3t" color={color("black60")}>
+                  Consign with Artsy
+                </Sans>
+              </Box>
+            </Flex>
           </Flex>
-        </Flex>
-        <Box>
-          <RouterLink
-            to={consignURL}
-            onClick={() => {
-              props.trackGetStartedClick({
-                destinationPath: consignURL,
-              })
-            }}
-          >
+          <Box>
             <Button variant="secondaryGray">Get started</Button>
-          </RouterLink>
-        </Box>
-      </Flex>
-    </BorderBox>
+          </Box>
+        </Flex>
+      </BorderBox>
+    </RouterLink>
   )
 }
 
@@ -104,37 +107,40 @@ export const ArtistConsignButtonSmall: React.FC<ArtistConsignButtonProps &
   )
 
   return (
-    <BorderBox maxWidth={335} p={1}>
-      <Flex alignItems="center">
-        {artistHasOwnConsignRoute && imageURL && (
-          <Image src={imageURL} width={75} height={66} />
-        )}
-        <Flex flexDirection="column" justifyContent="center" pl={1}>
-          <Sans size="3t" weight="medium">
-            {headline}
-          </Sans>
-          <Box top="-2px" position="relative">
-            <Sans size="3t" color={color("black60")}>
-              Consign with Artsy
+    <RouterLink
+      to={consignURL}
+      style={{
+        textDecoration: "none",
+      }}
+      onClick={() => {
+        props.trackGetStartedClick({
+          destinationPath: consignURL,
+        })
+      }}
+    >
+      <BorderBox maxWidth={335} p={1}>
+        <Flex alignItems="center">
+          {artistHasOwnConsignRoute && imageURL && (
+            <Image src={imageURL} width={75} height={66} />
+          )}
+          <Flex flexDirection="column" justifyContent="center" pl={1}>
+            <Sans size="3t" weight="medium">
+              {headline}
             </Sans>
-          </Box>
-          <Box>
-            <RouterLink
-              to={consignURL}
-              onClick={() => {
-                props.trackGetStartedClick({
-                  destinationPath: consignURL,
-                })
-              }}
-            >
+            <Box top="-2px" position="relative">
+              <Sans size="3t" color={color("black60")}>
+                Consign with Artsy
+              </Sans>
+            </Box>
+            <Box>
               <Button size="small" variant="secondaryGray">
                 Get started
               </Button>
-            </RouterLink>
-          </Box>
+            </Box>
+          </Flex>
         </Flex>
-      </Flex>
-    </BorderBox>
+      </BorderBox>
+    </RouterLink>
   )
 }
 

--- a/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
@@ -210,7 +210,7 @@ describe("OverviewRoute", () => {
   })
 
   describe("ConsignButton", () => {
-    it("shows a consign button", () => {
+    it("shows a default consign button", () => {
       const wrapper = getWrapper({
         ...defaultArtist,
       })

--- a/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/index.test.tsx
@@ -209,6 +209,15 @@ describe("OverviewRoute", () => {
     })
   })
 
+  describe("ConsignButton", () => {
+    it("shows a consign button", () => {
+      const wrapper = getWrapper({
+        ...defaultArtist,
+      })
+      expect(wrapper.find("ArtistConsignButton").length).toEqual(1)
+    })
+  })
+
   describe("Artist Recommendations", () => {
     it("Does not display recommendations if related.artists is empty", () => {
       const wrapper = getWrapper(defaultArtist)
@@ -251,6 +260,11 @@ const defaultArtist: routes_OverviewQueryRawResponse["artist"] = {
     auction_artworks: 40,
     artworks: 50,
     has_make_offer_artworks: true,
+  },
+  image: {
+    cropped: {
+      url: "/some/image.jpg",
+    },
   },
   articlesConnection: {
     edges: [

--- a/src/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/Apps/Artist/Routes/Overview/index.tsx
@@ -23,6 +23,7 @@ import { ArtistBioFragmentContainer as ArtistBio } from "Components/ArtistBio"
 import { Carousel } from "Components/Carousel"
 import { SelectedCareerAchievementsFragmentContainer as SelectedCareerAchievements } from "Components/SelectedCareerAchievements"
 
+import { ArtistConsignButtonFragmentContainer as ArtistConsignButton } from "Apps/Artist/Components/ArtistConsignButton"
 import { StyledLink } from "Apps/Artist/Components/StyledLink"
 import { WorksForSaleRailQueryRenderer as WorksForSaleRail } from "Apps/Artist/Routes/Overview/Components/WorksForSaleRail"
 import { pMedia } from "Components/Helpers"
@@ -95,20 +96,6 @@ const TruncatedLine = styled.div`
   overflow: hidden;
   white-space: nowrap;
 `
-
-interface ConsignLinkProps {
-  consignLinkAction: () => void
-}
-
-const ConsignLink: React.FC<ConsignLinkProps> = props => (
-  <Sans size="2" color="black60">
-    Want to sell a work by this artist?{" "}
-    <a href="/consign" onClick={props.consignLinkAction}>
-      Consign with Artsy
-    </a>
-    .
-  </Sans>
-)
 
 // Exported just for tests
 export const FeaturedArticlesItem = styled(Flex)`
@@ -226,10 +213,8 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
                 )}
                 {showConsignable && (
                   <>
-                    <Spacer mb={1} />
-                    <ConsignLink
-                      consignLinkAction={this.handleConsignClick.bind(this)}
-                    />
+                    <Spacer mb={3} />
+                    <ArtistConsignButton artist={artist} />
                   </>
                 )}
               </>
@@ -267,14 +252,6 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
                   this.setState({ isReadMoreExpanded: true })
                 }}
                 bio={artist}
-              />
-            </>
-          )}
-          {showConsignable && (
-            <>
-              <Spacer mb={1} />
-              <ConsignLink
-                consignLinkAction={this.handleConsignClick.bind(this)}
               />
             </>
           )}
@@ -467,6 +444,7 @@ export const OverviewRouteFragmentContainer = createFragmentContainer(
         ...Genes_artist
         ...FollowArtistButton_artist
         ...WorksForSaleRail_artist
+        ...ArtistConsignButton_artist
         slug
         id
         statuses {

--- a/src/__generated__/Overview_artist.graphql.ts
+++ b/src/__generated__/Overview_artist.graphql.ts
@@ -88,7 +88,7 @@ export type Overview_artist = {
     readonly insights: ReadonlyArray<{
         readonly type: string | null;
     } | null> | null;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistBio_bio" | "CurrentEvent_artist" | "MarketInsights_artist" | "SelectedCareerAchievements_artist" | "Genes_artist" | "FollowArtistButton_artist" | "WorksForSaleRail_artist">;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistBio_bio" | "CurrentEvent_artist" | "MarketInsights_artist" | "SelectedCareerAchievements_artist" | "Genes_artist" | "FollowArtistButton_artist" | "WorksForSaleRail_artist" | "ArtistConsignButton_artist">;
     readonly " $refType": "Overview_artist";
 };
 export type Overview_artist$data = Overview_artist;
@@ -721,9 +721,14 @@ return {
       "kind": "FragmentSpread",
       "name": "WorksForSaleRail_artist",
       "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtistConsignButton_artist",
+      "args": null
     }
   ]
 };
 })();
-(node as any).hash = 'd49804f9b186cd7f560a0747696f38fd';
+(node as any).hash = '8fd6ad871ac1627419e0a34ea74d541f';
 export default node;

--- a/src/__generated__/routes_OverviewQuery.graphql.ts
+++ b/src/__generated__/routes_OverviewQuery.graphql.ts
@@ -152,11 +152,16 @@ export type routes_OverviewQueryRawResponse = {
             }) | null> | null;
         }) | null;
         readonly slug: string;
+        readonly href: string | null;
+        readonly image: ({
+            readonly cropped: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null;
         readonly statuses: ({
             readonly artworks: boolean | null;
             readonly cv: boolean | null;
         }) | null;
-        readonly href: string | null;
         readonly is_consignable: boolean | null;
         readonly showsConnection: ({
             readonly edges: ReadonlyArray<({
@@ -213,6 +218,18 @@ query routes_OverviewQuery(
 fragment ArtistBio_bio on Artist {
   biographyBlurb(format: HTML, partnerBio: true) {
     text
+  }
+}
+
+fragment ArtistConsignButton_artist on Artist {
+  internalID
+  slug
+  name
+  href
+  image {
+    cropped(width: 75, height: 66) {
+      url
+    }
   }
 }
 
@@ -391,6 +408,7 @@ fragment Overview_artist on Artist {
   ...Genes_artist
   ...FollowArtistButton_artist
   ...WorksForSaleRail_artist
+  ...ArtistConsignButton_artist
   slug
   id
   statuses {
@@ -1426,6 +1444,39 @@ return {
             ]
           },
           (v8/*: any*/),
+          (v6/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "cropped",
+                "storageKey": "cropped(height:66,width:75)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 66
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 75
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "plural": false,
+                "selections": (v4/*: any*/)
+              }
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -1451,7 +1502,6 @@ return {
               }
             ]
           },
-          (v6/*: any*/),
           {
             "kind": "ScalarField",
             "alias": "is_consignable",
@@ -1677,7 +1727,7 @@ return {
     "operationKind": "query",
     "name": "routes_OverviewQuery",
     "id": null,
-    "text": "query routes_OverviewQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Overview_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MarketInsights_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Overview_artist on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsights_artist\n  ...SelectedCareerAchievements_artist\n  ...Genes_artist\n  ...FollowArtistButton_artist\n  ...WorksForSaleRail_artist\n  slug\n  id\n  statuses {\n    artworks\n    cv(minShowCount: 0)\n  }\n  counts {\n    partner_shows: partnerShows\n    forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  href\n  name\n  is_consignable: isConsignable\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  showsConnection(first: 5, sort: END_AT_ASC, status: \"running\") {\n    edges {\n      node {\n        name\n        href\n        exhibitionPeriod\n        coverImage {\n          cropped(width: 220, height: 140) {\n            url\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n  }\n  articlesConnection(first: 4, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        href\n        thumbnailTitle\n        publishedAt(format: \"MMM Do, YYYY\")\n        thumbnailImage {\n          cropped(width: 120, height: 80) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment WorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n",
+    "text": "query routes_OverviewQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Overview_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistConsignButton_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 75, height: 66) {\n      url\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment CurrentEvent_artist on Artist {\n  currentEvent {\n    event {\n      __typename\n      ... on Node {\n        id\n      }\n    }\n    image {\n      resized(width: 300) {\n        url\n      }\n    }\n    name\n    status\n    details\n    partner\n    href\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Genes_artist on Artist {\n  related {\n    genes {\n      edges {\n        node {\n          href\n          name\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment MarketInsights_artist on Artist {\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Overview_artist on Artist {\n  ...ArtistBio_bio\n  ...CurrentEvent_artist\n  ...MarketInsights_artist\n  ...SelectedCareerAchievements_artist\n  ...Genes_artist\n  ...FollowArtistButton_artist\n  ...WorksForSaleRail_artist\n  ...ArtistConsignButton_artist\n  slug\n  id\n  statuses {\n    artworks\n    cv(minShowCount: 0)\n  }\n  counts {\n    partner_shows: partnerShows\n    forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  href\n  name\n  is_consignable: isConsignable\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n  currentEvent {\n    name\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  showsConnection(first: 5, sort: END_AT_ASC, status: \"running\") {\n    edges {\n      node {\n        name\n        href\n        exhibitionPeriod\n        coverImage {\n          cropped(width: 220, height: 140) {\n            url\n            width\n            height\n          }\n        }\n        id\n      }\n    }\n  }\n  articlesConnection(first: 4, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        href\n        thumbnailTitle\n        publishedAt(format: \"MMM Do, YYYY\")\n        thumbnailImage {\n          cropped(width: 120, height: 80) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n  internalID\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment WorksForSaleRail_artist on Artist {\n  artworksConnection(first: 20, sort: AVAILABILITY_ASC) {\n    edges {\n      node {\n        id\n        image {\n          aspect_ratio: aspectRatio\n        }\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=86&projectKey=CSGN&modal=detail&selectedIssue=CSGN-109

This adds the new consign  button to the Artist/Overview page: 


#### Top 20: 

<img width="837" alt="Screen Shot 2020-03-30 at 1 33 25 PM" src="https://user-images.githubusercontent.com/236943/77959280-2d0bf380-728b-11ea-8b33-4eebacf81f83.png">


#### General Artist: 

<img width="849" alt="Screen Shot 2020-03-30 at 1 31 15 PM" src="https://user-images.githubusercontent.com/236943/77958990-bff85e00-728a-11ea-8673-c2418b419e74.png">
