### PR TITLE
[Experiment] SSR Render Collections rail on Apps/Artist

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -750,7 +750,14 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply
   years: String
-  marketingCollections(size: Int): [MarketingCollection]
+  marketingCollections(
+    slugs: [String!]
+    category: String
+    randomizationSeed: String
+    size: Int
+    isFeaturedArtistContent: Boolean
+    showOnEditorial: Boolean
+  ): [MarketingCollection]
 }
 
 type ArtistArtworkGrid implements ArtworkContextGrid {
@@ -4059,6 +4066,19 @@ type FairSponsoredContent {
   pressReleaseUrl: String
 }
 
+type FeaturedLink {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: String
+  href: String
+  image: Image
+  initials(length: Int = 3): String
+  subtitle: String
+  title: String
+}
+
 type Feedback {
   # A globally unique ID.
   id: ID!
@@ -5594,6 +5614,30 @@ type OpeningHoursText {
 
 union OpeningHoursUnion = OpeningHoursArray | OpeningHoursText
 
+type OrderedSet {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  cached: Int
+  description: String
+  key: String
+  itemType: String
+  items: [OrderedSetItem]
+
+  # Returns a connection of the items. Only Artwork supported right now.
+  itemsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+  name: String
+}
+
+union OrderedSetItem = Artist | Artwork | FeaturedLink | Gene
+
 union OrderParty = Partner | User
 
 type organizer {
@@ -5979,6 +6023,26 @@ type Query {
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
 
+  # An Article
+  article(
+    # The ID of the Article
+    id: String!
+  ): Article
+
+  # A list of Articles
+  articles(
+    auctionID: String
+
+    #
+    #         Only return articles matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    published: Boolean = true
+    showID: String
+    sort: ArticleSorts
+  ): [Article]
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
@@ -6080,6 +6144,25 @@ type Query {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A list of Fairs
+  fairs(
+    fairOrganizerID: String
+    hasFullFeature: Boolean
+    hasHomepageSection: Boolean
+    hasListing: Boolean
+
+    #
+    #         Only return fairs matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    near: Near
+    page: Int
+    size: Int
+    sort: FairSorts
+    status: EventStatus
+  ): [Fair]
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -6107,6 +6190,12 @@ type Query {
     id: ID!
   ): Node
 
+  # An OrderedSet
+  orderedSet(
+    # The ID of the OrderedSet
+    id: String!
+  ): OrderedSet
+
   # A Partner
   partner(
     # The slug or ID of the Partner
@@ -6121,6 +6210,12 @@ type Query {
 
   # A list of Sales
   salesConnection(
+    #
+    #         Only return sales matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+
     # Limit by auction.
     isAuction: Boolean = true
 
@@ -6310,6 +6405,7 @@ type Query {
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats
   marketingCollections(
+    slugs: [String!]
     category: String
     randomizationSeed: String
     size: Int
@@ -7624,6 +7720,26 @@ type Viewer {
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
 
+  # An Article
+  article(
+    # The ID of the Article
+    id: String!
+  ): Article
+
+  # A list of Articles
+  articles(
+    auctionID: String
+
+    #
+    #         Only return articles matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    published: Boolean = true
+    showID: String
+    sort: ArticleSorts
+  ): [Article]
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
@@ -7725,6 +7841,25 @@ type Viewer {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A list of Fairs
+  fairs(
+    fairOrganizerID: String
+    hasFullFeature: Boolean
+    hasHomepageSection: Boolean
+    hasListing: Boolean
+
+    #
+    #         Only return fairs matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    near: Near
+    page: Int
+    size: Int
+    sort: FairSorts
+    status: EventStatus
+  ): [Fair]
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -7752,6 +7887,12 @@ type Viewer {
     id: ID!
   ): Node
 
+  # An OrderedSet
+  orderedSet(
+    # The ID of the OrderedSet
+    id: String!
+  ): OrderedSet
+
   # A Partner
   partner(
     # The slug or ID of the Partner
@@ -7766,6 +7907,12 @@ type Viewer {
 
   # A list of Sales
   salesConnection(
+    #
+    #         Only return sales matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+
     # Limit by auction.
     isAuction: Boolean = true
 
@@ -7826,6 +7973,15 @@ type Viewer {
     # ID of the user
     id: String
   ): User
+  marketingCollections(
+    slugs: [String!]
+    category: String
+    randomizationSeed: String
+    size: Int
+    isFeaturedArtistContent: Boolean
+    showOnEditorial: Boolean
+    artistID: String
+  ): [MarketingCollection]
 }
 
 type YearRange {

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
@@ -13,10 +13,17 @@ interface ArtistArtworkFilterProps {
   relay: RelayRefetchProp
   sidebarAggregations: Works_artist["sidebarAggregations"]
   match?: Match
+  showTopBorder?: boolean
 }
 
 const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
-  const { match, relay, artist, sidebarAggregations } = props
+  const {
+    match,
+    relay,
+    artist,
+    sidebarAggregations,
+    showTopBorder = true,
+  } = props
   const { filtered_artworks } = artist
 
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -37,6 +44,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       ]}
       aggregations={sidebarAggregations.aggregations as any}
       counts={artist.counts}
+      showTopBorder={showTopBorder}
       onChange={updateUrl}
     >
       <BaseArtworkFilter

--- a/src/Apps/Artist/Routes/Works/__tests__/Works.test.tsx
+++ b/src/Apps/Artist/Routes/Works/__tests__/Works.test.tsx
@@ -1,4 +1,5 @@
 import { Works_Test_QueryRawResponse } from "__generated__/Works_Test_Query.graphql"
+import { ArtistCollectionsRailFragmentContainer as ArtistCollectionsRail } from "Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail"
 import { ArtistArtworkFilterRefetchContainer as ArtworkFilter } from "Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter"
 import { WorksRouteFragmentContainer as WorksRoute } from "Apps/Artist/Routes/Works"
 import { MockBoot, renderRelayTree } from "DevTools"
@@ -56,9 +57,21 @@ describe("Works Route", () => {
     })
 
     it("renders correct sections", () => {
+      expect(wrapper.find(ArtistCollectionsRail).length).toEqual(1)
       expect(wrapper.find(ArtworkFilter).length).toEqual(1)
       expect(wrapper.html()).toContain("Mock ArtistRecommendations")
-      expect(wrapper.html()).toContain("Mock ArtistCollectionRail")
+    })
+  })
+
+  describe("Artist Collections Rail", () => {
+    it("does not render rail if artist.collections is empty", async () => {
+      wrapper = await getWrapper("xl", {
+        artist: {
+          ...defaultWorks.artist,
+          collections: [],
+        },
+      })
+      expect(wrapper.find(ArtistCollectionsRail).length).toEqual(0)
     })
   })
 
@@ -121,6 +134,69 @@ const defaultWorks: Works_Test_QueryRawResponse = {
       artworks: 4995,
       has_make_offer_artworks: true,
     },
+    collections: [
+      {
+        headerImage: "",
+        slug: "banksy-girl-with-balloon",
+        title: "Banksy: Girl with Balloon",
+        price_guidance: 75000,
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                artist: {
+                  name: "Banksy",
+                  id: "QXJ0aXN0OjRkZDE1ODRkZTAwOTFlMDAwMTAwMjA3Yw==",
+                },
+                title: "Girl with Balloon (Unsigned)",
+                image: {
+                  resized: {
+                    url:
+                      "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=262&height=353&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fh29RjKvIQMaxZHcWx6Ws9g%2Flarge.jpg",
+                  },
+                },
+                id: "QXJ0d29yazo1ZTcyNGUwZTQwYmZhMjAwMGUxZTM0ZjA=",
+              },
+            },
+            {
+              node: {
+                artist: {
+                  name: "Banksy",
+                  id: "QXJ0aXN0OjRkZDE1ODRkZTAwOTFlMDAwMTAwMjA3Yw==",
+                },
+                title: "Girl With Balloon (Unsigned)",
+                image: {
+                  resized: {
+                    url:
+                      "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=262&height=377&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGelUGc-Z9pasoDBQxZLxwg%2Flarge.jpg",
+                  },
+                },
+                id: "QXJ0d29yazo1ZTVkM2U2ODFlM2Y0MzAwMGU0ODI2ZmU=",
+              },
+            },
+            {
+              node: {
+                artist: {
+                  name: "Banksy",
+                  id: "QXJ0aXN0OjRkZDE1ODRkZTAwOTFlMDAwMTAwMjA3Yw==",
+                },
+                title: "Girl with Balloon",
+                image: {
+                  resized: {
+                    url:
+                      "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=262&height=350&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FIIqkOV1aZDEsEaciki1ZRw%2Flarge.jpg",
+                  },
+                },
+                id: "QXJ0d29yazo1ZTAzMzE2NjVjMDBiZjAwMTM4MzUwODg=",
+              },
+            },
+          ],
+          id:
+            "ZmlsdGVyQXJ0d29ya3NDb25uZWN0aW9uOnsiYWdncmVnYXRpb25zIjpbInRvdGFsIl0sImFydGlzdF9pZHMiOlsiNGRkMTU4NGRlMDA5MWUwMDAxMDAyMDdjIl0sImdlbmVfaWRzIjpbXSwia2V5d29yZCI6Ikdpcmwgd2l0aCBCYWxsb29uIiwia2V5d29yZF9tYXRjaF9leGFjdCI6dHJ1ZSwicGFnZSI6MSwic2l6ZSI6Mywic29ydCI6Ii1kZWNheWVkX21lcmNoIn0=",
+        },
+        id: "5beb5aca1338c043ac8ae226",
+      },
+    ],
     filtered_artworks: {
       id:
         "ZmlsdGVyQXJ0d29ya3NDb25uZWN0aW9uOnsiYWdncmVnYXRpb25zIjpbInRvdGFsIl0sImFydGlzdF9pZCI6IjRkOGI5MmIzNGViNjhhMWIyYzAwMDNmNCIsInBhZ2UiOjEsInNpemUiOjMwLCJzb3J0IjoiLXBhcnRuZXJfdXBkYXRlZF9hdCJ9",

--- a/src/Apps/Artist/Routes/Works/index.tsx
+++ b/src/Apps/Artist/Routes/Works/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Col, Row, Separator } from "@artsy/palette"
 import { Works_artist } from "__generated__/Works_artist.graphql"
-import { ArtistCollectionsRailContent as ArtistCollectionsRail } from "Apps/Artist/Components/ArtistCollectionsRail"
+import { ArtistCollectionsRailFragmentContainer as ArtistCollectionsRail } from "Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail"
 import { ArtistArtworkFilterRefetchContainer as ArtworkFilter } from "Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter"
 import { ArtistRecommendationsQueryRenderer as ArtistRecommendations } from "Apps/Artist/Routes/Overview/Components/ArtistRecommendations"
 import React from "react"
@@ -22,12 +22,14 @@ export const WorksRoute: React.FC<WorksRouteProps> = props => {
 
   return (
     <>
-      <Box>
-        <ArtistCollectionsRail
-          artistID={artist.internalID}
-          includeTopSpacer={false}
-        />
-      </Box>
+      {props.artist.collections.length > 0 && (
+        <Box>
+          <ArtistCollectionsRail
+            collections={props.artist.collections}
+            includeTopSpacer={false}
+          />
+        </Box>
+      )}
 
       <Row>
         <Col>
@@ -36,6 +38,7 @@ export const WorksRoute: React.FC<WorksRouteProps> = props => {
           <ArtworkFilter
             artist={artist}
             sidebarAggregations={sidebarAggregations}
+            showTopBorder={artist.collections.length > 0}
           />
         </Col>
       </Row>
@@ -76,6 +79,15 @@ export const WorksRouteFragmentContainer = createFragmentContainer(WorksRoute, {
         width: { type: "String" }
       ) {
       internalID
+
+      ... on Artist {
+        collections: marketingCollections(
+          isFeaturedArtistContent: true
+          size: 16
+        ) {
+          ...ArtistCollectionsRail_collections
+        }
+      }
 
       related {
         artistsConnection(first: 1) {

--- a/src/Apps/Artist/routes.tsx
+++ b/src/Apps/Artist/routes.tsx
@@ -91,6 +91,7 @@ export const routes: RouteConfig[] = [
           id
         }
         artist(id: $artistID) @principalField {
+          internalID
           ...ArtistApp_artist
           ...routes_Artist @relay(mask: false)
         }

--- a/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -107,6 +107,9 @@ export interface ArtworkFilterContextProps {
   resetFilters: () => void
   setFilter: (name: keyof ArtworkFilters, value: any) => void
   unsetFilter: (name: keyof ArtworkFilters) => void
+
+  // Misc
+  showTopBorder?: boolean
 }
 
 /**
@@ -121,6 +124,7 @@ export const ArtworkFilterContext = React.createContext<
   rangeToTuple: null,
   resetFilters: null,
   setFilter: null,
+  showTopBorder: true,
   sortOptions: [],
   unsetFilter: null,
   ZeroState: null,
@@ -139,6 +143,7 @@ export type SharedArtworkFilterContextProps = Pick<
   | "sortOptions"
   | "onArtworkBrickClick"
   | "onFilterClick"
+  | "showTopBorder"
   | "ZeroState"
 > & {
   onChange?: (filterState) => void
@@ -155,6 +160,7 @@ export const ArtworkFilterContextProvider: React.FC<SharedArtworkFilterContextPr
   onChange,
   onFilterClick,
   sortOptions,
+  showTopBorder,
   ZeroState,
 }) => {
   const initialFilterState = {
@@ -191,6 +197,9 @@ export const ArtworkFilterContextProvider: React.FC<SharedArtworkFilterContextPr
     setAggregations,
     counts: artworkCounts,
     setCounts,
+
+    // Misc
+    showTopBorder,
 
     // Components
     ZeroState,

--- a/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Separator } from "@artsy/palette"
 import React from "react"
 
+import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { ColorFilter } from "./ColorFilter"
 import { GalleryFilter } from "./GalleryFilter"
 import { InstitutionFilter } from "./InstitutionFilter"
@@ -11,11 +12,16 @@ import { TimePeriodFilter } from "./TimePeriodFilter"
 import { WaysToBuyFilter } from "./WaysToBuyFilter"
 
 export const ArtworkFilters: React.FC = () => {
+  const { showTopBorder } = useArtworkFilterContext()
+
   return (
     <Box pr={2}>
-      <Box pb={2}>
-        <Separator />
-      </Box>
+      {showTopBorder && (
+        <Box pb={2}>
+          <Separator />
+        </Box>
+      )}
+
       <WaysToBuyFilter />
       <MediumFilter />
       <PriceRangeFilter />

--- a/src/Components/v2/ArtworkFilter/index.tsx
+++ b/src/Components/v2/ArtworkFilter/index.tsx
@@ -210,9 +210,12 @@ export const BaseArtworkFilter: React.FC<{
           </Box>
           <Box width="75%">
             <Box mb={2}>
-              <Box pb={2} mt={0.5}>
-                <Separator />
-              </Box>
+              {filterContext.showTopBorder && (
+                <Box pb={2} mt={0.5}>
+                  <Separator />
+                </Box>
+              )}
+
               <SortFilter />
             </Box>
 

--- a/src/__generated__/Works_Test_Query.graphql.ts
+++ b/src/__generated__/Works_Test_Query.graphql.ts
@@ -14,6 +14,31 @@ export type Works_Test_QueryResponse = {
 export type Works_Test_QueryRawResponse = {
     readonly artist: ({
         readonly internalID: string;
+        readonly collections: ReadonlyArray<({
+            readonly headerImage: string | null;
+            readonly slug: string;
+            readonly title: string;
+            readonly price_guidance: number | null;
+            readonly artworksConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly artist: ({
+                            readonly name: string | null;
+                            readonly id: string | null;
+                        }) | null;
+                        readonly title: string | null;
+                        readonly image: ({
+                            readonly resized: ({
+                                readonly url: string | null;
+                            }) | null;
+                        }) | null;
+                        readonly id: string | null;
+                    }) | null;
+                }) | null> | null;
+                readonly id: string | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
         readonly related: ({
             readonly artistsConnection: ({
                 readonly edges: ReadonlyArray<({
@@ -170,6 +195,35 @@ fragment ArtistArtworkFilter_artist_2W18tF on Artist {
     id
     ...ArtworkFilterArtworkGrid2_filtered_artworks
   }
+}
+
+fragment ArtistCollectionEntity_collection on MarketingCollection {
+  headerImage
+  slug
+  title
+  price_guidance: priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        artist {
+          name
+          id
+        }
+        title
+        image {
+          resized(width: 262) {
+            url
+          }
+        }
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  ...ArtistCollectionEntity_collection
 }
 
 fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
@@ -344,6 +398,10 @@ fragment Save_artwork on Artwork {
 
 fragment Works_artist on Artist {
   internalID
+  collections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   related {
     artistsConnection(first: 1) {
       edges {
@@ -393,63 +451,77 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v4 = {
-  "kind": "Literal",
-  "name": "after",
-  "value": ""
-},
-v5 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 30
-},
-v6 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "-partner_updated_at"
-},
-v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slice",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "value",
+  "name": "id",
   "args": null,
   "storageKey": null
+},
+v7 = {
+  "kind": "Literal",
+  "name": "after",
+  "value": ""
+},
+v8 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 30
+},
+v9 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-partner_updated_at"
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "cursor",
+  "name": "slice",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "value",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v12 = [
-  (v10/*: any*/),
-  (v11/*: any*/),
+v14 = [
+  (v12/*: any*/),
+  (v13/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -458,21 +530,21 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v14 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = [
+v17 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -525,6 +597,147 @@ return {
           (v2/*: any*/),
           {
             "kind": "LinkedField",
+            "alias": "collections",
+            "name": "marketingCollections",
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "headerImage",
+                "args": null,
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": "price_guidance",
+                "name": "priceGuidance",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artworksConnection",
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 3
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artist",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": false,
+                            "selections": [
+                              (v5/*: any*/),
+                              (v6/*: any*/)
+                            ]
+                          },
+                          (v4/*: any*/),
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "resized",
+                                "storageKey": "resized(width:262)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 262
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          (v6/*: any*/)
+                        ]
+                      }
+                    ]
+                  },
+                  (v6/*: any*/)
+                ]
+              },
+              (v6/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": null,
             "name": "related",
             "storageKey": null,
@@ -565,7 +778,7 @@ return {
                         "concreteType": "Artist",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/)
+                          (v6/*: any*/)
                         ]
                       }
                     ]
@@ -580,9 +793,9 @@ return {
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(after:\"\",first:30,sort:\"-partner_updated_at\")",
             "args": [
-              (v4/*: any*/),
-              (v5/*: any*/),
-              (v6/*: any*/)
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -596,7 +809,7 @@ return {
                 "concreteType": "ArtworksAggregationResults",
                 "plural": true,
                 "selections": [
-                  (v7/*: any*/),
+                  (v10/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -606,13 +819,13 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v5/*: any*/),
+                      (v11/*: any*/)
                     ]
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v6/*: any*/)
             ]
           },
           {
@@ -681,19 +894,19 @@ return {
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(after:\"\",first:30,medium:\"*\",sort:\"-partner_updated_at\")",
             "args": [
-              (v4/*: any*/),
-              (v5/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "medium",
                 "value": "*"
               },
-              (v6/*: any*/)
+              (v9/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -703,7 +916,7 @@ return {
                 "concreteType": "ArtworksAggregationResults",
                 "plural": true,
                 "selections": [
-                  (v7/*: any*/),
+                  (v10/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -713,8 +926,8 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v9/*: any*/),
-                      (v8/*: any*/),
+                      (v11/*: any*/),
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -768,7 +981,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v12/*: any*/)
+                    "selections": (v14/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -778,7 +991,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v12/*: any*/)
+                    "selections": (v14/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -788,7 +1001,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v12/*: any*/)
+                    "selections": (v14/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -799,8 +1012,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/),
-                      (v11/*: any*/)
+                      (v12/*: any*/),
+                      (v13/*: any*/)
                     ]
                   }
                 ]
@@ -823,15 +1036,9 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v6/*: any*/),
                       (v3/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "slug",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      (v13/*: any*/),
+                      (v15/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -871,13 +1078,7 @@ return {
                         ]
                       },
                       (v2/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "title",
-                        "args": null,
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "image_title",
@@ -911,13 +1112,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v14/*: any*/),
+                        "args": (v16/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v13/*: any*/),
-                          (v8/*: any*/)
+                          (v6/*: any*/),
+                          (v15/*: any*/),
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -932,13 +1133,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v14/*: any*/),
+                        "args": (v16/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
-                          (v13/*: any*/),
-                          (v3/*: any*/),
+                          (v5/*: any*/),
+                          (v15/*: any*/),
+                          (v6/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -971,7 +1172,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v6/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -1037,7 +1238,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v15/*: any*/)
+                            "selections": (v17/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1047,9 +1248,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v15/*: any*/)
+                            "selections": (v17/*: any*/)
                           },
-                          (v3/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -1089,12 +1290,12 @@ return {
                       }
                     ]
                   },
-                  (v3/*: any*/)
+                  (v6/*: any*/)
                 ]
               }
             ]
           },
-          (v3/*: any*/)
+          (v6/*: any*/)
         ]
       }
     ]
@@ -1103,7 +1304,7 @@ return {
     "operationKind": "query",
     "name": "Works_Test_Query",
     "id": null,
-    "text": "query Works_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Works_artist\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2W18tF on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 30, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_artist on Artist {\n  internalID\n  related {\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  sidebarAggregations: filterArtworksConnection(sort: \"-partner_updated_at\", first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_2W18tF\n}\n",
+    "text": "query Works_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Works_artist\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2W18tF on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 30, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_artist on Artist {\n  internalID\n  collections: marketingCollections(isFeaturedArtistContent: true, size: 16) {\n    ...ArtistCollectionsRail_collections\n    id\n  }\n  related {\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  sidebarAggregations: filterArtworksConnection(sort: \"-partner_updated_at\", first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_2W18tF\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Works_artist.graphql.ts
+++ b/src/__generated__/Works_artist.graphql.ts
@@ -5,6 +5,9 @@ export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS
 import { FragmentRefs } from "relay-runtime";
 export type Works_artist = {
     readonly internalID: string;
+    readonly collections: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_collections">;
+    } | null> | null;
     readonly related: {
         readonly artistsConnection: {
             readonly edges: ReadonlyArray<{
@@ -172,6 +175,33 @@ return {
       "name": "internalID",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "collections",
+      "name": "marketingCollections",
+      "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "isFeaturedArtistContent",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 16
+        }
+      ],
+      "concreteType": "MarketingCollection",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtistCollectionsRail_collections",
+          "args": null
+        }
+      ]
     },
     {
       "kind": "LinkedField",
@@ -385,5 +415,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '6af1a5b23990ff0078e21cbef30eff9b';
+(node as any).hash = 'b7af424c088cddafc14e06aaae5898d5';
 export default node;

--- a/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
+++ b/src/__generated__/routes_ArtistTopLevelQuery.graphql.ts
@@ -10,6 +10,7 @@ export type routes_ArtistTopLevelQueryResponse = {
         readonly id: string;
     } | null;
     readonly artist: {
+        readonly internalID: string;
         readonly slug: string;
         readonly statuses: {
             readonly shows: boolean | null;
@@ -217,6 +218,7 @@ query routes_ArtistTopLevelQuery(
     id
   }
   artist(id: $artistID) @principalField {
+    internalID
     ...ArtistApp_artist
     slug
     statuses {
@@ -484,18 +486,25 @@ v3 = [
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "shows",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "shows",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cv",
@@ -508,35 +517,35 @@ v6 = {
   ],
   "storageKey": "cv(minShowCount:0)"
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "articles",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "forSaleArtworks",
   "args": null,
   "storageKey": null
 },
-v9 = [
-  (v4/*: any*/)
+v10 = [
+  (v5/*: any*/)
 ],
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "displayOnPartnerProfile",
     "value": true
   },
-  (v10/*: any*/),
+  (v11/*: any*/),
   {
     "kind": "Literal",
     "name": "partnerCategory",
@@ -552,7 +561,7 @@ v11 = [
     "value": true
   }
 ],
-v12 = {
+v13 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "insights",
@@ -570,7 +579,7 @@ v12 = {
     }
   ]
 },
-v13 = {
+v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "biographyBlurb",
@@ -599,35 +608,35 @@ v13 = {
     }
   ]
 },
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "description",
   "args": null,
   "storageKey": null
 },
-v18 = {
+v19 = {
   "kind": "ScalarField",
   "alias": "large",
   "name": "url",
@@ -640,22 +649,22 @@ v18 = {
   ],
   "storageKey": "url(version:\"large\")"
 },
-v19 = {
+v20 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "artworks",
   "args": null,
   "storageKey": null
 },
-v20 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "major",
   "args": null,
   "storageKey": null
 },
-v21 = [
-  (v20/*: any*/),
+v22 = [
+  (v21/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -664,7 +673,7 @@ v21 = [
     "storageKey": null
   }
 ],
-v22 = {
+v23 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -686,20 +695,20 @@ v22 = {
       ],
       "storageKey": "url(version:\"small\")"
     },
-    (v18/*: any*/)
+    (v19/*: any*/)
   ]
 },
-v23 = [
-  (v4/*: any*/),
+v24 = [
+  (v5/*: any*/),
   (v1/*: any*/)
 ],
-v24 = [
+v25 = [
   {
     "kind": "LinkedField",
     "alias": null,
     "name": "partnersConnection",
     "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)",
-    "args": (v11/*: any*/),
+    "args": (v12/*: any*/),
     "concreteType": "PartnerArtistConnection",
     "plural": false,
     "selections": [
@@ -729,7 +738,7 @@ v24 = [
                 "args": null,
                 "concreteType": "PartnerCategory",
                 "plural": true,
-                "selections": (v23/*: any*/)
+                "selections": (v24/*: any*/)
               },
               (v1/*: any*/)
             ]
@@ -760,6 +769,7 @@ return {
         "plural": false,
         "selections": [
           (v4/*: any*/),
+          (v5/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -769,9 +779,9 @@ return {
             "concreteType": "ArtistStatuses",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
               (v6/*: any*/),
-              (v7/*: any*/)
+              (v7/*: any*/),
+              (v8/*: any*/)
             ]
           },
           {
@@ -783,7 +793,7 @@ return {
             "concreteType": "ArtistCounts",
             "plural": false,
             "selections": [
-              (v8/*: any*/)
+              (v9/*: any*/)
             ]
           },
           {
@@ -821,7 +831,7 @@ return {
                         "args": null,
                         "concreteType": "Gene",
                         "plural": false,
-                        "selections": (v9/*: any*/)
+                        "selections": (v10/*: any*/)
                       }
                     ]
                   }
@@ -843,7 +853,7 @@ return {
                 "alias": null,
                 "name": "partnersConnection",
                 "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)",
-                "args": (v11/*: any*/),
+                "args": (v12/*: any*/),
                 "concreteType": "PartnerArtistConnection",
                 "plural": false,
                 "selections": [
@@ -873,7 +883,7 @@ return {
                             "args": null,
                             "concreteType": "PartnerCategory",
                             "plural": true,
-                            "selections": (v9/*: any*/)
+                            "selections": (v10/*: any*/)
                           }
                         ]
                       }
@@ -883,8 +893,8 @@ return {
               }
             ]
           },
-          (v12/*: any*/),
           (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "FragmentSpread",
             "name": "ArtistApp_artist",
@@ -909,15 +919,9 @@ return {
         "concreteType": "Artist",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
-          (v14/*: any*/),
           (v4/*: any*/),
+          (v15/*: any*/),
+          (v5/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -946,7 +950,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v15/*: any*/),
+          (v16/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -956,8 +960,8 @@ return {
             "concreteType": "ArtistMeta",
             "plural": false,
             "selections": [
-              (v16/*: any*/),
-              (v17/*: any*/)
+              (v17/*: any*/),
+              (v18/*: any*/)
             ]
           },
           {
@@ -983,7 +987,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "square",
@@ -1008,7 +1012,7 @@ return {
             "concreteType": "ArtistCounts",
             "plural": false,
             "selections": [
-              (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1016,7 +1020,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v9/*: any*/)
             ]
           },
           {
@@ -1037,7 +1041,7 @@ return {
                 "name": "filter",
                 "value": "IS_FOR_SALE"
               },
-              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "Literal",
                 "name": "published",
@@ -1065,7 +1069,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v16/*: any*/),
+                      (v17/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1073,7 +1077,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v17/*: any*/),
+                      (v18/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1116,7 +1120,7 @@ return {
                                 "args": null,
                                 "concreteType": "Money",
                                 "plural": false,
-                                "selections": (v21/*: any*/)
+                                "selections": (v22/*: any*/)
                               },
                               {
                                 "kind": "LinkedField",
@@ -1127,7 +1131,7 @@ return {
                                 "concreteType": "Money",
                                 "plural": false,
                                 "selections": [
-                                  (v20/*: any*/)
+                                  (v21/*: any*/)
                                 ]
                               }
                             ]
@@ -1135,7 +1139,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "type": "Money",
-                            "selections": (v21/*: any*/)
+                            "selections": (v22/*: any*/)
                           }
                         ]
                       },
@@ -1146,8 +1150,8 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v15/*: any*/),
-                      (v22/*: any*/),
+                      (v16/*: any*/),
+                      (v23/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1157,8 +1161,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v14/*: any*/),
                           (v15/*: any*/),
+                          (v16/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1168,7 +1172,7 @@ return {
                             "concreteType": "Profile",
                             "plural": false,
                             "selections": [
-                              (v22/*: any*/),
+                              (v23/*: any*/),
                               (v1/*: any*/)
                             ]
                           },
@@ -1190,7 +1194,7 @@ return {
             "args": null,
             "concreteType": "ArtistHighlights",
             "plural": false,
-            "selections": (v24/*: any*/)
+            "selections": (v25/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -1302,10 +1306,10 @@ return {
             "concreteType": "ArtistStatuses",
             "plural": false,
             "selections": [
-              (v19/*: any*/),
-              (v5/*: any*/),
+              (v20/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1333,7 +1337,7 @@ return {
                 "concreteType": "Image",
                 "plural": true,
                 "selections": [
-                  (v15/*: any*/),
+                  (v16/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1419,7 +1423,7 @@ return {
                         "args": null,
                         "concreteType": "Gene",
                         "plural": false,
-                        "selections": (v23/*: any*/)
+                        "selections": (v24/*: any*/)
                       }
                     ]
                   }
@@ -1435,10 +1439,10 @@ return {
             "args": null,
             "concreteType": "ArtistHighlights",
             "plural": false,
-            "selections": (v24/*: any*/)
+            "selections": (v25/*: any*/)
           },
-          (v12/*: any*/),
-          (v13/*: any*/)
+          (v13/*: any*/),
+          (v14/*: any*/)
         ]
       }
     ]
@@ -1447,10 +1451,10 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistTopLevelQuery",
     "id": null,
-    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  me {\n    id\n  }\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: true) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  name\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  artistHightlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n",
+    "text": "query routes_ArtistTopLevelQuery(\n  $artistID: String!\n) {\n  me {\n    id\n  }\n  artist(id: $artistID) @principalField {\n    internalID\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: true) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  internalID\n  name\n  slug\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...NavigationTabs_artist\n}\n\nfragment ArtistHeader_artist on Artist {\n  artistHightlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  statuses {\n    artworks\n  }\n  carousel {\n    images {\n      href\n      resized(height: 200) {\n        url\n        width\n        height\n      }\n    }\n  }\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    title\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment NavigationTabs_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '495f4da2d9856d2f7162bc17746a9925';
+(node as any).hash = 'c95a7f9dd9cb814d2409559f8b959c3e';
 export default node;

--- a/src/__generated__/routes_WorksQuery.graphql.ts
+++ b/src/__generated__/routes_WorksQuery.graphql.ts
@@ -31,6 +31,31 @@ export type routes_WorksQueryResponse = {
 export type routes_WorksQueryRawResponse = {
     readonly artist: ({
         readonly internalID: string;
+        readonly collections: ReadonlyArray<({
+            readonly headerImage: string | null;
+            readonly slug: string;
+            readonly title: string;
+            readonly price_guidance: number | null;
+            readonly artworksConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly artist: ({
+                            readonly name: string | null;
+                            readonly id: string | null;
+                        }) | null;
+                        readonly title: string | null;
+                        readonly image: ({
+                            readonly resized: ({
+                                readonly url: string | null;
+                            }) | null;
+                        }) | null;
+                        readonly id: string | null;
+                    }) | null;
+                }) | null> | null;
+                readonly id: string | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
         readonly related: ({
             readonly artistsConnection: ({
                 readonly edges: ReadonlyArray<({
@@ -206,6 +231,35 @@ fragment ArtistArtworkFilter_artist_2c4z0P on Artist {
   }
 }
 
+fragment ArtistCollectionEntity_collection on MarketingCollection {
+  headerImage
+  slug
+  title
+  price_guidance: priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        artist {
+          name
+          id
+        }
+        title
+        image {
+          resized(width: 262) {
+            url
+          }
+        }
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  ...ArtistCollectionEntity_collection
+}
+
 fragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {
   id
   aggregations {
@@ -378,6 +432,10 @@ fragment Save_artwork on Artwork {
 
 fragment Works_artist_2c4z0P on Artist {
   internalID
+  collections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   related {
     artistsConnection(first: 1) {
       edges {
@@ -625,58 +683,72 @@ v20 = {
 v21 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v22 = {
-  "kind": "Literal",
-  "name": "after",
-  "value": ""
-},
-v23 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 30
-},
-v24 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slice",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v23 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v26 = {
+v24 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "value",
+  "name": "id",
   "args": null,
   "storageKey": null
+},
+v25 = {
+  "kind": "Literal",
+  "name": "after",
+  "value": ""
+},
+v26 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 30
 },
 v27 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "cursor",
+  "name": "slice",
   "args": null,
   "storageKey": null
 },
 v28 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "value",
+  "args": null,
+  "storageKey": null
+},
+v29 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v30 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v29 = [
-  (v27/*: any*/),
-  (v28/*: any*/),
+v31 = [
+  (v29/*: any*/),
+  (v30/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -685,21 +757,21 @@ v29 = [
     "storageKey": null
   }
 ],
-v30 = {
+v32 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v31 = [
+v33 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v32 = [
+v34 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -771,6 +843,147 @@ return {
           (v20/*: any*/),
           {
             "kind": "LinkedField",
+            "alias": "collections",
+            "name": "marketingCollections",
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "headerImage",
+                "args": null,
+                "storageKey": null
+              },
+              (v21/*: any*/),
+              (v22/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": "price_guidance",
+                "name": "priceGuidance",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artworksConnection",
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 3
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artist",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "plural": false,
+                            "selections": [
+                              (v23/*: any*/),
+                              (v24/*: any*/)
+                            ]
+                          },
+                          (v22/*: any*/),
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "resized",
+                                "storageKey": "resized(width:262)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 262
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": null,
+                                    "storageKey": null
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          (v24/*: any*/)
+                        ]
+                      }
+                    ]
+                  },
+                  (v24/*: any*/)
+                ]
+              },
+              (v24/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": null,
             "name": "related",
             "storageKey": null,
@@ -811,7 +1024,7 @@ return {
                         "concreteType": "Artist",
                         "plural": false,
                         "selections": [
-                          (v21/*: any*/)
+                          (v24/*: any*/)
                         ]
                       }
                     ]
@@ -826,9 +1039,9 @@ return {
             "name": "filterArtworksConnection",
             "storageKey": null,
             "args": [
-              (v22/*: any*/),
+              (v25/*: any*/),
               (v3/*: any*/),
-              (v23/*: any*/),
+              (v26/*: any*/),
               (v15/*: any*/),
               (v18/*: any*/)
             ],
@@ -844,7 +1057,7 @@ return {
                 "concreteType": "ArtworksAggregationResults",
                 "plural": true,
                 "selections": [
-                  (v24/*: any*/),
+                  (v27/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -854,13 +1067,13 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v25/*: any*/),
-                      (v26/*: any*/)
+                      (v23/*: any*/),
+                      (v28/*: any*/)
                     ]
                   }
                 ]
               },
-              (v21/*: any*/)
+              (v24/*: any*/)
             ]
           },
           {
@@ -930,13 +1143,13 @@ return {
             "storageKey": null,
             "args": [
               (v2/*: any*/),
-              (v22/*: any*/),
+              (v25/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
-              (v23/*: any*/),
+              (v26/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
@@ -953,7 +1166,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v21/*: any*/),
+              (v24/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -963,7 +1176,7 @@ return {
                 "concreteType": "ArtworksAggregationResults",
                 "plural": true,
                 "selections": [
-                  (v24/*: any*/),
+                  (v27/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -973,8 +1186,8 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v26/*: any*/),
-                      (v25/*: any*/),
+                      (v28/*: any*/),
+                      (v23/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1028,7 +1241,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1038,7 +1251,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1048,7 +1261,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -1059,8 +1272,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v27/*: any*/),
-                      (v28/*: any*/)
+                      (v29/*: any*/),
+                      (v30/*: any*/)
                     ]
                   }
                 ]
@@ -1083,15 +1296,9 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v24/*: any*/),
                       (v21/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "slug",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      (v30/*: any*/),
+                      (v32/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1131,13 +1338,7 @@ return {
                         ]
                       },
                       (v20/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "title",
-                        "args": null,
-                        "storageKey": null
-                      },
+                      (v22/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "image_title",
@@ -1171,13 +1372,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v31/*: any*/),
+                        "args": (v33/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
-                          (v21/*: any*/),
-                          (v30/*: any*/),
-                          (v25/*: any*/)
+                          (v24/*: any*/),
+                          (v32/*: any*/),
+                          (v23/*: any*/)
                         ]
                       },
                       {
@@ -1192,13 +1393,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v31/*: any*/),
+                        "args": (v33/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v25/*: any*/),
-                          (v30/*: any*/),
-                          (v21/*: any*/),
+                          (v23/*: any*/),
+                          (v32/*: any*/),
+                          (v24/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1231,7 +1432,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v21/*: any*/),
+                          (v24/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -1297,7 +1498,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v32/*: any*/)
+                            "selections": (v34/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1307,9 +1508,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v32/*: any*/)
+                            "selections": (v34/*: any*/)
                           },
-                          (v21/*: any*/)
+                          (v24/*: any*/)
                         ]
                       },
                       {
@@ -1349,12 +1550,12 @@ return {
                       }
                     ]
                   },
-                  (v21/*: any*/)
+                  (v24/*: any*/)
                 ]
               }
             ]
           },
-          (v21/*: any*/)
+          (v24/*: any*/)
         ]
       }
     ]
@@ -1363,7 +1564,7 @@ return {
     "operationKind": "query",
     "name": "routes_WorksQuery",
     "id": null,
-    "text": "query routes_WorksQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...Works_artist_2c4z0P\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2c4z0P on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_artist_2c4z0P on Artist {\n  internalID\n  related {\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  sidebarAggregations: filterArtworksConnection(sort: $sort, page: $page, aggregations: $aggregations, first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_2c4z0P\n}\n",
+    "text": "query routes_WorksQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $artistID: String!\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sort: String\n  $width: String\n) {\n  artist(id: $artistID) {\n    ...Works_artist_2c4z0P\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2c4z0P on Artist {\n  is_followed: isFollowed\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, artistID: $artistID, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, first: 30, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistCollectionsRail_collections on MarketingCollection {\n  ...ArtistCollectionEntity_collection\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_artist_2c4z0P on Artist {\n  internalID\n  collections: marketingCollections(isFeaturedArtistContent: true, size: 16) {\n    ...ArtistCollectionsRail_collections\n    id\n  }\n  related {\n    artistsConnection(first: 1) {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n  }\n  sidebarAggregations: filterArtworksConnection(sort: $sort, page: $page, aggregations: $aggregations, first: 30, after: \"\") {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n      }\n    }\n    id\n  }\n  ...ArtistArtworkFilter_artist_2c4z0P\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Depends on https://github.com/artsy/metaphysics/pull/2279

Seeing what it looks like to SSR render the collections rail. There are concerns about performance, but that might be offset by SEO impact since these rails currently only render on the client. (We're pushing collections content a lot lately.) Wanted to get y'alls thoughts.

#### Before: 

<img width="464" alt="Screen Shot 2020-04-06 at 11 23 12 PM" src="https://user-images.githubusercontent.com/236943/78636717-b60fc580-785d-11ea-9bd3-9219b201cee7.png">

#### After: 

<img width="455" alt="Screen Shot 2020-04-06 at 10 55 23 PM" src="https://user-images.githubusercontent.com/236943/78634940-f10ffa00-7859-11ea-83b9-3df2213c0286.png">

The difference is ~900ms (pointing at staging MP) for SSR. Seems maybe worth it since these pages are going to be in the top search results. It also fixes the poor UX problem around above-the-fold loading spinner > show rail > shift entire layout down.

#### Fix top hz border on artwork grid

Also adds a new prop `showTopBorder` to the `ArtworkFilter` component -- its been driving me crazy that its always there even if there's not a top rail sitting above it. The problem is we can only compute showing / hiding based on collect rail data. If it only renders on the client then it's impossible to check it before the page renders, throwing the layout off. 

#### Before: 

<img width="1259" alt="Screen Shot 2020-04-06 at 11 03 41 PM" src="https://user-images.githubusercontent.com/236943/78635361-e86bf380-785a-11ea-8d2c-6d3b0de1edbc.png">

#### After: 

<img width="872" alt="Screen Shot 2020-04-06 at 10 46 32 PM" src="https://user-images.githubusercontent.com/236943/78635103-4b10bf80-785a-11ea-8bcc-74a690862b08.png">


