### PR TITLE
[Clientside Nav] Move Pageloader from Palette

### DIFF
--- a/src/Artsy/Router/PageLoader.tsx
+++ b/src/Artsy/Router/PageLoader.tsx
@@ -1,0 +1,102 @@
+import { Box, ProgressBar } from "@artsy/palette"
+import { random } from "lodash"
+import React, { CSSProperties } from "react"
+import { Spring } from "react-spring/renderprops.cjs"
+
+interface PageLoaderProps {
+  className?: string
+  complete?: boolean
+  percentComplete?: number
+  showBackground?: boolean
+  step?: number
+  style?: CSSProperties
+}
+
+interface PageLoaderState {
+  progress: number
+}
+
+/**
+ * A top-level loading bar used when transitioning between pages.
+ *
+ * Spec: https://app.zeplin.io/project/5acd19ff49a1429169c3128b/screen/5d7166295b4fca9d4724c13d
+ */
+export class PageLoader extends React.Component<
+  PageLoaderProps,
+  PageLoaderState
+> {
+  state = {
+    progress: 0,
+    step: random(1, this.props.step),
+  }
+
+  static defaultProps = {
+    showBackground: true,
+    style: {},
+    step: 2,
+  }
+
+  currentProgress = 0
+  interval
+
+  constructor(props) {
+    super(props)
+    this.currentProgress = this.props.percentComplete || 0
+
+    this.state = {
+      progress: this.currentProgress,
+      step: this.state.step,
+    }
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      this.currentProgress += this.state.step
+      this.setState({
+        progress:
+          Math.round(
+            (Math.atan(this.currentProgress) / (Math.PI / 1.5)) * 100 * 1000
+          ) / 1000,
+      })
+    }, 100)
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  render() {
+    const { showBackground, style, className } = this.props
+    const { progress } = this.state
+    const isComplete = progress === 100
+
+    const animation = {
+      from: {
+        opacity: 0,
+        top: 0,
+      },
+      to: {
+        opacity: 1,
+        top: 0,
+      },
+    }
+
+    return (
+      <Box width="100%" style={style} className={className}>
+        <Spring from={animation.from} to={animation.to} reverse={isComplete}>
+          {animationProps => {
+            return (
+              <Box style={animationProps} position="relative">
+                <ProgressBar
+                  percentComplete={progress}
+                  highlight="purple100"
+                  showBackground={showBackground}
+                />
+              </Box>
+            )
+          }}
+        </Spring>
+      </Box>
+    )
+  }
+}

--- a/src/Artsy/Router/RenderStatus.tsx
+++ b/src/Artsy/Router/RenderStatus.tsx
@@ -1,13 +1,14 @@
 import React from "react"
 import StaticContainer from "react-static-container"
 
-import { Box, PageLoader } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { useSystemContext } from "Artsy"
 import { ErrorPage } from "Components/ErrorPage"
 import ElementsRenderer from "found/lib/ElementsRenderer"
 import { data as sd } from "sharify"
 import createLogger from "Utils/logger"
 import { NetworkTimeout } from "./NetworkTimeout"
+import { PageLoader } from "./PageLoader"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
@@ -37,6 +38,7 @@ export const RenderPending = () => {
           <PageLoader
             className="reactionPageLoader" // positional styling comes from Force body.styl
             showBackground={false}
+            step={20} // speed of progress bar, randomized between 1/x to simulate variable progress
             style={{
               position: "fixed",
               left: 0,


### PR DESCRIPTION
Follow-up to https://github.com/artsy/palette/pull/665

Moving the top loading bar logic back over to reaction so that we can have more control. 

Eventually want to replace this with something like https://github.com/klendi/react-top-loading-bar, or at least match the functionality better. 