### PR TITLE
Add desktop menu item for navigating to conversations

### DIFF
--- a/src/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/Components/NavBar/Menus/UserMenu.tsx
@@ -16,7 +16,7 @@ import {
 import { AnalyticsSchema, SystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { data as sd } from "sharify"
-import { userHasLabFeature, userIsAdmin } from "Utils/user"
+import { userIsAdmin } from "Utils/user"
 
 export const UserMenu: React.FC = () => {
   const { trackEvent } = useTracking()
@@ -54,6 +54,11 @@ export const UserMenu: React.FC = () => {
       {isAdmin && (
         <MenuItem href="/user/purchases">
           <TagIcon mr={1} /> Purchases
+        </MenuItem>
+      )}
+      {userHasLabFeature(user, "User Conversations View") && (
+        <MenuItem href="/user/conversations">
+          <TagIcon mr={1} /> Inquiries
         </MenuItem>
       )}
       <MenuItem href="/user/saves">

--- a/src/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/Components/NavBar/Menus/UserMenu.tsx
@@ -56,11 +56,6 @@ export const UserMenu: React.FC = () => {
           <TagIcon mr={1} /> Purchases
         </MenuItem>
       )}
-      {userHasLabFeature(user, "User Conversations View") && (
-        <MenuItem href="/user/conversations">
-          <TagIcon mr={1} /> Inquiries
-        </MenuItem>
-      )}
       <MenuItem href="/user/saves">
         <HeartIcon mr={1} /> Saves & Follows
       </MenuItem>

--- a/src/Components/NavBar/Menus/__tests__/UserMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/UserMenu.test.tsx
@@ -58,22 +58,6 @@ describe("UserMenu", () => {
     expect(mediator.trigger).toBeCalledWith("auth:logout")
   })
 
-  describe("lab features", () => {
-    it("hides inquiries button if lab feature not enabled", () => {
-      const wrapper = getWrapper({
-        user: { type: "NotAdmin", lab_features: [] },
-      })
-      expect(wrapper.html()).not.toContain("Inquiries")
-    })
-
-    it("shows inquiries button if lab feature enabled", () => {
-      const wrapper = getWrapper({
-        user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
-      })
-      expect(wrapper.html()).toContain("Inquiries")
-    })
-  })
-
   describe("admin features", () => {
     it("hides admin button if not admin", () => {
       const wrapper = getWrapper({ user: { type: "NotAdmin" } })

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -39,6 +39,7 @@ import { track, useTracking } from "Artsy/Analytics"
 import * as SchemaV2 from "Artsy/Analytics/v2/Schema"
 import Events from "Utils/Events"
 import { useMedia } from "Utils/Hooks/useMedia"
+import { userHasLabFeature } from "Utils/user"
 
 export const NavBar: React.FC = track(
   {
@@ -55,7 +56,10 @@ export const NavBar: React.FC = track(
   const { xs, sm } = useMedia()
   const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
-  const hasPartnerAccess = user && Boolean(user.has_partner_access)
+  const conversationsEnabled = userHasLabFeature(
+    user,
+    "User Conversations View"
+  )
 
   const getNotificationCount = () => cookie.get("notification-count") || 0
 
@@ -155,7 +159,7 @@ export const NavBar: React.FC = track(
                     )
                   }}
                 </NavItem>
-                {hasPartnerAccess && (
+                {conversationsEnabled && (
                   <NavItem>
                     {({ hover }) => {
                       return (

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   color,
+  EnvelopeIcon,
   Flex,
   Link,
   SoloIcon,
@@ -54,6 +55,7 @@ export const NavBar: React.FC = track(
   const { xs, sm } = useMedia()
   const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
+  const hasPartnerAccess = user && Boolean(user.has_partner_access)
 
   const getNotificationCount = () => cookie.get("notification-count") || 0
 
@@ -153,6 +155,18 @@ export const NavBar: React.FC = track(
                     )
                   }}
                 </NavItem>
+                {hasPartnerAccess && (
+                  <NavItem>
+                    {({ hover }) => {
+                      return (
+                        <EnvelopeIcon
+                          top={3}
+                          fill={hover ? "purple100" : "black80"}
+                        />
+                      )
+                    }}
+                  </NavItem>
+                )}
                 <NavItem Menu={UserMenu}>
                   {({ hover }) => {
                     if (hover) {

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -160,7 +160,7 @@ export const NavBar: React.FC = track(
                   }}
                 </NavItem>
                 {conversationsEnabled && (
-                  <NavItem>
+                  <NavItem href="/user/conversations">
                     {({ hover }) => {
                       return (
                         <EnvelopeIcon

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -1,4 +1,4 @@
-import { BellIcon, SoloIcon } from "@artsy/palette"
+import { BellIcon, EnvelopeIcon, SoloIcon } from "@artsy/palette"
 import { SystemContextProvider } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount } from "enzyme"
@@ -91,6 +91,22 @@ describe("NavBar", () => {
       expect(wrapper.html()).not.toContain("Sign up")
       expect(wrapper.find(BellIcon).length).toEqual(1)
       expect(wrapper.find(SoloIcon).length).toEqual(1)
+    })
+
+    describe("lab features", () => {
+      it("hides inquiries icon if lab feature not enabled", () => {
+        const wrapper = getWrapper({
+          user: { type: "NotAdmin", lab_features: [] },
+        })
+        expect(wrapper.find(EnvelopeIcon).length).toEqual(0)
+      })
+
+      it("shows inquiries icon if lab feature enabled", () => {
+        const wrapper = getWrapper({
+          user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
+        })
+        expect(wrapper.find(EnvelopeIcon).length).toEqual(1)
+      })
     })
   })
 

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -86,7 +86,7 @@ describe("NavBar", () => {
     })
 
     it("renders logged in items", () => {
-      const wrapper = getWrapper({ user: { has_partner_access: null } })
+      const wrapper = getWrapper({ user: true })
       expect(wrapper.html()).not.toContain("Log in")
       expect(wrapper.html()).not.toContain("Sign up")
       expect(wrapper.find(BellIcon).length).toEqual(1)

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -86,7 +86,7 @@ describe("NavBar", () => {
     })
 
     it("renders logged in items", () => {
-      const wrapper = getWrapper({ user: true })
+      const wrapper = getWrapper({ user: { has_partner_access: null } })
       expect(wrapper.html()).not.toContain("Log in")
       expect(wrapper.html()).not.toContain("Sign up")
       expect(wrapper.find(BellIcon).length).toEqual(1)


### PR DESCRIPTION
PURCHASE-1855

Add envelop icon that links off to the conversations app when clicked. We should also clean up the link to inquires under the user settings menu. UserMenu.tsx#L59-L63 

Out of scope for this ticket:
showing the dropdown menu
indicating unread messages

Notes:
Uses EnvelopeIcon from Palette
Links to /user/conversations
Should be behind the User Conversations View lab feature flag. 
See this link for an example: ConversationApp.tsx#L18 

__Before:__
<img width="208" alt="Screen Shot 2020-04-07 at 12 58 39 PM" src="https://user-images.githubusercontent.com/5643895/78698674-aed5cf80-78d0-11ea-8dd4-c514a99b5b6a.png">

<img width="259" alt="Screen Shot 2020-04-06 at 4 24 54 PM" src="https://user-images.githubusercontent.com/5643895/78698642-a2517700-78d0-11ea-85ae-a30cee9a7609.png">

__After:__
<img width="256" alt="Screen Shot 2020-04-07 at 9 57 32 AM" src="https://user-images.githubusercontent.com/5643895/78698700-b72e0a80-78d0-11ea-8656-f3275d08519f.png">

Hover:
<img width="43" alt="Screen Shot 2020-04-07 at 1 05 17 PM" src="https://user-images.githubusercontent.com/5643895/78698726-be551880-78d0-11ea-8591-9b015d7d7a02.png">

<img width="225" alt="Screen Shot 2020-04-07 at 1 08 18 PM" src="https://user-images.githubusercontent.com/5643895/78698820-e5134f00-78d0-11ea-9e57-bff14ad29dc7.png">



 


