### PR TITLE
Land on Work for Sale tab when coming from internal links

### DIFF
--- a/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -108,6 +108,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     return (
       <>
         {artists.map((artist, index) => {
+          const worksForSaleHref = artist.href + "/works-for-sale"
           return (
             <Box key={index}>
               <GenericSearchResultItem
@@ -115,7 +116,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
                 description={artist.bio}
                 imageUrl={artist.imageUrl}
                 entityType="Artist"
-                href={artist.href}
+                href={worksForSaleHref}
                 index={index}
                 term={term}
                 id={artist.internalID}

--- a/src/Apps/WorksForYou/WorksForYouArtistFeed.tsx
+++ b/src/Apps/WorksForYou/WorksForYouArtistFeed.tsx
@@ -58,6 +58,7 @@ export class WorksForYouArtistFeed extends React.Component<Props, State> {
       (forSale
         ? get(artist, p => p.counts.for_sale_artworks.toLocaleString(), "")
         : get(artist, p => p.counts.artworks.toLocaleString(), "")) + " Works"
+    const worksForSaleHref = artist.href + "/works-for-sale"
 
     return (
       <>
@@ -65,7 +66,7 @@ export class WorksForYouArtistFeed extends React.Component<Props, State> {
           name={artist.name}
           meta={meta}
           imageUrl={avatarImageUrl}
-          href={artist.href}
+          href={worksForSaleHref}
         />
 
         <Spacer mb={3} />

--- a/src/Apps/WorksForYou/WorksForYouFeed.tsx
+++ b/src/Apps/WorksForYou/WorksForYouFeed.tsx
@@ -84,6 +84,7 @@ export class WorksForYouFeed extends Component<Props, State> {
           ({ node }, index) => {
             const avatarImageUrl = get(node, p => p.image.resized.url)
             const meta = `${node.summary}, ${node.published_at}`
+            const worksForSaleHref = node.href + "/works-for-sale"
 
             return (
               <Box key={index}>
@@ -91,7 +92,7 @@ export class WorksForYouFeed extends Component<Props, State> {
                   name={node.artists}
                   meta={meta}
                   imageUrl={avatarImageUrl}
-                  href={node.href}
+                  href={worksForSaleHref}
                 />
 
                 <Spacer mb={3} />

--- a/src/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -53,9 +53,10 @@ export const NotificationMenuItems: React.FC<NotificationsMenuQueryResponse> = p
     <>
       {notifications.map(({ node }, index) => {
         const { artists, href, image, summary } = node
+        const worksForSaleHref = href + "/works-for-sale"
         return (
           <MenuItem
-            href={href}
+            href={worksForSaleHref}
             key={index}
             onClick={() => {
               handleClick(href, AnalyticsSchema.Subject.Notification)


### PR DESCRIPTION
[PURCHASE-1787]

https://www.artsy.net/works-for-you =>sort should be “most recent”

Activity feed bell => Sort should be “most recent”

Works by artists you follow rail 

From Search bar, Artist

They should land on Work For Sale

[PURCHASE-1787]: https://artsyproduct.atlassian.net/browse/PURCHASE-1787