### PR TITLE
[Bugfix] Add missing `action` call to ArtworkConsignButton

### DIFF
--- a/src/Apps/Artist/Components/ArtistConsignButton.tsx
+++ b/src/Apps/Artist/Components/ArtistConsignButton.tsx
@@ -27,6 +27,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = ({
 
   const trackGetStartedClick = ({ destinationPath }) => {
     tracking.trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
       context_page: AnalyticsSchema.PageName.ArtistPage,
       context_page_owner_id: artist.internalID,
       context_page_owner_slug: artist.slug,

--- a/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistConsignButton.test.tsx
@@ -77,6 +77,7 @@ describe("ArtistConsignButton", () => {
     }
 
     const analyticsEvent = {
+      action_type: "Click",
       context_page: "Artist",
       context_page_owner_id: response.artist.internalID,
       context_page_owner_slug: response.artist.slug,
@@ -173,6 +174,7 @@ describe("ArtistConsignButton", () => {
     }
 
     const analyticsEvent = {
+      action_type: "Click",
       context_page: "Artist",
       context_page_owner_id: response.artist.internalID,
       context_page_owner_slug: response.artist.slug,


### PR DESCRIPTION
Was flagged that tracking was missing from the button click and noticed that `action` was missing from the schema props. 

Raised the issue here in an effort to make things a little more frictionless: https://artsy.slack.com/archives/C0KEQD4B0/p1585865660062300

#trivial 
