### PR TITLE
Use "Artsy for Galleries" instead of "Partner with Artsy" naming in mobile nav

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu/index.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/index.tsx
@@ -49,7 +49,7 @@ export const MobileNavMenu: React.FC<Props> = props => {
             <MobileLink href="/shows">Shows</MobileLink>
             <MobileLink href="/institutions">Museums</MobileLink>
             <MobileLink href="/gallery-partnerships">
-              Partner with Artsy
+              Artsy for Galleries
             </MobileLink>
             {user ? <LoggedInLinks /> : <AuthenticateLinks />}
           </ul>

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -440,7 +440,7 @@ export const menuData: MenuData = {
       href: "/institutions",
     },
     {
-      text: "Partner with Artsy",
+      text: "Artsy for Galleries",
       href: "/gallery-partnerships",
     },
     // TODO: links here for logged-in vs. logged-out state


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/FX-1880

![image](https://user-images.githubusercontent.com/2081340/78279541-aef75900-74e5-11ea-9c4e-ea49eb56c6e0.png)
