### PR TITLE
Use logger instead of console.error to capture missing data reports

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -1,7 +1,12 @@
 import { Flex, LargeSelect, Spacer, Toggle } from "@artsy/palette"
 import { FilterResetLink } from "Components/FilterResetLink"
 import React, { useMemo } from "react"
+import createLogger from "Utils/logger"
 import { useAuctionResultsFilterContext } from "../../AuctionResultsFilterContext"
+
+const log = createLogger(
+  "Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx"
+)
 
 const buildDateRange = (startYear: number, endYear: number) =>
   [...Array(1 + endYear - startYear).keys()].map(yearNum => {
@@ -24,7 +29,7 @@ export const YearCreated: React.FC = () => {
     typeof earliestCreatedYear !== "number" ||
     typeof latestCreatedYear !== "number"
   ) {
-    console.error("Couldn't display year created filter due to missing data")
+    log.error("Couldn't display year created filter due to missing data")
     return null
   }
   const hasChanges =


### PR DESCRIPTION
Use logger instead of console.error so we get results reported to sentry. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.8.7-canary.3379.57276.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.8.7-canary.3379.57276.0
  # or 
  yarn add @artsy/reaction@26.8.7-canary.3379.57276.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
