### PR TITLE
Add log out link back to mWeb

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -8,12 +8,12 @@ import {
   Sans,
   Separator,
 } from "@artsy/palette"
-import { AnalyticsSchema, useSystemContext } from "Artsy"
+import { AnalyticsSchema, SystemContext, useSystemContext } from "Artsy"
 import { useTracking } from "Artsy/Analytics"
 import { AuthIntent, ContextModule } from "Artsy/Analytics/v2/Schema"
 import { ModalType } from "Components/Authentication/Types"
 import { LinkData, MenuData, MenuLinkData } from "Components/NavBar/menuData"
-import React from "react"
+import React, { useContext } from "react"
 import styled from "styled-components"
 import { getMobileAuthLink } from "Utils/openAuthModal"
 import { MobileLink } from "./MobileLink"
@@ -255,11 +255,21 @@ const AuthenticateLinks: React.FC = () => {
 }
 
 const LoggedInLinks: React.FC = () => {
+  const { mediator } = useContext(SystemContext)
   return (
     <Box>
       <Separator my={1} color={color("black10")} />
       <MobileLink href="/works-for-you">Works for you</MobileLink>
       <MobileLink href="/user/edit">Account</MobileLink>
+      <MobileLink
+        href="#"
+        onClick={event => {
+          event.preventDefault()
+          mediator.trigger("auth:logout")
+        }}
+      >
+        Log out
+      </MobileLink>
     </Box>
   )
 }

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -14,10 +14,13 @@ import { MobileLink } from "../MobileLink"
 jest.mock("Artsy/Analytics/useTracking")
 
 describe("MobileNavMenu", () => {
+  const mediator = {
+    trigger: jest.fn(),
+  }
   const trackEvent = jest.fn()
   const getWrapper = props => {
     return mount(
-      <SystemContextProvider user={props.user}>
+      <SystemContextProvider mediator={mediator} user={props.user}>
         <MobileNavMenu isOpen menuData={menuData} />
       </SystemContextProvider>
     )
@@ -31,6 +34,15 @@ describe("MobileNavMenu", () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+  })
+
+  it("calls logout auth action on logout menu click", () => {
+    const wrapper = getWrapper({ user: { type: "NotAdmin" } })
+    wrapper
+      .find("MobileLink")
+      .last()
+      .simulate("click")
+    expect(mediator.trigger).toBeCalledWith("auth:logout")
   })
 
   describe("nav structure", () => {


### PR DESCRIPTION
Fixes [PURCHASE-1858](https://artsyproduct.atlassian.net/browse/PURCHASE-1858)

Currently in production for users on the mobile site can't log out. The FX team has some places around updates to the mobile nav experience, so this just temporarily adds logout back in until the new nav updates happen. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.8.0-canary.3360.57003.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.8.0-canary.3360.57003.0
  # or 
  yarn add @artsy/reaction@26.8.0-canary.3360.57003.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
