### PR TITLE
Remove inbox icon from menu

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -3,7 +3,6 @@ import {
   ChevronIcon,
   CloseIcon,
   color,
-  EnvelopeIcon,
   Flex,
   MenuIcon,
   Sans,
@@ -266,10 +265,7 @@ const LoggedInLinks: React.FC = () => {
     <Box>
       <Separator my={1} color={color("black10")} />
       {conversationsEnabled && (
-        <MobileLink href="/user/conversations">
-          <EnvelopeIcon fill={"black60"} top={3} mr={10} />
-          Inbox
-        </MobileLink>
+        <MobileLink href="/user/conversations">Inbox</MobileLink>
       )}
       <MobileLink href="/works-for-you">Works for you</MobileLink>
       <MobileLink href="/user/edit">Account</MobileLink>

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -1,4 +1,3 @@
-import { EnvelopeIcon } from "@artsy/palette"
 import { SystemContextProvider } from "Artsy"
 import { useTracking } from "Artsy/Analytics/useTracking"
 import { menuData, SimpleLinkData } from "Components/NavBar/menuData"
@@ -90,7 +89,6 @@ describe("MobileNavMenu", () => {
         user: { type: "NotAdmin", lab_features: [] },
       })
       expect(wrapper.html()).not.toContain("Inbox")
-      expect(wrapper.find(EnvelopeIcon).length).toEqual(0)
     })
 
     it("shows inbox menu option if lab feature enabled", () => {
@@ -98,7 +96,6 @@ describe("MobileNavMenu", () => {
         user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
       })
       expect(wrapper.html()).toContain("Inbox")
-      expect(wrapper.find(EnvelopeIcon).length).toEqual(1)
     })
   })
 


### PR DESCRIPTION
Give that FX is intending more changes to the menu (especially on mobile), I'm going to remove the inbox icon for now.  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.8.4-canary.3375.57220.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.8.4-canary.3375.57220.0
  # or 
  yarn add @artsy/reaction@26.8.4-canary.3375.57220.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
