### PR TITLE
Remove trailing separator char from Storybook story path

### DIFF
--- a/src/Components/Publishing/__stories__/ToolTip.story.tsx
+++ b/src/Components/Publishing/__stories__/ToolTip.story.tsx
@@ -8,7 +8,7 @@ import React from "react"
 
 const tracking = { trackEvent: x => x, getTrackingData: x => x } as any
 
-storiesOf("Publishing/ToolTips/", module)
+storiesOf("Publishing/ToolTips", module)
   .add("Artist", () => {
     return (
       <div style={{ maxWidth: 580, margin: "50px auto 0 auto" }}>


### PR DESCRIPTION
Follow-up to https://github.com/artsy/reaction/pull/3388

Starting at some version between v5.1.10 and v5.3.18 of Storybook, separator chars like `/` should only be used to separate path parts and not present at the end of a path string, otherwise the UI breaks. /shrug

```
Error: Invalid part '', leading to id === parentId
('publishing-tooltips'), inside kind 'Publishing/ToolTips/'

Did you create a path that uses the separator char accidentally, such as
'Vue <docs/>' where '/' is a separator char? See
https://github.com/storybookjs/storybook/issues/6128
```