### PR TITLE
Bump timeout

### DIFF
--- a/src/Artsy/Router/NetworkTimeout.tsx
+++ b/src/Artsy/Router/NetworkTimeout.tsx
@@ -5,7 +5,7 @@ import createLogger from "Utils/logger"
 
 const logger = createLogger("Artsy/Router/NetworkTimeout")
 
-const NETWORK_TIMEOUT_MS = 10000
+const NETWORK_TIMEOUT_MS = 15000
 
 export const NetworkTimeout: React.FC = () => {
   const [showErrorModal, toggleErrorModal] = useState(false)


### PR DESCRIPTION
Looking at sentry we're getting a lot of timeout errors: 

<img width="1081" alt="Screen Shot 2020-04-09 at 10 19 15 PM" src="https://user-images.githubusercontent.com/236943/78964877-4ba29380-7ab0-11ea-9307-6b9bd2f6b6cf.png">

I bumped the timeout from 10s to 15s -- but maybe its better that the dialog with the reload button appears at 10, forcing an action in order to jog MP in some way? 