### PR TITLE
Add inbox to mobile nav menu

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -16,6 +16,7 @@ import { LinkData, MenuData, MenuLinkData } from "Components/NavBar/menuData"
 import React from "react"
 import styled from "styled-components"
 import { getMobileAuthLink } from "Utils/openAuthModal"
+import { userHasLabFeature } from "Utils/user"
 import { MobileLink } from "./MobileLink"
 import {
   NavigatorContextProvider,
@@ -255,9 +256,17 @@ const AuthenticateLinks: React.FC = () => {
 }
 
 const LoggedInLinks: React.FC = () => {
+  const { user } = useSystemContext()
+  const conversationsEnabled = userHasLabFeature(
+    user,
+    "User Conversations View"
+  )
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
+      {conversationsEnabled && (
+        <MobileLink href="/user/conversations">Inbox</MobileLink>
+      )}
       <MobileLink href="/works-for-you">Works for you</MobileLink>
       <MobileLink href="/user/edit">Account</MobileLink>
     </Box>

--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -267,7 +267,7 @@ const LoggedInLinks: React.FC = () => {
       <Separator my={1} color={color("black10")} />
       {conversationsEnabled && (
         <MobileLink href="/user/conversations">
-          <EnvelopeIcon fill={"black80"} top={3} mr={10} />
+          <EnvelopeIcon fill={"black60"} top={3} mr={10} />
           Inbox
         </MobileLink>
       )}

--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -3,6 +3,7 @@ import {
   ChevronIcon,
   CloseIcon,
   color,
+  EnvelopeIcon,
   Flex,
   MenuIcon,
   Sans,
@@ -265,7 +266,10 @@ const LoggedInLinks: React.FC = () => {
     <Box>
       <Separator my={1} color={color("black10")} />
       {conversationsEnabled && (
-        <MobileLink href="/user/conversations">Inbox</MobileLink>
+        <MobileLink href="/user/conversations">
+          <EnvelopeIcon fill={"black80"} top={3} mr={10} />
+          Inbox
+        </MobileLink>
       )}
       <MobileLink href="/works-for-you">Works for you</MobileLink>
       <MobileLink href="/user/edit">Account</MobileLink>

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -77,6 +77,7 @@ describe("MobileNavMenu", () => {
         user: { type: "NotAdmin", lab_features: [] },
       })
       expect(wrapper.html()).not.toContain("Inbox")
+      expect(wrapper.find(EnvelopeIcon).length).toEqual(0)
     })
 
     it("shows inbox menu option if lab feature enabled", () => {
@@ -84,6 +85,7 @@ describe("MobileNavMenu", () => {
         user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
       })
       expect(wrapper.html()).toContain("Inbox")
+      expect(wrapper.find(EnvelopeIcon).length).toEqual(1)
     })
   })
 

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -1,3 +1,4 @@
+import { EnvelopeIcon } from "@artsy/palette"
 import { SystemContextProvider } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { menuData, SimpleLinkData } from "Components/NavBar/menuData"

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -71,6 +71,22 @@ describe("MobileNavMenu", () => {
     })
   })
 
+  describe("lab features", () => {
+    it("hides inbox menu option if lab feature not enabled", () => {
+      const wrapper = getWrapper({
+        user: { type: "NotAdmin", lab_features: [] },
+      })
+      expect(wrapper.html()).not.toContain("Inbox")
+    })
+
+    it("shows inbox menu option if lab feature enabled", () => {
+      const wrapper = getWrapper({
+        user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
+      })
+      expect(wrapper.html()).toContain("Inbox")
+    })
+  })
+
   describe("Analytics tracking", () => {
     it("tracks back button click", () => {
       const wrapper = mount(


### PR DESCRIPTION
[PURCHASE-1854]

Add the ability to navigate to the conversations app from the mobile nav menu. 
For this ticket, don’t worry about the number of unread messages. We’ll get to that later. 

Uses EnvelopeIcon from Palette
Links to /user/conversations
Should be behind the User Conversations View lab feature flag. 
See this link for an example: ConversationApp.tsx#L18 

<img width="220" alt="Screen Shot 2020-04-07 at 3 59 48 PM" src="https://user-images.githubusercontent.com/5643895/78714006-1861d800-78e9-11ea-8ab8-4c68513b8746.png">


[PURCHASE-1854]: https://artsyproduct.atlassian.net/browse/PURCHASE-1854