### PR TITLE
[FX-1885] restructure the main nav menu

### DIFF
--- a/src/Components/NavBar/Menus/MoreNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MoreNavMenu.tsx
@@ -24,13 +24,8 @@ export const MoreNavMenu: React.FC<{ width?: number }> = ({ width = 160 }) => {
       {/*
         Hide nav items at md / lg as they appear in the top nav
       */}
-      <MenuItem href="/galleries" display={["block", "block", "none"]}>
-        Galleries
-      </MenuItem>
-      <MenuItem href="/fairs" display={["block", "block", "block", "none"]}>
-        Fairs
-      </MenuItem>
-      <MenuItem href="/artists">Artists</MenuItem>
+      <MenuItem href="/galleries">Galleries</MenuItem>
+      <MenuItem href="/fairs">Fairs</MenuItem>
       <MenuItem href="/shows">Shows</MenuItem>
       <MenuItem href="/institutions">Museums</MenuItem>
       <MenuItem href="/consign">Consign</MenuItem>

--- a/src/Components/NavBar/Menus/__tests__/MoreNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/MoreNavMenu.test.tsx
@@ -16,7 +16,6 @@ describe("MoreNavMenu", () => {
   const defaultLinks = [
     ["/galleries", "Galleries"],
     ["/fairs", "Fairs"],
-    ["/artists", "Artists"],
     ["/shows", "Shows"],
     ["/institutions", "Museums"],
     ["/consign", "Consign"],

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -88,18 +88,8 @@ export const NavBar: React.FC = track(
         <NavSection display={["none", "none", "flex"]}>
           <NavSection>
             <NavItem href="/collect">Artworks</NavItem>
+            <NavItem href="/artists">Artists</NavItem>
             <NavItem href="/auctions">Auctions</NavItem>
-            <NavItem href="/galleries">Galleries</NavItem>
-
-            {/**
-              Only show Fairs at `xlg`
-            */}
-            <NavItem
-              href="/art-fairs"
-              display={["none", "none", "none", "none", "block"]}
-            >
-              Fairs
-            </NavItem>
             <NavItem href="/articles">Editorial</NavItem>
             <NavItem
               Menu={() => {

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -52,9 +52,8 @@ describe("NavBar", () => {
   describe("desktop", () => {
     const defaultLinks = [
       ["/collect", "Artworks"],
+      ["/artists", "Artists"],
       ["/auctions", "Auctions"],
-      ["/galleries", "Galleries"],
-      ["/art-fairs", "Fairs"],
       ["/articles", "Editorial"],
     ]
 


### PR DESCRIPTION
Addresses: [FX-1885](https://artsyproduct.atlassian.net/browse/FX-1885)

This restructures the main desktop nav menu to expose Artworks, Artists, Auctions, and Editorial and place everything else in the More menu.

**Before Nav Menu Change:**
<img width="1606" alt="Screen Shot 2020-04-01 at 4 20 55 PM" src="https://user-images.githubusercontent.com/5201004/78182908-0984ac80-7435-11ea-8347-47ca2a624c29.png">



**After Nav Menu Change:**
<img width="1605" alt="Screen Shot 2020-04-01 at 4 25 31 PM" src="https://user-images.githubusercontent.com/5201004/78183186-78fa9c00-7435-11ea-86d0-7ad599c6b8fb.png">

