### PR TITLE
[Clientside Nav] Clear cache on mutation

### DIFF
--- a/src/Artsy/Relay/createRelaySSREnvironment.ts
+++ b/src/Artsy/Relay/createRelaySSREnvironment.ts
@@ -98,6 +98,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
     cacheMiddleware({
       size: 100, // max 100 requests
       ttl: 900000, // 15 minutes
+      clearOnMutation: true,
       onInit: queryResponseCache => {
         if (!isServer) {
           hydrateCacheFromSSR(queryResponseCache)


### PR DESCRIPTION
Noticed an issue where clicking an artist, clicking follow, then clicking an artwork, then clicking back to an artist the follow button wasn't selected because we had a cache hit on artist view. 

There's a config setting in our network layer to bust cache on mutations. Setting this to true. 

![cache](https://user-images.githubusercontent.com/236943/78588715-f5a1c780-77f3-11ea-9006-ef32b3d85ffb.gif)
