### PR TITLE
[Clientside Nav] Use app shell top-loader by default

### DIFF
--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -154,6 +154,7 @@ export const routes: RouteConfig[] = [
         prepare: () => {
           OverviewRoute.preload()
         },
+        fetchIndicator: "spinner",
         displayNavigationTabs: true,
         query: graphql`
           query routes_OverviewQuery($artistID: String!) @raw_response_type {
@@ -169,6 +170,7 @@ export const routes: RouteConfig[] = [
         prepare: () => {
           WorksForSaleRoute.preload()
         },
+        fetchIndicator: "spinner",
         displayNavigationTabs: true,
         query: graphql`
           query routes_WorksQuery(
@@ -248,6 +250,7 @@ export const routes: RouteConfig[] = [
         prepare: () => {
           AuctionResultsRoute.preload()
         },
+        fetchIndicator: "spinner",
         displayNavigationTabs: true,
         query: graphql`
           query routes_AuctionResultsQuery($artistID: String!) {

--- a/src/Artsy/Router/Route.tsx
+++ b/src/Artsy/Router/Route.tsx
@@ -4,7 +4,6 @@
  */
 
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
-import { HttpError } from "found"
 import BaseRoute from "found/lib/Route"
 import React from "react"
 

--- a/src/Artsy/Router/Route.tsx
+++ b/src/Artsy/Router/Route.tsx
@@ -22,12 +22,12 @@ interface RenderArgProps {
 }
 
 function createRender({
-  fetchIndicator = "spinner",
+  fetchIndicator = "overlay",
   render,
 }: CreateRenderProps) {
   return (renderArgs: RenderArgProps) => {
     const { Component, props, error } = renderArgs
-    if (error && error instanceof HttpError) {
+    if (error) {
       throw error
     }
 
@@ -71,9 +71,15 @@ function createRender({
           };
         */
 
-        return
+        /**
+         * Its an odd requirement, but the way in which one triggers RenderStatus
+         * component updates is to return undefined.
+         */
+        return undefined
+
+        // If for some reason something else is passed, fall back to the spinner
       } else {
-        return
+        return <RouteSpinner />
       }
     }
 

--- a/src/Artsy/Router/__tests__/buildServerApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildServerApp.test.tsx
@@ -239,14 +239,14 @@ describe("buildServerApp", () => {
         }),
       })
       const relayEnvironment = createRelaySSREnvironment({ relayNetwork })
-      // try {
-      await getWrapper({
-        url: "/relay",
-        context: { relayEnvironment },
-      })
-      // } catch (error) {
-      // expect(error.message).toMatch(/Oh noes/)
-      // }
+      try {
+        await getWrapper({
+          url: "/relay",
+          context: { relayEnvironment },
+        })
+      } catch (error) {
+        expect(error.message).toMatch(/Oh noes/)
+      }
     })
   })
 })

--- a/src/Components/Modal/ErrorModal.tsx
+++ b/src/Components/Modal/ErrorModal.tsx
@@ -2,6 +2,7 @@ import { Box, Link } from "@artsy/palette"
 import React from "react"
 import { getENV } from "Utils/getENV"
 import { ModalDialog } from "./ModalDialog"
+import { ModalWidth } from "./ModalWrapper"
 
 interface ErrorModalProps {
   show?: boolean
@@ -40,12 +41,15 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
     } = this.props
     const emailAddress = contactEmail ? contactEmail : "support@artsy.net"
     const showErrorStack = errorStack && getENV("NODE_ENV") !== "production"
+    const width =
+      getENV("NODE_ENV") === "development" ? ModalWidth.Wide : ModalWidth.Narrow
 
     return (
       <ModalDialog
         show={show}
         onClose={onClose}
         heading={headerText}
+        width={width}
         detail={
           <>
             {detailText || (
@@ -57,7 +61,7 @@ export class ErrorModal extends React.Component<ErrorModalProps> {
 
             {showErrorStack && (
               <Box py={3}>
-                <Box>{errorStack}</Box>
+                <Box style={{ whiteSpace: "pre-wrap" }}>{errorStack}</Box>
               </Box>
             )}
           </>

--- a/src/Components/Modal/ModalDialog.tsx
+++ b/src/Components/Modal/ModalDialog.tsx
@@ -15,9 +15,14 @@ export interface ModalDialogProps {
   primaryCta: CtaProps
   secondaryCta?: CtaProps
   onClose?: () => void
+  width?: ModalWidth
 }
 
 export class ModalDialog extends React.Component<ModalDialogProps> {
+  static defaultProps = {
+    width: ModalWidth.Narrow,
+  }
+
   render() {
     const {
       show,
@@ -26,13 +31,14 @@ export class ModalDialog extends React.Component<ModalDialogProps> {
       onClose,
       primaryCta,
       secondaryCta,
+      width,
     } = this.props
 
     return (
       <ModalWrapper
         show={show}
         onClose={onClose || (() => undefined)}
-        width={ModalWidth.Narrow}
+        width={width}
       >
         <Flex flexDirection="column" pt={2} px={2}>
           <Sans size="4" weight="medium" mb={10}>


### PR DESCRIPTION
We have the loader split between a few different styles, from the spinner to the top purple bar. Rather than default to spinner on route transition, which was in place before the router work, lets use the purple bar by default unless we explicitly want the spinner. (Spinner is good for nested content like artist tabs)

Also cleans up error modal stack trace a bit by making it wider in development and respecting `\n` breaks: 

<img width="345" alt="Screen Shot 2020-04-02 at 10 13 30 PM" src="https://user-images.githubusercontent.com/236943/78326592-a3308480-752f-11ea-9244-1437cbe72178.png">
