### PR TITLE
Update artwork preview in conversation

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -1,4 +1,4 @@
-import { Flex, Image, Serif } from "@artsy/palette"
+import { color, Flex, Image, Sans, Serif } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
 import { DateTime } from "luxon"
 import React from "react"
@@ -16,17 +16,26 @@ const Item: React.FC<ItemProps> = props => {
   const { item } = props
   if (item.__typename === "Artwork") {
     return (
-      <Flex width="350px">
-        <Flex height="auto" alignItems="center" mr={2}>
-          <Image src={item.image.url} width="55px" />
-        </Flex>
-        <Flex flexDirection="column" justifyContent="center">
-          <Serif size="2" weight="semibold">
+      <Flex
+        flexDirection="column"
+        width="350px"
+        p={1}
+        style={{ alignSelf: "flex-end" }}
+      >
+        <Image src={item.image.url} borderRadius="15px 15px 0 0" />
+        <Flex
+          p={1}
+          flexDirection="column"
+          justifyContent="center"
+          background={color("black100")}
+          borderRadius="0 0 15px 15px"
+        >
+          <Sans size="4" weight="medium" color="white100">
             {item.artistNames}
-          </Serif>
-          <Serif italic size="2" color="black60" lineHeight={1.3}>
-            {item.title}, {item.date}
-          </Serif>
+          </Sans>
+          <Sans size="2" color="white100">
+            {item.title} / {item.date}
+          </Sans>
         </Flex>
       </Flex>
     )


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3087225/79253326-00daa000-7e51-11ea-9dcd-ef45845ae03e.png)


After:

![image](https://user-images.githubusercontent.com/3087225/79253308-fae4bf00-7e50-11ea-9771-543570023d6d.png)

The layout here isn't perfect. We really should only show this when we're for certain rendering the first image. It's hard to do that given how we currently calculate things on the client though. There's a ticket to add `isFirstMessage` to metaphysics to help w/ this though, so we can follow up after. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.15.0-canary.3393.57577.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.15.0-canary.3393.57577.0
  # or 
  yarn add @artsy/reaction@26.15.0-canary.3393.57577.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
