### PR TITLE
Update desktop nav menu

### DIFF
--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -67,8 +67,8 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
                 return (
                   <MenuItemContainer mb={1}>
                     <MenuItem
-                      paddingX={0}
-                      paddingY={0}
+                      px={0}
+                      py={0}
                       href={menuItem.href}
                       textColor={color("black60")}
                       textWeight="regular"

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -60,8 +60,8 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   return (
     <Menu onClick={trackClick} width={width}>
       <ItemsContainer>
-        <OuterLinkContainer py={4}>
-          <Box mr={3} width={150}>
+        <OuterLinkContainer py={4} mr={[4, 4, 4, 6]}>
+          <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>
             {menu.links.map(menuItem => {
               if (!menuItem.menu) {
                 return (
@@ -100,7 +100,6 @@ const MenuItemContainer = styled(Box)``
 
 const OuterLinkContainer = styled(Box)`
   border-right: 1px solid ${color("black10")};
-  margin-right: 60px;
   ${MenuItemContainer} {
     &:last-child {
       margin-top: 130px;

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -65,7 +65,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
             {menu.links.map(menuItem => {
               if (!menuItem.menu) {
                 return (
-                  <MenuItemContainer mb={1}>
+                  <MenuItemContainer mb={1} key={menuItem.text}>
                     <MenuItem
                       px={0}
                       py={0}
@@ -96,7 +96,7 @@ const ItemsContainer = styled(Flex)`
   margin: auto auto;
 `
 
-const MenuItemContainer = styled(Box)``
+export const MenuItemContainer = styled(Box)``
 
 const OuterLinkContainer = styled(Box)`
   border-right: 1px solid ${color("black10")};

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -1,0 +1,102 @@
+import { Box, Flex, Menu, MenuItem } from "@artsy/palette"
+import { AnalyticsSchema } from "Artsy"
+import { useTracking } from "Artsy/Analytics/useTracking"
+import React from "react"
+import styled from "styled-components"
+
+interface DropDownNavMenuProps {
+  width?: string
+  paddingTop?: number
+  paddingBottom?: number
+}
+
+export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
+  width = "100%",
+}) => {
+  const { trackEvent } = useTracking()
+
+  const trackClick = event => {
+    const link = event.target
+    const text = link.innerText
+    const href = link.parentNode.parentNode.getAttribute("href")
+
+    trackEvent({
+      action_type: AnalyticsSchema.ActionType.Click,
+      context_module: AnalyticsSchema.ContextModule.HeaderMoreDropdown,
+      subject: text,
+      destination_path: href,
+    })
+  }
+
+  return (
+    <Menu onClick={trackClick} width={width}>
+      <ItemsContainer>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+        <Box width={150}>
+          <MenuItem href="/galleries">Galleries</MenuItem>
+          <MenuItem href="/fairs">Fairs</MenuItem>
+          <MenuItem href="/shows">Shows</MenuItem>
+          <MenuItem href="/institutions">Museums</MenuItem>
+          <MenuItem href="/consign">Consign</MenuItem>
+          <MenuItem href="https://partners.artsy.net">
+            Artsy for Galleries
+          </MenuItem>
+        </Box>
+      </ItemsContainer>
+    </Menu>
+  )
+}
+
+const ItemsContainer = styled(Flex)`
+  margin: auto auto;
+  padding: 10px 0 20px;
+`

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -57,8 +57,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
           </Box>
         </SimpleLinksContainer>
 
-        {/* We use splice here to ignore the first 4 links which are simple links and handled above */}
-        {menu.links.slice(4).map(subMenu => {
+        {menu.links.map(subMenu => {
           if (subMenu.menu) {
             return <DropDownSection key={subMenu.text} section={subMenu} />
           }

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -20,8 +20,8 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
   const trackClick = event => {
     const link = event.target
-    const text = link.innerText
-    const href = link.parentNode.parentNode.getAttribute("href")
+    const text = link.textContent
+    const href = link.getAttribute("href")
 
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -57,8 +57,8 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
   return (
     <Menu onClick={trackClick} width={width}>
-      <ItemsContainer>
-        <OuterLinkContainer py={4} mr={[4, 4, 4, 6]}>
+      <Flex justifyContent="center">
+        <SimpleLinksContainer py={4} mr={[4, 4, 4, 6]}>
           <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>
             {menu.links.map(menuItem => {
               if (!menuItem.menu) {
@@ -79,24 +79,20 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
               }
             })}
           </Box>
-        </OuterLinkContainer>
+        </SimpleLinksContainer>
         <DropDownSection section={mediumLinks} />
         <DropDownSection section={genreLinks} />
         <DropDownSection section={rarityLinks} />
         <DropDownSection section={priceLinks} />
         <DropDownSection section={sellerLocationLinks} />
-      </ItemsContainer>
+      </Flex>
     </Menu>
   )
 }
 
-const ItemsContainer = styled(Flex)`
-  margin: auto auto;
-`
-
 export const MenuItemContainer = styled(Box)``
 
-const OuterLinkContainer = styled(Box)`
+const SimpleLinksContainer = styled(Box)`
   border-right: 1px solid ${color("black10")};
   ${MenuItemContainer} {
     &:last-child {

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -1,17 +1,20 @@
-import { Box, Flex, Menu, MenuItem } from "@artsy/palette"
+import { Box, color, Flex, Menu, MenuItem } from "@artsy/palette"
 import { AnalyticsSchema } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import React from "react"
 import styled from "styled-components"
+import { DropDownSection } from "./DropDownSection"
 
 interface DropDownNavMenuProps {
   width?: string
   paddingTop?: number
   paddingBottom?: number
+  menu: any
 }
 
 export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   width = "100%",
+  menu,
 }) => {
   const { trackEvent } = useTracking()
 
@@ -22,75 +25,68 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,
-      context_module: AnalyticsSchema.ContextModule.HeaderMoreDropdown,
+      context_module: AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
       subject: text,
       destination_path: href,
     })
   }
 
+  // const getSubMenu = text => {
+  //   menu.links.filter(item => {
+  //     return item.text === text
+  //   })[0]
+  // }
+
+  const mediumLinks = menu.links.filter(item => {
+    return item.text === "Medium"
+  })[0]
+
+  const genreLinks = menu.links.filter(item => {
+    return item.text === "Genre"
+  })[0]
+
+  const rarityLinks = menu.links.filter(item => {
+    return item.text === "Rarity"
+  })[0]
+
+  const priceLinks = menu.links.filter(item => {
+    return item.text === "Price"
+  })[0]
+
+  const sellerLocationLinks = menu.links.filter(item => {
+    return item.text === "Seller Location"
+  })[0]
+
   return (
     <Menu onClick={trackClick} width={width}>
       <ItemsContainer>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
-        <Box width={150}>
-          <MenuItem href="/galleries">Galleries</MenuItem>
-          <MenuItem href="/fairs">Fairs</MenuItem>
-          <MenuItem href="/shows">Shows</MenuItem>
-          <MenuItem href="/institutions">Museums</MenuItem>
-          <MenuItem href="/consign">Consign</MenuItem>
-          <MenuItem href="https://partners.artsy.net">
-            Artsy for Galleries
-          </MenuItem>
-        </Box>
+        <OuterLinkContainer py={4}>
+          <Box mr={3} width={150}>
+            {menu.links.map(menuItem => {
+              if (!menuItem.menu) {
+                return (
+                  <MenuItemContainer mb={1}>
+                    <MenuItem
+                      paddingX={0}
+                      paddingY={0}
+                      href={menuItem.href}
+                      textColor={color("black60")}
+                      textWeight="regular"
+                      fontSize="3t"
+                    >
+                      {menuItem.text}
+                    </MenuItem>
+                  </MenuItemContainer>
+                )
+              }
+            })}
+          </Box>
+        </OuterLinkContainer>
+        <DropDownSection section={mediumLinks} />
+        <DropDownSection section={genreLinks} />
+        <DropDownSection section={rarityLinks} />
+        <DropDownSection section={priceLinks} />
+        <DropDownSection section={sellerLocationLinks} />
       </ItemsContainer>
     </Menu>
   )
@@ -98,5 +94,18 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
 const ItemsContainer = styled(Flex)`
   margin: auto auto;
-  padding: 10px 0 20px;
+`
+
+const MenuItemContainer = styled(Box)``
+
+const OuterLinkContainer = styled(Box)`
+  border-right: 1px solid ${color("black10")};
+  margin-right: 60px;
+  ${MenuItemContainer} {
+    &:last-child {
+      margin-top: 130px;
+      text-decoration: underline;
+      color: ${color("black100")};
+    }
+  }
 `

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -1,5 +1,5 @@
 import { Box, color, Flex, Menu, MenuItem } from "@artsy/palette"
-import { AnalyticsSchema } from "Artsy"
+import { AnalyticsSchema, ContextModule } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import React from "react"
 import styled from "styled-components"
@@ -8,11 +8,13 @@ import { DropDownSection } from "./DropDownSection"
 interface DropDownNavMenuProps {
   width?: string
   menu: any
+  contextModule: ContextModule
 }
 
 export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   width = "100%",
   menu,
+  contextModule,
 }) => {
   const { trackEvent } = useTracking()
 
@@ -23,7 +25,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,
-      context_module: AnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+      context_module: contextModule,
       subject: text,
       destination_path: href,
     })

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -29,32 +29,6 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
     })
   }
 
-  // const getSubMenu = text => {
-  //   menu.links.filter(item => {
-  //     return item.text === text
-  //   })[0]
-  // }
-
-  const mediumLinks = menu.links.filter(item => {
-    return item.text === "Medium"
-  })[0]
-
-  const genreLinks = menu.links.filter(item => {
-    return item.text === "Genre"
-  })[0]
-
-  const rarityLinks = menu.links.filter(item => {
-    return item.text === "Rarity"
-  })[0]
-
-  const priceLinks = menu.links.filter(item => {
-    return item.text === "Price"
-  })[0]
-
-  const sellerLocationLinks = menu.links.filter(item => {
-    return item.text === "Seller Location"
-  })[0]
-
   return (
     <Menu onClick={trackClick} width={width}>
       <Flex justifyContent="center">
@@ -80,11 +54,13 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
             })}
           </Box>
         </SimpleLinksContainer>
-        <DropDownSection section={mediumLinks} />
-        <DropDownSection section={genreLinks} />
-        <DropDownSection section={rarityLinks} />
-        <DropDownSection section={priceLinks} />
-        <DropDownSection section={sellerLocationLinks} />
+
+        {/* We use splice here to ignore the first 4 links which are simple links and handled above */}
+        {menu.links.slice(4).map(subMenu => {
+          if (subMenu.menu) {
+            return <DropDownSection key={subMenu.text} section={subMenu} />
+          }
+        })}
       </Flex>
     </Menu>
   )

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -7,8 +7,6 @@ import { DropDownSection } from "./DropDownSection"
 
 interface DropDownNavMenuProps {
   width?: string
-  paddingTop?: number
-  paddingBottom?: number
   menu: any
 }
 

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -1,0 +1,33 @@
+import { Box, color, MenuItem, Sans } from "@artsy/palette"
+import React from "react"
+import { MenuLinkData, SimpleLinkData } from "../menuData"
+
+interface DropDownSectionProps {
+  section: MenuLinkData
+}
+
+export const DropDownSection: React.FC<DropDownSectionProps> = ({
+  section,
+}) => {
+  return (
+    <Box width={150} py={4} mr={3}>
+      <Sans size="2" mb={1}>
+        {section.text}
+      </Sans>
+      {section.menu.links.map((menuItem: SimpleLinkData) => {
+        return (
+          <MenuItem
+            paddingX={0}
+            paddingY={0.5}
+            href={menuItem.href}
+            textColor={color("black60")}
+            textWeight="regular"
+            fontSize="3t"
+          >
+            {menuItem.text}
+          </MenuItem>
+        )
+      })}
+    </Box>
+  )
+}

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -10,7 +10,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
   section,
 }) => {
   return (
-    <Box width={150} py={4} mr={3}>
+    <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
       <Sans size="2" mb={1}>
         {section.text}
       </Sans>

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -1,4 +1,4 @@
-import { Box, color, MenuItem, Sans } from "@artsy/palette"
+import { Box, color, Flex, MenuItem, Sans } from "@artsy/palette"
 import React from "react"
 import { MenuLinkData, SimpleLinkData } from "../menuData"
 
@@ -12,25 +12,77 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
   if (!section) return null
 
   return (
-    <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
-      <Sans size="2" mb={1}>
-        {section.text}
-      </Sans>
-      {section.menu.links.map((menuItem: SimpleLinkData) => {
-        return (
-          <MenuItem
-            key={menuItem.text}
-            px={0}
-            py={0.5}
-            href={menuItem.href}
-            textColor={color("black60")}
-            textWeight="regular"
-            fontSize="3t"
+    <>
+      {section.text === "Artist Nationality & Region" ? (
+        <Flex>
+          <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
+            <Sans size="2" mb={1}>
+              {section.text}
+            </Sans>
+            {section.menu &&
+              section.menu.links.slice(0, 8).map((menuItem: SimpleLinkData) => {
+                return (
+                  <MenuItem
+                    key={menuItem.text}
+                    px={0}
+                    py={0.5}
+                    href={menuItem.href}
+                    textColor={color("black60")}
+                    textWeight="regular"
+                    fontSize="3t"
+                  >
+                    {menuItem.text}
+                  </MenuItem>
+                )
+              })}
+          </Box>
+          <Box
+            width={[110, 110, 110, 135, 150]}
+            pt="66px"
+            pb={4}
+            mr={[2, 2, 3, 3]}
           >
-            {menuItem.text}
-          </MenuItem>
-        )
-      })}
-    </Box>
+            {section.menu &&
+              section.menu.links.slice(-8).map((menuItem: SimpleLinkData) => {
+                return (
+                  <MenuItem
+                    key={menuItem.text}
+                    px={0}
+                    py={0.5}
+                    href={menuItem.href}
+                    textColor={color("black60")}
+                    textWeight="regular"
+                    fontSize="3t"
+                  >
+                    {menuItem.text}
+                  </MenuItem>
+                )
+              })}
+          </Box>
+        </Flex>
+      ) : (
+        <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
+          <Sans size="2" mb={1}>
+            {section.text}
+          </Sans>
+          {section.menu &&
+            section.menu.links.map((menuItem: SimpleLinkData) => {
+              return (
+                <MenuItem
+                  key={menuItem.text}
+                  px={0}
+                  py={0.5}
+                  href={menuItem.href}
+                  textColor={color("black60")}
+                  textWeight="regular"
+                  fontSize="3t"
+                >
+                  {menuItem.text}
+                </MenuItem>
+              )
+            })}
+        </Box>
+      )}
+    </>
   )
 }

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -9,6 +9,8 @@ interface DropDownSectionProps {
 export const DropDownSection: React.FC<DropDownSectionProps> = ({
   section,
 }) => {
+  if (!section) return null
+
   return (
     <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
       <Sans size="2" mb={1}>

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -1,6 +1,7 @@
-import { Box, color, Flex, MenuItem, Sans } from "@artsy/palette"
+import { Box, color, MenuItem, Sans } from "@artsy/palette"
 import React from "react"
 import { MenuLinkData, SimpleLinkData } from "../menuData"
+import { TwoColumnDropDownSection } from "./TwoColumnDropDownSection"
 
 interface DropDownSectionProps {
   section: MenuLinkData
@@ -14,52 +15,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
   return (
     <>
       {section.text === "Artist Nationality & Region" ? (
-        <Flex>
-          <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
-            <Sans size="2" mb={1}>
-              {section.text}
-            </Sans>
-            {section.menu &&
-              section.menu.links.slice(0, 8).map((menuItem: SimpleLinkData) => {
-                return (
-                  <MenuItem
-                    key={menuItem.text}
-                    px={0}
-                    py={0.5}
-                    href={menuItem.href}
-                    textColor={color("black60")}
-                    textWeight="regular"
-                    fontSize="3t"
-                  >
-                    {menuItem.text}
-                  </MenuItem>
-                )
-              })}
-          </Box>
-          <Box
-            width={[110, 110, 110, 135, 150]}
-            pt="66px"
-            pb={4}
-            mr={[2, 2, 3, 3]}
-          >
-            {section.menu &&
-              section.menu.links.slice(-8).map((menuItem: SimpleLinkData) => {
-                return (
-                  <MenuItem
-                    key={menuItem.text}
-                    px={0}
-                    py={0.5}
-                    href={menuItem.href}
-                    textColor={color("black60")}
-                    textWeight="regular"
-                    fontSize="3t"
-                  >
-                    {menuItem.text}
-                  </MenuItem>
-                )
-              })}
-          </Box>
-        </Flex>
+        <TwoColumnDropDownSection section={section} />
       ) : (
         <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
           <Sans size="2" mb={1}>

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -17,8 +17,8 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
       {section.menu.links.map((menuItem: SimpleLinkData) => {
         return (
           <MenuItem
-            paddingX={0}
-            paddingY={0.5}
+            px={0}
+            py={0.5}
             href={menuItem.href}
             textColor={color("black60")}
             textWeight="regular"

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -17,6 +17,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
       {section.menu.links.map((menuItem: SimpleLinkData) => {
         return (
           <MenuItem
+            key={menuItem.text}
             px={0}
             py={0.5}
             href={menuItem.href}

--- a/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
@@ -12,6 +12,8 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
   // The data for nationality and region are represented in a single array, but
   // visually they should be shown as two distinct columns. This is the only
   // section that behaves this way so we've created a separate component for it.
+  const nationalities = section.menu.links.slice(0, 8)
+  const regions = section.menu.links.slice(-8)
 
   return (
     <Flex>
@@ -20,7 +22,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
           {section.text}
         </Sans>
         {section.menu &&
-          section.menu.links.slice(0, 8).map((menuItem: SimpleLinkData) => {
+          nationalities.map((menuItem: SimpleLinkData) => {
             return (
               <MenuItem
                 key={menuItem.text}
@@ -38,7 +40,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
       </Box>
       <Box width={[110, 110, 110, 135, 150]} pt="66px" pb={4} mr={[2, 2, 3, 3]}>
         {section.menu &&
-          section.menu.links.slice(-8).map((menuItem: SimpleLinkData) => {
+          regions.map((menuItem: SimpleLinkData) => {
             return (
               <MenuItem
                 key={menuItem.text}

--- a/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
@@ -9,6 +9,10 @@ interface TwoColumnDropDownSectionProps {
 export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> = ({
   section,
 }) => {
+  // The data for nationality and region are represented in a single array, but
+  // visually they should be shown as two distinct columns. This is the only
+  // section that behaves this way so we've created a separate component for it.
+
   return (
     <Flex>
       <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>

--- a/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
@@ -1,0 +1,55 @@
+import { Box, color, Flex, MenuItem, Sans } from "@artsy/palette"
+import React from "react"
+import { MenuLinkData, SimpleLinkData } from "../menuData"
+
+interface TwoColumnDropDownSectionProps {
+  section: MenuLinkData
+}
+
+export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> = ({
+  section,
+}) => {
+  return (
+    <Flex>
+      <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
+        <Sans size="2" mb={1}>
+          {section.text}
+        </Sans>
+        {section.menu &&
+          section.menu.links.slice(0, 8).map((menuItem: SimpleLinkData) => {
+            return (
+              <MenuItem
+                key={menuItem.text}
+                px={0}
+                py={0.5}
+                href={menuItem.href}
+                textColor={color("black60")}
+                textWeight="regular"
+                fontSize="3t"
+              >
+                {menuItem.text}
+              </MenuItem>
+            )
+          })}
+      </Box>
+      <Box width={[110, 110, 110, 135, 150]} pt="66px" pb={4} mr={[2, 2, 3, 3]}>
+        {section.menu &&
+          section.menu.links.slice(-8).map((menuItem: SimpleLinkData) => {
+            return (
+              <MenuItem
+                key={menuItem.text}
+                px={0}
+                py={0.5}
+                href={menuItem.href}
+                textColor={color("black60")}
+                textWeight="regular"
+                fontSize="3t"
+              >
+                {menuItem.text}
+              </MenuItem>
+            )
+          })}
+      </Box>
+    </Flex>
+  )
+}

--- a/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
@@ -1,0 +1,45 @@
+import { useTracking } from "Artsy/Analytics/useTracking"
+import { mount } from "enzyme"
+import React from "react"
+import { menuData, MenuLinkData } from "../../menuData"
+import { DropDownNavMenu, MenuItemContainer } from "../DropDownMenu"
+import { DropDownSection } from "../DropDownSection"
+
+jest.mock("Artsy/Analytics/useTracking")
+
+describe("DropDownMenu", () => {
+  const trackEvent = jest.fn()
+  const getWrapper = () => {
+    return mount(
+      <DropDownNavMenu menu={(menuData.links[0] as MenuLinkData).menu} />
+    )
+  }
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders simple links", () => {
+    const wrapper = getWrapper()
+    const menuItemContainers = wrapper.find(MenuItemContainer)
+
+    expect(menuItemContainers.length).toBe(5)
+    expect(menuItemContainers.at(0).text()).toContain("New this Week")
+    expect(menuItemContainers.at(1).text()).toContain("Trending this Month")
+    expect(menuItemContainers.at(2).text()).toContain("Exclusively on Artsy")
+    expect(menuItemContainers.at(3).text()).toContain("Closing Soon")
+  })
+
+  it("renders correct number of DropDownSection links", () => {
+    const wrapper = getWrapper()
+    const dropDownSection = wrapper.find(DropDownSection)
+
+    expect(dropDownSection.length).toBe(5)
+  })
+})

--- a/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
@@ -11,6 +11,7 @@ jest.mock("Artsy/Analytics/useTracking")
 
 describe("DropDownMenu", () => {
   const trackEvent = jest.fn()
+
   const getWrapper = () => {
     return mount(
       <DropDownNavMenu
@@ -48,12 +49,10 @@ describe("DropDownMenu", () => {
     expect(dropDownSection.length).toBe(5)
   })
 
-  xit("tracks analytics click events correctly", () => {
+  it("tracks analytics click events correctly", () => {
     const wrapper = getWrapper()
-    wrapper
-      .find(MenuItem)
-      .first()
-      .simulate("click")
+    const menuItem = wrapper.find(MenuItem).first()
+    menuItem.simulate("click")
 
     expect(trackEvent).toHaveBeenCalledWith({
       action_type: "Click",

--- a/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
@@ -1,3 +1,4 @@
+import { MenuItem } from "@artsy/palette"
 import { ContextModule } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount } from "enzyme"
@@ -45,5 +46,20 @@ describe("DropDownMenu", () => {
     const dropDownSection = wrapper.find(DropDownSection)
 
     expect(dropDownSection.length).toBe(5)
+  })
+
+  xit("tracks analytics click events correctly", () => {
+    const wrapper = getWrapper()
+    wrapper
+      .find(MenuItem)
+      .first()
+      .simulate("click")
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      action_type: "Click",
+      context_module: "HeaderArtworksDropdown",
+      subject: "New this Week",
+      destination_path: "/collection/new-this-week",
+    })
   })
 })

--- a/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { mount } from "enzyme"
 import React from "react"
@@ -11,7 +12,10 @@ describe("DropDownMenu", () => {
   const trackEvent = jest.fn()
   const getWrapper = () => {
     return mount(
-      <DropDownNavMenu menu={(menuData.links[0] as MenuLinkData).menu} />
+      <DropDownNavMenu
+        menu={(menuData.links[0] as MenuLinkData).menu}
+        contextModule={ContextModule.HeaderArtworksDropdown}
+      />
     )
   }
 

--- a/src/Components/NavBar/Menus/__tests__/DropDownSection.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownSection.test.tsx
@@ -1,0 +1,42 @@
+import { MenuItem } from "@artsy/palette"
+import { useTracking } from "Artsy/Analytics/useTracking"
+import { mount } from "enzyme"
+import React from "react"
+import { menuData, MenuLinkData } from "../../menuData"
+import { DropDownSection } from "../DropDownSection"
+
+jest.mock("Artsy/Analytics/useTracking")
+
+describe("DropDownMenu", () => {
+  const trackEvent = jest.fn()
+  const mediumLinks = (menuData.links[0] as MenuLinkData).menu.links.filter(
+    item => {
+      return item.text === "Medium"
+    }
+  )[0] as MenuLinkData
+
+  const getWrapper = () => {
+    return mount(<DropDownSection section={mediumLinks} />)
+  }
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders simple links", () => {
+    const wrapper = getWrapper()
+    const menuItems = wrapper.find(MenuItem)
+
+    expect(menuItems.length).toBe(8)
+    expect(menuItems.first().text()).toContain("Painting")
+    expect(menuItems.first().prop("href")).toContain("/collection/painting")
+    expect(menuItems.last().text()).toContain("Design")
+    expect(menuItems.last().prop("href")).toContain("/collection/design")
+  })
+})

--- a/src/Components/NavBar/Menus/__tests__/DropDownSection.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownSection.test.tsx
@@ -15,8 +15,8 @@ describe("DropDownMenu", () => {
     }
   )[0] as MenuLinkData
 
-  const getWrapper = () => {
-    return mount(<DropDownSection section={mediumLinks} />)
+  const getWrapper = links => {
+    return mount(<DropDownSection section={links} />)
   }
 
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe("DropDownMenu", () => {
   })
 
   it("renders simple links", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper(mediumLinks)
     const menuItems = wrapper.find(MenuItem)
 
     expect(menuItems.length).toBe(8)
@@ -38,5 +38,12 @@ describe("DropDownMenu", () => {
     expect(menuItems.first().prop("href")).toContain("/collection/painting")
     expect(menuItems.last().text()).toContain("Design")
     expect(menuItems.last().prop("href")).toContain("/collection/design")
+  })
+
+  it("does not render DropDownSection when section is undefined", () => {
+    const wrapper = getWrapper(undefined)
+    const menuItems = wrapper.find(MenuItem)
+
+    expect(menuItems.length).toBe(0)
   })
 })

--- a/src/Components/NavBar/Menus/index.tsx
+++ b/src/Components/NavBar/Menus/index.tsx
@@ -1,4 +1,5 @@
 export * from "./MobileNavMenu/MobileNavMenu"
+export * from "./DropDownMenu"
 export * from "./MoreNavMenu"
 export * from "./NotificationsMenu"
 export * from "./UserMenu"

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -61,11 +61,9 @@ export const NavBar: React.FC = track(
     user,
     "User Conversations View"
   )
-  const canViewNewDropDown = Boolean(
-    user?.lab_features?.includes("Updated Navigation")
-  )
+  const canViewNewDropDown = userHasLabFeature(user, "Updated Navigation")
   const {
-    links: [artworks],
+    links: [artworks, artists],
   } = menuData
 
   const getNotificationCount = () => cookie.get("notification-count") || 0
@@ -137,7 +135,27 @@ export const NavBar: React.FC = track(
               <NavItem href="/collect">Artworks</NavItem>
             )}
 
-            <NavItem href="/artists">Artists</NavItem>
+            {canViewNewDropDown ? (
+              <NavItem
+                isFullScreenDropDown
+                Menu={() => {
+                  return (
+                    <Box>
+                      <DropDownNavMenu
+                        width="100vw"
+                        menu={(artists as MenuLinkData).menu}
+                      />
+                    </Box>
+                  )
+                }}
+              >
+                Artists
+              </NavItem>
+            ) : (
+              <NavItem href="/artists">Artists</NavItem>
+            )}
+
+            {/* <NavItem href="/artists">Artists</NavItem> */}
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>
             <NavItem

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -125,8 +125,6 @@ export const NavBar: React.FC = track(
                     <Box>
                       <DropDownNavMenu
                         width="100vw"
-                        paddingTop={2}
-                        paddingBottom={2}
                         menu={(artworks as MenuLinkData).menu}
                       />
                     </Box>

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -61,6 +61,9 @@ export const NavBar: React.FC = track(
     user,
     "User Conversations View"
   )
+  const canViewNewDropDown = Boolean(
+    user?.lab_features?.includes("Updated Navigation")
+  )
   const {
     links: [artworks],
   } = menuData
@@ -114,23 +117,28 @@ export const NavBar: React.FC = track(
         */}
         <NavSection display={["none", "none", "flex"]}>
           <NavSection>
-            <NavItem
-              isFullScreenDropDown
-              Menu={() => {
-                return (
-                  <Box>
-                    <DropDownNavMenu
-                      width="100vw"
-                      paddingTop={2}
-                      paddingBottom={2}
-                      menu={(artworks as MenuLinkData).menu}
-                    />
-                  </Box>
-                )
-              }}
-            >
-              Artworks
-            </NavItem>
+            {canViewNewDropDown ? (
+              <NavItem
+                isFullScreenDropDown
+                Menu={() => {
+                  return (
+                    <Box>
+                      <DropDownNavMenu
+                        width="100vw"
+                        paddingTop={2}
+                        paddingBottom={2}
+                        menu={(artworks as MenuLinkData).menu}
+                      />
+                    </Box>
+                  )
+                }}
+              >
+                Artworks
+              </NavItem>
+            ) : (
+              <NavItem href="/collect">Artworks</NavItem>
+            )}
+
             <NavItem href="/artists">Artists</NavItem>
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -20,6 +20,7 @@ import { SystemContext } from "Artsy/SystemContext"
 import { SearchBarQueryRenderer as SearchBar } from "Components/Search/SearchBar"
 
 import {
+  DropDownNavMenu,
   MobileNavMenu,
   MobileToggleIcon,
   MoreNavMenu,
@@ -110,7 +111,22 @@ export const NavBar: React.FC = track(
         */}
         <NavSection display={["none", "none", "flex"]}>
           <NavSection>
-            <NavItem href="/collect">Artworks</NavItem>
+            <NavItem
+              isFullScreenDropDown
+              Menu={() => {
+                return (
+                  <Box>
+                    <DropDownNavMenu
+                      width="100vw"
+                      paddingTop={2}
+                      paddingBottom={2}
+                    />
+                  </Box>
+                )
+              }}
+            >
+              Artworks
+            </NavItem>
             <NavItem href="/artists">Artists</NavItem>
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -124,6 +124,9 @@ export const NavBar: React.FC = track(
                       <DropDownNavMenu
                         width="100vw"
                         menu={(artworks as MenuLinkData).menu}
+                        contextModule={
+                          AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+                        }
                       />
                     </Box>
                   )
@@ -144,6 +147,9 @@ export const NavBar: React.FC = track(
                       <DropDownNavMenu
                         width="100vw"
                         menu={(artists as MenuLinkData).menu}
+                        contextModule={
+                          AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+                        }
                       />
                     </Box>
                   )

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -29,7 +29,7 @@ import {
 } from "./Menus"
 
 import { ModalType } from "Components/Authentication/Types"
-import { menuData } from "Components/NavBar/menuData"
+import { menuData, MenuLinkData } from "Components/NavBar/menuData"
 import { openAuthModal } from "Utils/openAuthModal"
 
 import { NavItem } from "./NavItem"
@@ -61,6 +61,9 @@ export const NavBar: React.FC = track(
     user,
     "User Conversations View"
   )
+  const {
+    links: [artworks],
+  } = menuData
 
   const getNotificationCount = () => cookie.get("notification-count") || 0
 
@@ -120,6 +123,7 @@ export const NavBar: React.FC = track(
                       width="100vw"
                       paddingTop={2}
                       paddingBottom={2}
+                      menu={(artworks as MenuLinkData).menu}
                     />
                   </Box>
                 )

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -155,7 +155,6 @@ export const NavBar: React.FC = track(
               <NavItem href="/artists">Artists</NavItem>
             )}
 
-            {/* <NavItem href="/artists">Artists</NavItem> */}
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>
             <NavItem

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -15,7 +15,10 @@ interface NavItemProps extends BoxProps {
   className?: string
   href?: string
   onClick?: () => void
+  isFullScreenDropDown?: boolean
 }
+
+type Position = React.CSSProperties["position"]
 
 export const NavItem: React.FC<NavItemProps> = ({
   Menu,
@@ -26,6 +29,7 @@ export const NavItem: React.FC<NavItemProps> = ({
   display = "block",
   href,
   onClick,
+  isFullScreenDropDown,
 }) => {
   const navItemLabel = children
   const { trackEvent } = useTracking()
@@ -36,6 +40,8 @@ export const NavItem: React.FC<NavItemProps> = ({
   const getAnimation = h => ({
     opacity: h ? 0 : 1,
     transform: `translate3d(0, ${h ? -90 : -65}px, 0)`,
+    position: isFullScreenDropDown ? ("absolute" as Position) : "static",
+    left: "0px",
   })
   const animatedStyle = useSpring({
     from: getAnimation(hover),
@@ -75,7 +81,6 @@ export const NavItem: React.FC<NavItemProps> = ({
 
   return (
     <Box
-      position="relative"
       onMouseEnter={() => toggleHover(true)}
       onMouseLeave={() => toggleHover(false)}
     >
@@ -110,7 +115,7 @@ export const NavItem: React.FC<NavItemProps> = ({
 
       {showMenu && (
         <animated.div style={animatedStyle}>
-          <MenuContainer top={space(6)}>
+          <MenuContainer top={space(6)} isFullScreen={isFullScreenDropDown}>
             <Menu />
           </MenuContainer>
         </animated.div>
@@ -121,8 +126,8 @@ export const NavItem: React.FC<NavItemProps> = ({
   )
 }
 
-const MenuContainer = styled(Box)`
+const MenuContainer = styled(Box)<{ isFullScreen?: boolean }>`
   position: absolute;
   margin-top: -1px; /* Offset border */
-  transform: translateX(-78%);
+  transform: translateX(${p => (p.isFullScreen ? 0 : "-78%")});
 `

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -296,9 +296,9 @@ export const menuData: MenuData = {
             },
           },
           {
-            text: "Artist Nationality and Region",
+            text: "Artist Nationality & Region",
             menu: {
-              title: "Artist Nationality and Region",
+              title: "Artist Nationality & Region",
               links: [
                 {
                   text: "American",


### PR DESCRIPTION
Addresses: [FX-1887](https://artsyproduct.atlassian.net/browse/FX-1887)

This is a WIP PR that introduces a new DropDownMenu component. It's blocked by some work on [palette Menu component](https://github.com/artsy/palette/pull/664). This PR includes most of the styling and layout structure in addition to hiding the new drop down behind a feature flag.

Missing the following ToDos:
- [x] Fix the broken tests + add new ones.
- [ ] Add chevron + underline to "Artworks" link.
- [x] Create a util to use for both Artworks & Artists data (might do this in a separate PR).

![nav menu drop down](https://user-images.githubusercontent.com/5201004/78836923-0a7f8600-79c1-11ea-9a78-545a26959df6.gif)

<img width="1653" alt="Screen Shot 2020-04-08 at 5 10 37 PM" src="https://user-images.githubusercontent.com/5201004/78836976-26832780-79c1-11ea-8854-61c90748ce71.png">
