### PR TITLE
[Tracking Experiment] Only track on route load complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "26.4.0",
+  "version": "26.4.0-canary.0-3363",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",

--- a/src/Apps/__stories__/AppShell.story.tsx
+++ b/src/Apps/__stories__/AppShell.story.tsx
@@ -17,6 +17,8 @@ storiesOf("Apps", module).add("AppShell", () => {
           // @ts-ignore
           COLLECTION_HUBS: "experiment",
           mediator: {
+            on: x => x,
+            off: x => x,
             trigger: x => x,
           },
         }}

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -114,11 +114,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
         break
       }
 
-      /**
-       * When the URL bar updates a new state transition has begun, but not yet
-       * committed into the store. Grab the pathname and store as a referrer.
-       */
       case FarceActionTypes.UPDATE_LOCATION: {
+        // When the URL bar updates a new state transition has begun, but not yet
+        // committed into the store. Grab the pathname and store as a referrer.
         referrer = get(
           store.getState(),
           state => state.found.match.location.pathname

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -1,5 +1,7 @@
 import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
-import ActionTypes from "farce/lib/ActionTypes"
+import FarceActionTypes from "farce/lib/ActionTypes"
+import { ActionTypes as FoundActionTypes } from "found"
+import { debounce } from "lodash"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
 
@@ -16,82 +18,122 @@ interface TrackingMiddlewareOptions {
 }
 
 export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
+  const actions = []
+  const debouncedTrack = debounce(trackPageView => trackPageView(), 100)
+  let referrer
+
   return store => next => action => {
     const { excludePaths = [] } = options
     const { type, payload } = action
 
-    switch (type) {
-      case ActionTypes.UPDATE_LOCATION: {
-        const { pathname } = payload
-        const referrer = get(
-          store.getState(),
-          state => state.found.match.location.pathname
-        )
+    function trackPageView() {
+      // On FarceActionTypes.INIT, pathname is directly passed. On
+      // FoundActionTypes.RESOLVE_MATCH, pathname is attached to `location`.
+      const pathname = payload.pathname || payload.location.pathname
 
-        // Pluck segment analytics instance from force
-        const analytics =
-          typeof window.analytics !== "undefined" && window.analytics
+      // Pluck segment analytics instance from force
+      const analytics =
+        typeof window.analytics !== "undefined" && window.analytics
 
-        if (analytics) {
-          // TODO: Pass referrer over to Artwork page if A/B test passes
-          // window.sd.routerReferrer = referrer
+      if (analytics) {
+        const foundExcludedPath = excludePaths.some(excludedPath => {
+          return pathname.includes(excludedPath)
+        })
 
-          const foundExcludedPath = excludePaths.some(excludedPath => {
-            return pathname.includes(excludedPath)
-          })
-
-          if (!foundExcludedPath) {
-            const trackingData: {
-              path: string
-              referrer?: string
-              url: string
-            } = {
-              path: pathname,
-              url: sd.APP_URL + pathname,
-            }
-
-            if (referrer) {
-              trackingData.referrer = sd.APP_URL + referrer
-            }
-
-            // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-            if (
-              ["/collect", "/collections", "/collection/"].some(path =>
-                pathname.includes(path)
-              ) &&
-              referrer
-            ) {
-              trackingData.referrer = sd.APP_URL + referrer
-            }
-
-            analytics.page(trackingData, { integrations: { Marketo: false } })
-
-            // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-            if (sd.CLIENT_NAVIGATION_V5) {
-              trackExperimentViewed("client_navigation_v5")
-            }
+        if (!foundExcludedPath) {
+          const trackingData: {
+            path: string
+            referrer?: string
+            url: string
+          } = {
+            path: pathname,
+            url: sd.APP_URL + pathname,
           }
 
-          // Reset timers that track time on page since we're tracking each order
-          // checkout view as a separate page.
-          const desktopPageTimeTrackers =
-            typeof window.desktopPageTimeTrackers !== "undefined" &&
-            window.desktopPageTimeTrackers
+          if (referrer) {
+            trackingData.referrer = sd.APP_URL + referrer
+          }
 
-          if (desktopPageTimeTrackers) {
-            desktopPageTimeTrackers.forEach(tracker => {
-              // No need to reset the tracker if we're on the same page.
-              if (pathname !== tracker.path) {
-                tracker.reset(pathname)
-              }
-            })
+          // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+          if (
+            ["/collect", "/collections", "/collection/"].some(path =>
+              pathname.includes(path)
+            ) &&
+            referrer
+          ) {
+            trackingData.referrer = sd.APP_URL + referrer
+          }
+
+          analytics.page(trackingData, {
+            integrations: {
+              Marketo: false,
+            },
+          })
+
+          // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
+          if (sd.CLIENT_NAVIGATION_V5) {
+            trackExperimentViewed("client_navigation_v5")
           }
         }
 
-        return next(action)
+        // Reset timers that track time on page since we're tracking each order
+        // checkout view as a separate page.
+        const desktopPageTimeTrackers =
+          typeof window.desktopPageTimeTrackers !== "undefined" &&
+          window.desktopPageTimeTrackers
+
+        if (desktopPageTimeTrackers) {
+          desktopPageTimeTrackers.forEach(tracker => {
+            // No need to reset the tracker if we're on the same page.
+            if (pathname !== tracker.path) {
+              tracker.reset(pathname)
+            }
+          })
+        }
       }
-      default:
-        return next(action)
     }
+
+    switch (type) {
+      case FarceActionTypes.INIT: {
+        actions.push(action) // store the first action so we can evaluate the below
+        break
+      }
+
+      /**
+       * This action can fire multiple times during a route transition, so we
+       * want to check if the previous event is an init event. If so, we know
+       * we've performed a hard jump to the page form an SSR pass. This is the
+       * session "start" within the the client-side nav experience, or the
+       * conventional pageview track otherwise.
+       */
+      case FarceActionTypes.CREATE_HREF: {
+        const isSSRPageRender = actions.pop()?.type === "@@farce/INIT"
+        if (isSSRPageRender) {
+          debouncedTrack(trackPageView)
+        }
+        break
+      }
+
+      /**
+       * When the URL bar updates a new state transition has begun, but not yet
+       * committed into the store. Grab the pathname and store as a referrer.
+       */
+      case FarceActionTypes.UPDATE_LOCATION: {
+        referrer = get(
+          store.getState(),
+          state => state.found.match.location.pathname
+        )
+        break
+      }
+
+      // Once the session has started, fire tracking when the page data is done
+      // loading and the new page renders.
+      case FoundActionTypes.RESOLVE_MATCH: {
+        debouncedTrack(trackPageView)
+        break
+      }
+    }
+
+    return next(action)
   }
 }


### PR DESCRIPTION
When looking at the Artist page Ani noticed that the logged-in state flow where a user navigates to `/artist/id` and is immediately redirected to `/artist/works-for-sale` would double track a page view. This led to a larger discussion around when we should be tracking page-views, when the URL bar changes, or when the page fully loads. Data may prefer the former as it captures more information about where the user has clicked, but the double tracking issue is only solvable with the latter. The latter is also (seemingly be) better data in a sense, as it represents a more honest flow; the page loads completely, and is tracked -- the user has actually seen the new page. The latter also captures the page title, which was a noted non-blocking issue in our QA session around new app shell. 

Building this into a review app for review and @anipetrov will advise on whether it should be merged or not once the team interacts with things. 