### PR TITLE
Update `back to <artist>` links to point directly to the overview page

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -82,7 +82,7 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
                     />
                     <Sans size="3" weight="medium" color="black100" ml="3px">
                       <StyledLink
-                        to={`/artist/${artist.slug}`}
+                        to={`/artist/${artist.slug}/overview`}
                         onClick={() =>
                           trackEvent({
                             action_type: Schema.ActionType.Click,


### PR DESCRIPTION
[PURCHASE-1853]
Currently on the cv, shows, and article pages there's a Back to <artist> link that the top which points to the root artist page (/). Given that we're doing redirects now when a user is logged in to the works-for-sale tab, it won't take logged in users who navigated to that page explicitly back to the overview which is a confusing experience. 

We should change all of those links to go specifically to /overview

Here's an example of what the link on https://www.artsy.net/artist/andy-warhol/cv

[PURCHASE-1853]: https://artsyproduct.atlassian.net/browse/PURCHASE-1853