### PR TITLE
Remove contextModule from auction redirect

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
@@ -65,7 +65,7 @@ export class ArtworkSidebarBidAction extends React.Component<
   redirectToBid(firstIncrement: number) {
     const { slug, sale } = this.props.artwork
     const bid = this.state.selectedMaxBidCents || firstIncrement
-    const href = `/auction/${sale.slug}/bid/${slug}?bid=${bid}&contextModule=artworkSidebar`
+    const href = `/auction/${sale.slug}/bid/${slug}?bid=${bid}`
     window.location.href = href
   }
 


### PR DESCRIPTION
Hotfix follow up to Analytics changes.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.0.2-canary.3343.56457.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.0.2-canary.3343.56457.0
  # or 
  yarn add @artsy/reaction@26.0.2-canary.3343.56457.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
