### PR TITLE
[Route] Log generic errors but throw on HttpError

### DIFF
--- a/src/Artsy/Router/Route.tsx
+++ b/src/Artsy/Router/Route.tsx
@@ -4,6 +4,7 @@
  */
 
 import { RouteSpinner } from "Artsy/Relay/renderWithLoadProgress"
+import { HttpError } from "found"
 import BaseRoute from "found/lib/Route"
 import React from "react"
 
@@ -27,7 +28,14 @@ function createRender({
   return (renderArgs: RenderArgProps) => {
     const { Component, props, error } = renderArgs
     if (error) {
-      throw error
+      if (error instanceof HttpError) {
+        throw error
+      }
+      console.error(
+        "[Artsy/Router/Route] Non HttpError rendering route:",
+        error
+      )
+      return null
     }
 
     if (render) {


### PR DESCRIPTION
This reverts a change in https://github.com/artsy/reaction/pull/3342.

In short, I noticed that we were masking errors in our routing layer by only throwing if it was an HTTP error. If a non-http error throws in the stack during a fetch it would get quietly consumed. In most cases this is fine as we surface these errors in other ways (such as our ErrorBoundary) but if something threw inside of our graphql stack [as this test shows](https://github.com/damassi/reaction/blob/914699fbe737dba9ece6bc9ff8e48ef6bdd3c7e1/src/Artsy/Router/__tests__/buildServerApp.test.tsx#L233-L253) we would never know about it. 

This ended up failing our acceptance test because it surfaced a masked error related to fixture data (or something):

<img width="904" alt="Screen Shot 2020-04-03 at 4 20 46 PM" src="https://user-images.githubusercontent.com/236943/78412277-9cede700-75c7-11ea-96fb-25d13cb19d74.png">

In any case, reverting that change and simply logging the error so that it's traceable if need be. 

