### PR TITLE
Adds video support for the Art Keeps Going campaign

### DIFF
--- a/src/Apps/FeatureAKG/Components/Feature.tsx
+++ b/src/Apps/FeatureAKG/Components/Feature.tsx
@@ -10,7 +10,8 @@ import { useSystemContext } from "Artsy/SystemContext"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { crop, resize } from "Utils/resizer"
+import { crop } from "Utils/resizer"
+import { Media } from "Utils/Responsive"
 
 interface FeatureProps {
   viewer: Feature_viewer
@@ -23,17 +24,14 @@ const Feature: React.FC<FeatureProps> = props => {
     return null
   }
 
-  const resizedUrl = resize(injectedData.hero_video_src, {
-    width: 1190,
-    quality: 80,
-    convert_to: "jpg",
-  })
-
   const featuredThisWeek = injectedData.featured_this_week
   const editorial = injectedData.editorial
   const selectedWorks = injectedData.selected_works
   const featuredArtists = injectedData.featured_artists
   const featuredRails = injectedData.browse
+  const heroVideo = injectedData.hero_video
+  const video1 = injectedData.video_1
+  const video2 = injectedData.video_2
 
   const showRails =
     featuredRails?.collections_rail?.items?.length ||
@@ -42,9 +40,20 @@ const Feature: React.FC<FeatureProps> = props => {
 
   return (
     <>
-      <Box width="100%">
-        <Image src={resizedUrl} />
-      </Box>
+      <Media greaterThanOrEqual="md">
+        {heroVideo?.large_src && (
+          <Box textAlign="center">
+            <Video src={heroVideo.large_src} />
+          </Box>
+        )}
+      </Media>
+      <Media lessThan="md">
+        {heroVideo?.small_src && (
+          <Box textAlign="center">
+            <Video src={heroVideo.small_src} />
+          </Box>
+        )}
+      </Media>
       <Box pt="3" maxWidth="475px" m="0 auto">
         <Sans size="4" mx="3" weight="medium">
           {injectedData.description}
@@ -67,6 +76,12 @@ const Feature: React.FC<FeatureProps> = props => {
       )}
 
       {/* Video 1 */}
+      <Media greaterThanOrEqual="md">
+        {video1?.large_src && <VideoSection src={video1.large_src} />}
+      </Media>
+      <Media lessThan="md">
+        {video1?.small_src && <VideoSection src={video1.small_src} />}
+      </Media>
 
       {/* Selected works */}
       {selectedWorks?.set_id && (
@@ -79,6 +94,12 @@ const Feature: React.FC<FeatureProps> = props => {
       )}
 
       {/* Video 2 */}
+      <Media greaterThanOrEqual="md">
+        {video2?.large_src && <VideoSection src={video2.large_src} />}
+      </Media>
+      <Media lessThan="md">
+        {video2?.small_src && <VideoSection src={video2.small_src} />}
+      </Media>
 
       {/* Featured Artists */}
       {featuredArtists?.artists?.length && (
@@ -149,6 +170,24 @@ const Section: React.FC<SectionProps> = props => {
         {props.children}
       </Box>
     </Box>
+  )
+}
+
+const VideoSection: React.FC<{ src: string }> = props => {
+  // Constrain the height, add 1px for the border
+  return (
+    <Box mb="-40px" height="591px">
+      <SectionSeparator mt="4" />
+      <Box textAlign="center">
+        <Video src={props.src} />
+      </Box>
+    </Box>
+  )
+}
+
+const Video: React.FC<{ src: string }> = props => {
+  return (
+    <video autoPlay loop muted playsInline controls={false} src={props.src} />
   )
 }
 

--- a/src/Apps/FeatureAKG/__tests__/FeatureAKGRoute.test.tsx
+++ b/src/Apps/FeatureAKG/__tests__/FeatureAKGRoute.test.tsx
@@ -3,6 +3,7 @@ import { MockBoot, renderRelayTree } from "DevTools"
 import React from "react"
 import { graphql } from "relay-runtime"
 
+import { Breakpoint } from "@artsy/palette"
 import { FeatureAKGRoute_Test_QueryRawResponse } from "__generated__/FeatureAKGRoute_Test_Query.graphql"
 import { FeatureAppFragmentContainer } from "../FeatureApp"
 
@@ -29,12 +30,13 @@ describe("FeatureAKG", () => {
   const getWrapper = async (
     response: FeatureAKGRoute_Test_QueryRawResponse = ArtKeepsGoingFixture,
     variables = defaultVariables,
-    injectedData = defaultData
+    injectedData = defaultData,
+    breakpoint: Breakpoint = "xl"
   ) => {
     return await renderRelayTree({
       Component: ({ viewer }) => {
         return (
-          <MockBoot context={{ injectedData }}>
+          <MockBoot breakpoint={breakpoint} context={{ injectedData }}>
             <FeatureAppFragmentContainer viewer={viewer} />
           </MockBoot>
         )
@@ -90,6 +92,101 @@ describe("FeatureAKG", () => {
 
     it("displays the correct number of sections", () => {
       expect(defaultWrapper.find("Section").length).toEqual(5)
+    })
+  })
+
+  describe("Videos", () => {
+    it("displays the large videos at the large breakpoint", () => {
+      expect(defaultWrapper.html()).toContain("video_1_large")
+      expect(defaultWrapper.html()).toContain("video_2_large")
+      expect(defaultWrapper.html()).toContain("hero_video_large")
+
+      // Does not display small videos
+      expect(defaultWrapper.html()).not.toContain("video_1_small")
+      expect(defaultWrapper.html()).not.toContain("video_2_small")
+      expect(defaultWrapper.html()).not.toContain("hero_video_small")
+    })
+
+    it("displays the small videos at the small breakpoint", async () => {
+      const smallWrapper = await getWrapper(
+        ArtKeepsGoingFixture,
+        defaultVariables,
+        defaultData,
+        "sm"
+      )
+      expect(smallWrapper.html()).not.toContain("video_1_large")
+      expect(smallWrapper.html()).not.toContain("video_2_large")
+      expect(smallWrapper.html()).not.toContain("hero_video_large")
+
+      // Does not display small videos
+      expect(smallWrapper.html()).toContain("video_1_small")
+      expect(smallWrapper.html()).toContain("video_2_small")
+      expect(smallWrapper.html()).toContain("hero_video_small")
+    })
+
+    it("displays no videos if none specified at the large breakpoint", async () => {
+      const largeWrapperData = {
+        ...defaultData,
+        video_1: {
+          ...defaultData.video_1,
+          large_src: null,
+        },
+        video_2: {
+          ...defaultData.video_2,
+          large_src: null,
+        },
+        hero_video: {
+          ...defaultData.hero_video,
+          large_src: null,
+        },
+      }
+
+      const largeWrapper = await getWrapper(
+        ArtKeepsGoingFixture,
+        defaultVariables,
+        largeWrapperData
+      )
+      expect(largeWrapper.html()).not.toContain("video_1_large")
+      expect(largeWrapper.html()).not.toContain("video_2_large")
+      expect(largeWrapper.html()).not.toContain("hero_video_large")
+
+      // Does not display small videos
+      expect(largeWrapper.html()).not.toContain("video_1_small")
+      expect(largeWrapper.html()).not.toContain("video_2_small")
+      expect(largeWrapper.html()).not.toContain("hero_video_small")
+    })
+
+    it("displays no videos if none specified at the small breakpoint", async () => {
+      const smallWrapperData = {
+        ...defaultData,
+        video_1: {
+          ...defaultData.video_1,
+          small_src: null,
+        },
+        video_2: {
+          ...defaultData.video_2,
+          small_src: null,
+        },
+        hero_video: {
+          ...defaultData.hero_video,
+          small_src: null,
+        },
+      }
+
+      const smallWrapper = await getWrapper(
+        ArtKeepsGoingFixture,
+        defaultVariables,
+        smallWrapperData,
+        "sm"
+      )
+      expect(smallWrapper.html()).not.toContain("video_1_large")
+      expect(smallWrapper.html()).not.toContain("video_2_large")
+      expect(smallWrapper.html()).not.toContain("hero_video_large")
+
+      // Does not display small videos
+      expect(smallWrapper.html()).not.toContain("video_1_small")
+      expect(smallWrapper.html()).not.toContain("video_2_small")
+      expect(smallWrapper.html()).not.toContain("hero_video_small")
     })
   })
 
@@ -567,15 +664,23 @@ const defaultData = {
     subtitle: null,
     title: "Featured This Week",
   },
-  hero_video_src:
-    "https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/The-Last-Supper-Restored-Da-Vinci_32x16.jpg/1600px-The-Last-Supper-Restored-Da-Vinci_32x16.jpg",
   selected_works: {
     set_id: "56e057c8139b213d70002393",
     subtitle: "10% of all proceeds to go to Charity Name",
     title: "Selected Works",
   },
-  video_1_src: null,
-  video_2_src: null,
+  video_1: {
+    small_src: "http://files.artsy.net/video_1_small.mp4",
+    large_src: "http://files.artsy.net/video_1_large.mp4",
+  },
+  video_2: {
+    small_src: "http://files.artsy.net/video_2_small.mp4",
+    large_src: "http://files.artsy.net/video_2_large.mp4",
+  },
+  hero_video: {
+    small_src: "http://files.artsy.net/hero_video_small.mp4",
+    large_src: "http://files.artsy.net/hero_video_large.mp4",
+  },
 }
 
 const ArtKeepsGoingFixture: FeatureAKGRoute_Test_QueryRawResponse = {


### PR DESCRIPTION
We have 3 different videos (one for the top and 2 sections in the middle), with two different assets depending on the breakpoint.

![akg-vids](https://user-images.githubusercontent.com/2081340/78608504-0a4f8100-782f-11ea-9f94-1fd155acbaaa.gif)
