### PR TITLE
[Consignments] Guard against missing data

### DIFF
--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
@@ -4,6 +4,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { getENV } from "Utils/getENV"
 
 import { ArtistConsignMeta_artist } from "__generated__/ArtistConsignMeta_artist.graphql"
+import { get } from "Utils/get"
 
 interface ArtistConsignMeta {
   artist: ArtistConsignMeta_artist
@@ -11,16 +12,14 @@ interface ArtistConsignMeta {
 
 export const ArtistConsignMeta: React.FC<ArtistConsignMeta> = props => {
   const {
-    artist: {
-      name,
-      href,
-      targetSupply: {
-        microfunnel: { artworks },
-      },
-    },
+    artist: { name, href, targetSupply },
   } = props
 
-  const imageURL = artworks[0].artwork.image.imageURL
+  const imageURL = get(
+    targetSupply,
+    p => p.microfunnel.artworks[0].artwork.image.imageURL
+  )
+
   const appURL = getENV("APP_URL")
   const title = `Sell Works by ${name}`
   const description = `Learn more about the market for ${name} works and receive a price estimate. Submit a work from ${name} for consignment, and our experts will guide you through selling with an auction house, gallery, or private collector.`

--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -15,6 +15,10 @@ interface ArtistConsignRecentlySoldProps {
 export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps> = ({
   artist,
 }) => {
+  if (!artist.targetSupply.microfunnel.randomArtworks) {
+    return null
+  }
+
   return (
     <SectionContainer>
       <Box textAlign="center">

--- a/src/Apps/Artist/Routes/Consign/Components/__tests__/ArtistConsignMeta.test.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/__tests__/ArtistConsignMeta.test.tsx
@@ -92,6 +92,22 @@ describe("ArtistConsignMeta", () => {
   })
 
   describe("image tags", () => {
+    it("doesn't blow up if no images", () => {
+      const wrapper = getWrapper({
+        artist: {
+          targetSupply: {
+            microfunnel: {
+              artworks: null,
+            },
+          },
+        },
+      })
+      expect(
+        wrapper.find("Meta").findWhere(c => c.props().name === "thumbnail")
+          .length
+      ).toEqual(0)
+    })
+
     it("does not output image tag if image not available", () => {
       const wrapper = getWrapper({
         artist: {

--- a/src/Apps/Artist/Routes/Consign/__tests__/ConsignRoute.test.tsx
+++ b/src/Apps/Artist/Routes/Consign/__tests__/ConsignRoute.test.tsx
@@ -2,6 +2,7 @@ import { ConsignRouteFixture } from "Apps/__tests__/Fixtures/Artist/Routes/Consi
 import { SystemContextProvider } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { MockBoot, renderRelayTree } from "DevTools"
+import { cloneDeep } from "lodash"
 import React from "react"
 import { graphql } from "relay-runtime"
 import { ConsignRouteFragmentContainer } from "../index"
@@ -96,6 +97,13 @@ describe("ConsignRoute", () => {
   })
 
   describe("ArtistConsignRecentlySold", () => {
+    it("returns null if no recently sold images", async () => {
+      const artistWithoutArtworks = cloneDeep(ConsignRouteFixture) as any
+      artistWithoutArtworks.artist.targetSupply.microfunnel.artworks = null
+      const wrapper = await getWrapper(artistWithoutArtworks)
+      expect(wrapper.find("ArtistConsignRecentlySold")).toEqual({})
+    })
+
     it("includes artist name in recently sold", async () => {
       const wrapper = await getWrapper()
       expect(

--- a/src/Apps/Artist/Routes/Consign/index.tsx
+++ b/src/Apps/Artist/Routes/Consign/index.tsx
@@ -21,7 +21,7 @@ export interface ConsignRouteProps {
 
 export const ConsignRoute: React.FC<ConsignRouteProps> = ({ artist }) => {
   return (
-    <Box>
+    <Box minHeight={1000}>
       <ArtistConsignMeta artist={artist} />
       <ArtistConsignHeader artist={artist} />
       <ArtistConsignRecentlySold artist={artist} />

--- a/src/Apps/Artist/Routes/Consign/index.tsx
+++ b/src/Apps/Artist/Routes/Consign/index.tsx
@@ -21,7 +21,7 @@ export interface ConsignRouteProps {
 
 export const ConsignRoute: React.FC<ConsignRouteProps> = ({ artist }) => {
   return (
-    <Box minHeight={1000}>
+    <Box>
       <ArtistConsignMeta artist={artist} />
       <ArtistConsignHeader artist={artist} />
       <ArtistConsignRecentlySold artist={artist} />

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -72,6 +72,7 @@ const ShowsRoute = loadable(() => import("./Routes/Shows"))
 // Artist pages tend to load almost instantly, so just preload it up front
 if (typeof window !== "undefined") {
   ArtistApp.preload()
+  ConsignRoute.preload()
 }
 
 // FIXME:
@@ -97,7 +98,7 @@ export const routes: RouteConfig[] = [
         const { artist } = props as any
 
         if (!artist) {
-          return null
+          return undefined
         }
 
         const showArtistInsights =
@@ -241,7 +242,7 @@ export const routes: RouteConfig[] = [
         displayFullPage: true,
         render: ({ Component, props, match }) => {
           if (!(Component && props)) {
-            return null
+            return undefined
           }
 
           const artistPathName = match.location.pathname.replace("/consign", "")

--- a/src/Apps/__stories__/ArtistApp.story.tsx
+++ b/src/Apps/__stories__/ArtistApp.story.tsx
@@ -189,8 +189,11 @@ storiesOf("Apps/Artist", module)
       />
     )
   })
-  .add("Artist-- Consign - banksy", () => {
+  .add("Artist-- Consign - no recently sold", () => {
     return (
-      <MockRouter routes={artistRoutes} initialRoute="/artist/banksy/consign" />
+      <MockRouter
+        routes={artistRoutes}
+        initialRoute="/artist/genieve-figgis/consign"
+      />
     )
   })


### PR DESCRIPTION
Noticed that `artsy.net/artist/genieve-figgis/consign` has no recently sold artworks, but is still in the microfunnel, and thus breaks as the assumption was that only artists with sold items were in this list. This guards against this case in the future by hiding the section entirely. 

#trivial 