### PR TITLE
Use auth helpers for minimalCTABanner tracking args

### DIFF
--- a/src/Artsy/Analytics/v2/Schema/Authentication.ts
+++ b/src/Artsy/Analytics/v2/Schema/Authentication.ts
@@ -34,6 +34,7 @@ export type AuthContextModule =
   | ContextModule.intextTooltip
   | ContextModule.liveAuctionsRail
   | ContextModule.mainCarousel
+  | ContextModule.minimalCTABanner
   | ContextModule.otherWorksByArtistRail
   | ContextModule.otherWorksFromPartnerRail
   | ContextModule.otherWorksFromShowRail

--- a/src/Artsy/Analytics/v2/Schema/ContextModule.ts
+++ b/src/Artsy/Analytics/v2/Schema/ContextModule.ts
@@ -29,6 +29,7 @@ export enum ContextModule {
   intextTooltip = "intextTooltip",
   liveAuctionsRail = "liveAuctionsRail",
   mainCarousel = "mainCarousel",
+  minimalCTABanner = "minimalCTABanner",
   otherWorksByArtistRail = "otherWorksByArtistRail",
   otherWorksFromPartnerRail = "otherWorksFromPartnerRail",
   otherWorksFromShowRail = "otherWorksFromShowRail",

--- a/src/Components/MinimalCtaBanner.tsx
+++ b/src/Components/MinimalCtaBanner.tsx
@@ -30,15 +30,6 @@ export class MinimalCtaBanner extends React.Component<
   }
 
   @track({
-    action_type: Schema.ActionType.AuthImpression,
-    intent: Schema.ActionName.ViewEditorial,
-    trigger: "click",
-  })
-  componentDidMount() {
-    // no op
-  }
-
-  @track({
     action_type: Schema.ActionType.Click,
     action_name: Schema.ActionName.Dismiss,
     subject: "dismiss auth banner for editorial cta on mobile",

--- a/src/Components/Publishing/Banner/Banner.tsx
+++ b/src/Components/Publishing/Banner/Banner.tsx
@@ -1,6 +1,8 @@
+import { AuthIntent, ContextModule } from "Artsy/Analytics/v2/Schema"
+import { ModalType } from "Components/Authentication/Types"
 import { debounce } from "lodash"
-import qs from "querystring"
 import React, { Component } from "react"
+import { getMobileAuthLink } from "Utils/openAuthModal"
 import { MinimalCtaBanner } from "../../MinimalCtaBanner"
 import { getArticleFullHref } from "../Constants"
 import { ArticleData } from "../Typings"
@@ -56,16 +58,16 @@ export class BannerWrapper extends Component<{ article: ArticleData }, State> {
     const copy = layout === "news" ? CtaCopy.news : CtaCopy.default
     const backgroundColor = layout === "video" ? "white" : "black"
     const textColor = layout === "video" ? "black" : "white"
+    const href = getMobileAuthLink(ModalType.signup, {
+      action: "editorialSignup",
+      intent: AuthIntent.viewEditorial,
+      contextModule: ContextModule.minimalCTABanner,
+      redirectTo: getArticleFullHref(slug),
+    })
 
     return (
       <MinimalCtaBanner
-        href={`/sign_up?${qs.stringify({
-          action: "editorialSignup",
-          intent: "viewed editorial",
-          trigger: "click",
-          contextModule: "auth minimal cta banner",
-          "redirect-to": getArticleFullHref(slug),
-        })}`}
+        href={href}
         height="55px"
         copy={copy}
         position="bottom"

--- a/src/Components/Publishing/Banner/__tests__/Banner.test.tsx
+++ b/src/Components/Publishing/Banner/__tests__/Banner.test.tsx
@@ -1,10 +1,10 @@
-import { shallow } from "enzyme"
+import { mount, shallow } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 
-import { BannerWrapper } from "../Banner"
-
+import { MinimalCtaBanner } from "../../../MinimalCtaBanner"
 import { StandardArticle } from "../../Fixtures/Articles"
+import { BannerWrapper } from "../Banner"
 
 describe("Banner", () => {
   it("it sets state appropriately based on scroll direction", () => {
@@ -21,5 +21,12 @@ describe("Banner", () => {
     article.handleScroll()
     wrapper.update()
     expect(article.state.showCtaBanner).toBe(true)
+  })
+
+  it("links to signup with expected URL", () => {
+    const wrapper = mount(<BannerWrapper article={StandardArticle} />)
+    expect(wrapper.find(MinimalCtaBanner).getElement().props.href).toBe(
+      "/sign_up?action=editorialSignup&intent=viewEditorial&contextModule=minimalCTABanner&redirectTo=https%3A%2F%2Fwww.artsy.net%2Farticle%2Fnew-yorks-next-art-district"
+    )
   })
 })


### PR DESCRIPTION
The tracking on the `MinimalCtaBanner` component was double-firing, because we get an `authImpression` event once we hit `/sign_up`.

This updates the link href for the banner to use updated auth tracking args and helpers, and removes the extraneous impression.