### PR TITLE
Update conversations UI to be closer to design spec

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -1,10 +1,12 @@
-import { Box, Flex, Image, Serif } from "@artsy/palette"
+import { Flex, Image, Serif } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
+import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer, RelayProp } from "react-relay"
 import { graphql } from "relay-runtime"
 import { MessageFragmentContainer as Message } from "./Message"
 import { Reply } from "./Reply"
+import { fromToday, TimeSince } from "./TimeSince"
 
 interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
@@ -47,7 +49,43 @@ const Item: React.FC<ItemProps> = props => {
   }
 }
 
-interface ConversationProps {
+type Message = Conversation_conversation["messages"]["edges"][number]["node"]
+/**
+ * Combines messages into groups of messages sent by the same party and
+ * separated out into different groups if sent across multiple days
+ * @param messages Messages in the conversation
+ */
+const groupMessages = (messages: Message[]): Message[][] => {
+  if (messages.length === 0) {
+    return []
+  }
+  // Make a copy of messages
+  const remainingMessages = [...messages]
+  const groups = [[remainingMessages.pop()]]
+  while (remainingMessages.length > 0) {
+    const lastGroup = groups[groups.length - 1]
+    const lastMessage = lastGroup[lastGroup.length - 1]
+    const currentMessage = remainingMessages.pop()
+
+    const lastMessageCreatedAt = DateTime.fromISO(lastMessage.createdAt)
+    const currentMessageCreatedAt = DateTime.fromISO(currentMessage.createdAt)
+    const sameDay = lastMessageCreatedAt.hasSame(currentMessageCreatedAt, "day")
+    const today = fromToday(currentMessageCreatedAt)
+
+    if (sameDay && !today) {
+      lastGroup.push(currentMessage)
+    } else if (!today) {
+      groups.push([currentMessage])
+    } else if (lastMessage.isFromUser !== currentMessage.isFromUser) {
+      groups.push([currentMessage])
+    } else {
+      lastGroup.push(currentMessage)
+    }
+  }
+  return groups
+}
+
+export interface ConversationProps {
   conversation: Conversation_conversation
   relay: RelayProp
 }
@@ -55,7 +93,7 @@ interface ConversationProps {
 const Conversation: React.FC<ConversationProps> = props => {
   const { conversation, relay } = props
   return (
-    <Box>
+    <Flex flexDirection="column" width="100%">
       {conversation.items.map((i, idx) => (
         <Item
           item={i.item}
@@ -66,16 +104,46 @@ const Conversation: React.FC<ConversationProps> = props => {
           }
         />
       ))}
-      {conversation.messages.edges.map((m, idx) => (
-        <Message
-          message={m.node}
-          initialMessage={conversation.initialMessage}
-          key={m.node.id}
-          isFirst={idx === 0}
-        />
-      ))}
+      {groupMessages(conversation.messages.edges.map(edge => edge.node)).map(
+        (messageGroup, groupIndex) => {
+          const today = fromToday(messageGroup[0].createdAt)
+          return (
+            <React.Fragment
+              key={`group-${groupIndex}-${messageGroup[0].internalID}`}
+            >
+              <TimeSince
+                style={{ alignSelf: "center" }}
+                time={messageGroup[0].createdAt}
+                exact
+                mt={0.5}
+                mb={1}
+              />
+              {messageGroup.map((message, messageIndex) => {
+                const nextMessage = messageGroup[messageIndex + 1]
+                return (
+                  <Message
+                    message={message}
+                    initialMessage={conversation.initialMessage}
+                    key={message.internalID}
+                    isFirst={groupIndex + messageIndex === 0}
+                    showTimeSince={
+                      today && messageGroup.length - 1 === messageIndex
+                    }
+                    mb={
+                      nextMessage &&
+                      nextMessage.isFromUser !== message.isFromUser
+                        ? 1
+                        : undefined
+                    }
+                  />
+                )
+              })}
+            </React.Fragment>
+          )
+        }
+      )}
       <Reply conversation={conversation} environment={relay.environment} />
-    </Box>
+    </Flex>
   )
 }
 
@@ -101,7 +169,7 @@ export const ConversationFragmentContainer = createFragmentContainer(
         initialMessage
         lastMessageID
         unread
-        messages(first: $count, after: $after, sort: ASC)
+        messages(first: $count, after: $after, sort: DESC)
           @connection(key: "Messages_messages", filters: []) {
           pageInfo {
             startCursor
@@ -113,6 +181,8 @@ export const ConversationFragmentContainer = createFragmentContainer(
             node {
               id
               internalID
+              createdAt
+              isFromUser
               ...Message_message
             }
           }

--- a/src/Apps/Conversation/Components/Message.tsx
+++ b/src/Apps/Conversation/Components/Message.tsx
@@ -18,7 +18,7 @@ interface AttachmentProps {
   item: Message_message["attachments"][0]
 }
 
-const Attachment: React.FC<AttachmentProps> = props => {
+export const Attachment: React.FC<AttachmentProps> = props => {
   const { item } = props
   if (item.contentType.startsWith("image")) {
     return (

--- a/src/Apps/Conversation/Components/Message.tsx
+++ b/src/Apps/Conversation/Components/Message.tsx
@@ -1,9 +1,18 @@
-import { BorderBox, Box, Flex, Image, Link, Sans, Serif } from "@artsy/palette"
+import {
+  Box,
+  BoxProps,
+  Flex,
+  Image,
+  Link,
+  Sans,
+  Serif,
+  Spacer,
+} from "@artsy/palette"
 import { Message_message } from "__generated__/Message_message.graphql"
-import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
+import { TimeSince } from "./TimeSince"
 
 interface AttachmentProps {
   item: Message_message["attachments"][0]
@@ -30,29 +39,54 @@ const Attachment: React.FC<AttachmentProps> = props => {
     return null
   }
 }
-interface MessageProps {
+interface MessageProps extends Omit<BoxProps, "color"> {
   message: Message_message
   initialMessage?: string
   isFirst: boolean
+  showTimeSince?: boolean
 }
 const Message: React.FC<MessageProps> = props => {
-  const { message, initialMessage, isFirst } = props
-  const createdAt = DateTime.fromISO(message.createdAt).toRelative()
+  const { message, initialMessage, isFirst, showTimeSince, ...boxProps } = props
+  const { isFromUser, body } = message
+  const text = isFirst ? initialMessage : body
+  // const createdAt = DateTime.fromISO(message.createdAt).toRelative()
+  // <Sans size="2">
+  //   From: {message.from.name} - {createdAt}
+  // </Sans>
+  // <Sans size="2">{isFirst ? initialMessage : message.body}</Sans>
+  // {message.attachments && message.attachments.length > 0 && (
+  //   <Serif size="3" mt={3}>
+  //     Attachments
+  //   </Serif>
+  // )}
+  // {message.attachments.map(a => (
+  //   <Attachment item={a} key={a.id} />
+  // ))}
+
+  const bgColor = isFromUser ? "black100" : "black10"
+  const textColor = isFromUser ? "white100" : "black100"
+  const alignSelf = isFromUser ? "flex-end" : undefined
   return (
-    <BorderBox m={2} flexDirection={"column"}>
-      <Sans size="2">
-        From: {message.from.name} - {createdAt}
-      </Sans>
-      <Sans size="2">{isFirst ? initialMessage : message.body}</Sans>
-      {message.attachments && message.attachments.length > 0 && (
-        <Serif size="3" mt={3}>
-          Attachments
-        </Serif>
+    <>
+      <Box
+        {...boxProps}
+        bg={bgColor}
+        p={1}
+        style={{
+          borderRadius: "15px",
+          alignSelf,
+        }}
+        width="66.67%"
+      >
+        <Sans size="4" color={textColor}>
+          {text}
+        </Sans>
+      </Box>
+      {showTimeSince && (
+        <TimeSince time={message.createdAt} style={{ alignSelf }} mt={0.5} />
       )}
-      {message.attachments.map(a => (
-        <Attachment item={a} key={a.id} />
-      ))}
-    </BorderBox>
+      <Spacer mb={showTimeSince ? 1 : 0.5} />
+    </>
   )
 }
 

--- a/src/Apps/Conversation/Components/TimeSince.tsx
+++ b/src/Apps/Conversation/Components/TimeSince.tsx
@@ -1,0 +1,51 @@
+import { Box, BoxProps, Sans, SansSize } from "@artsy/palette"
+import { DateTime } from "luxon"
+import React from "react"
+
+const daysSinceDate = (time: string | DateTime) => {
+  const date = typeof time === "string" ? DateTime.fromISO(time) : time
+  return Math.floor(Math.abs(date.diffNow("days").toObject().days))
+}
+
+export const fromToday = (time: string | DateTime) => {
+  const date = typeof time === "string" ? DateTime.fromISO(time) : time
+  return daysSinceDate(date) === 0
+}
+
+const exactDate = (time: string) => {
+  const date = DateTime.fromISO(time)
+  const daysSince = daysSinceDate(date)
+  console.log("days since", daysSince)
+  if (daysSince === 0) {
+    return `Today ${date.toFormat("t")}`
+  } else if (daysSince === 1) {
+    return `Yesterday ${date.toFormat("t")}`
+  } else if (daysSince < 7) {
+    return date.toFormat("cccc t")
+  } else {
+    return date.toFormat("ccc, LLL d, t")
+  }
+}
+
+const relativeDate = (time: string) => DateTime.fromISO(time).toRelative()
+
+interface TimeSinceProps extends Omit<BoxProps, "color"> {
+  size?: SansSize
+  time: string
+  exact?: boolean
+  style?: React.CSSProperties
+}
+export const TimeSince: React.FC<TimeSinceProps> = ({
+  size = "2",
+  time,
+  exact,
+  ...props
+}) => {
+  return (
+    <Box {...props}>
+      <Sans size={size} color="black30">
+        {exact ? exactDate(time) : relativeDate(time)}
+      </Sans>
+    </Box>
+  )
+}

--- a/src/__generated__/Conversation_conversation.graphql.ts
+++ b/src/__generated__/Conversation_conversation.graphql.ts
@@ -27,6 +27,8 @@ export type Conversation_conversation = {
             readonly node: {
                 readonly id: string;
                 readonly internalID: string;
+                readonly createdAt: string | null;
+                readonly isFromUser: boolean | null;
                 readonly " $fragmentRefs": FragmentRefs<"Message_message">;
             } | null;
         } | null> | null;
@@ -265,6 +267,20 @@ return {
               "selections": [
                 (v0/*: any*/),
                 (v1/*: any*/),
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "createdAt",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "isFromUser",
+                  "args": null,
+                  "storageKey": null
+                },
                 (v3/*: any*/),
                 {
                   "kind": "FragmentSpread",
@@ -378,5 +394,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'bcf380e0b952c72dddca48ab44031d10';
+(node as any).hash = '804cbe21587bb9598e69e62d4aab6e1d';
 export default node;

--- a/src/__generated__/routes_DetailQuery.graphql.ts
+++ b/src/__generated__/routes_DetailQuery.graphql.ts
@@ -43,7 +43,7 @@ fragment Conversation_conversation on Conversation {
   initialMessage
   lastMessageID
   unread
-  messages(first: 30, sort: ASC) {
+  messages(first: 30, sort: DESC) {
     pageInfo {
       startCursor
       endCursor
@@ -54,6 +54,8 @@ fragment Conversation_conversation on Conversation {
       node {
         id
         internalID
+        createdAt
+        isFromUser
         ...Message_message
         __typename
       }
@@ -162,7 +164,7 @@ v5 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "ASC"
+    "value": "DESC"
   }
 ],
 v6 = {
@@ -304,7 +306,7 @@ return {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "messages",
-                "storageKey": "messages(first:30,sort:\"ASC\")",
+                "storageKey": "messages(first:30,sort:\"DESC\")",
                 "args": (v5/*: any*/),
                 "concreteType": "MessageConnection",
                 "plural": false,
@@ -371,13 +373,6 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "body",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
                             "name": "createdAt",
                             "args": null,
                             "storageKey": null
@@ -386,6 +381,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "isFromUser",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "body",
                             "args": null,
                             "storageKey": null
                           },
@@ -561,7 +563,7 @@ return {
     "operationKind": "query",
     "name": "routes_DetailQuery",
     "id": null,
-    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: ASC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  conversation(id: $conversationID) {\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
+    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  conversation(id: $conversationID) {\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Addresses [PURCHASE-1866](https://artsyproduct.atlassian.net/browse/PURCHASE-1866) and starts to address [PURCHASE-1865](https://artsyproduct.atlassian.net/browse/PURCHASE-1865)

Before:

![image](https://user-images.githubusercontent.com/3087225/79181617-c20a0300-7dda-11ea-86a8-6b26db7f44ec.png)


After: 

![image](https://user-images.githubusercontent.com/3087225/79181567-a141ad80-7dda-11ea-87fd-62be84f973dc.png)

The design:

![image](https://user-images.githubusercontent.com/3087225/79181710-072e3500-7ddb-11ea-8864-af3d0897eb31.png)

This is not complete, but a PreMVP piece of work to push the state of the conversation view forward. I'll follow up with tests. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.13.0-canary.3389.57478.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.13.0-canary.3389.57478.0
  # or 
  yarn add @artsy/reaction@26.13.0-canary.3389.57478.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
