### PR TITLE
Add data-test attribute on ForgotPassword forms

### DIFF
--- a/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Desktop/ForgotPasswordForm.tsx
@@ -54,7 +54,11 @@ export class ForgotPasswordForm extends Component<
           }
 
           return (
-            <Form onSubmit={handleSubmit} height={180}>
+            <Form
+              onSubmit={handleSubmit}
+              height={180}
+              data-test="ForgotPasswordForm"
+            >
               <QuickInput
                 block
                 error={touched.email && errors.email}

--- a/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
+++ b/src/Components/Authentication/Mobile/ForgotPasswordForm.tsx
@@ -41,7 +41,11 @@ export class MobileForgotPasswordForm extends React.Component<FormProps> {
           return (
             <MobileContainer>
               <MobileInnerWrapper>
-                <Form onSubmit={handleSubmit} height={270}>
+                <Form
+                  onSubmit={handleSubmit}
+                  height={270}
+                  data-test="ForgotPasswordForm"
+                >
                   <MobileHeader>{this.props.title}</MobileHeader>
                   <QuickInput
                     block


### PR DESCRIPTION
Similar to the `data-test` attribute on the login and signup forms, this allows us to query `ForgotPasswordForm` elements in the DOM during Cypress integration testing.

@eessex I followed the Login/SignUp examples found elsewhere. I wonder if we should at some point create a typed Cypress-specific schema which we can use in the artsy/integrity codebase similar to the analytics schema: https://github.com/artsy/reaction/blob/master/src/Artsy/Analytics/Schema/index.ts

Maybe we can also be more explicit in marking components as "queryable" within a Cypress test suite.