### PR TITLE
Convert images to JPG and add poster for video

### DIFF
--- a/src/Apps/FeatureAKG/Components/Feature.tsx
+++ b/src/Apps/FeatureAKG/Components/Feature.tsx
@@ -12,7 +12,7 @@ import { useSystemContext } from "Artsy/SystemContext"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { crop } from "Utils/resizer"
+import { crop, resize } from "Utils/resizer"
 import { Media } from "Utils/Responsive"
 
 interface FeatureProps {
@@ -40,19 +40,35 @@ const Feature: React.FC<FeatureProps> = props => {
     !!featuredRails?.auctions_rail?.items?.length ||
     !!featuredRails?.fairs_rail?.items?.length
 
+  const resizedSmallPlaceholder = resize(heroVideo.small_placeholder_src, {
+    width: 600,
+    convert_to: "jpg",
+  })
+
+  const resizedLargePlaceholder = resize(heroVideo.large_placeholder_src, {
+    width: 1500,
+    convert_to: "jpg",
+  })
+
   return (
     <>
       <Media greaterThanOrEqual="sm">
         {heroVideo?.large_src && (
           <Box textAlign="center" mb={-1}>
-            <Video src={heroVideo.large_src} />
+            <Video
+              src={heroVideo.large_src}
+              placeholder={resizedLargePlaceholder}
+            />
           </Box>
         )}
       </Media>
       <Media at="xs">
         {heroVideo?.small_src && (
           <Box textAlign="center" mb={-1}>
-            <Video src={heroVideo.small_src} />
+            <Video
+              src={heroVideo.small_src}
+              placeholder={resizedSmallPlaceholder}
+            />
           </Box>
         )}
       </Media>
@@ -204,7 +220,7 @@ const Section: React.FC<SectionProps> = props => {
   )
 }
 
-const Video: React.FC<{ src: string }> = props => {
+const Video: React.FC<{ src: string; placeholder: string }> = props => {
   return (
     <StyledVideo
       src={props.src}
@@ -213,6 +229,7 @@ const Video: React.FC<{ src: string }> = props => {
       muted
       playsInline
       controls={false}
+      poster={props.placeholder}
     />
   )
 }
@@ -257,6 +274,7 @@ export const FeaturedContentLink: React.FC<FeaturedLinkType> = props => {
   const croppedUrl = crop(props.image_src, {
     width: width * devicePixelRatio,
     height: height * devicePixelRatio,
+    convert_to: "jpg",
   })
 
   const tracking = useTracking()

--- a/src/Apps/FeatureAKG/Components/FeaturedRails/index.tsx
+++ b/src/Apps/FeatureAKG/Components/FeaturedRails/index.tsx
@@ -143,6 +143,7 @@ export const FeaturedRailCarousel: React.FC<FeaturedRailCarouselProps> = props =
         const croppedImageUrl = crop(item.imageSrc, {
           width: imgWidth * devicePixelRatio,
           height: imgHeight * devicePixelRatio,
+          convert_to: "jpg",
         })
 
         return (

--- a/src/Utils/resizer.ts
+++ b/src/Utils/resizer.ts
@@ -13,9 +13,10 @@ export const crop = (
     width: number
     height: number
     quality?: number
+    convert_to?: string
   }
 ) => {
-  const { width, height, quality } = options
+  const { width, height, quality, convert_to } = options
 
   // dont call gemini with empty src
   if (!src) return null
@@ -37,6 +38,7 @@ export const crop = (
     width,
     height,
     quality: quality || 80,
+    convert_to,
   }
 
   return [GEMINI_CLOUDFRONT_URL, qs.stringify(config)].join("?")


### PR DESCRIPTION
Couple of performance wins:
- Images were being uploaded a `png`s-- this explicitly converts them to jpeg.
- Added a `poster` attribute for the video so if someone has a setting or otherwise that doesn't let it autoplay, they get the first contentful frame vs. a white screen.