### PR TITLE
[PURCHASE-1852] Add checkbox and filtering for lots with nil date information

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -607,6 +607,10 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
 
     # Filter auction results by latest created at year
     latestCreatedYear: Int
+
+    # Filter auction results by empty artwork created date values
+    allowEmptyCreatedDates: Boolean = true
+
     after: String
     first: Int
     before: String

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -47,6 +47,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     sizes,
     createdAfterYear,
     createdBeforeYear,
+    allowEmptyCreatedDates,
   } = filterContext.filters
 
   const loadNext = () => {
@@ -73,6 +74,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
         sort,
         createdBeforeYear,
         createdAfterYear,
+        allowEmptyCreatedDates,
       },
       null,
       error => {
@@ -236,6 +238,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           sizes: { type: "[ArtworkSizes]" }
           createdAfterYear: { type: "Int" }
           createdBeforeYear: { type: "Int" }
+          allowEmptyCreatedDates: { type: "Boolean" }
         ) {
         slug
         ...AuctionResultHeader_artist
@@ -250,6 +253,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           sizes: $sizes
           earliestCreatedYear: $createdAfterYear
           latestCreatedYear: $createdBeforeYear
+          allowEmptyCreatedDates: $allowEmptyCreatedDates
         ) {
           ...AuctionResultsCount_results
           createdYearRange {
@@ -295,6 +299,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
       $sizes: [ArtworkSizes]
       $createdBeforeYear: Int
       $createdAfterYear: Int
+      $allowEmptyCreatedDates: Boolean
     ) {
       artist(id: $artistID) {
         ...ArtistAuctionResults_artist
@@ -309,6 +314,7 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
             sizes: $sizes
             createdAfterYear: $createdAfterYear
             createdBeforeYear: $createdBeforeYear
+            allowEmptyCreatedDates: $allowEmptyCreatedDates
           )
       }
     }

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -8,6 +8,7 @@ export interface AuctionResultsFilters {
   sort?: string
   createdAfterYear?: number
   createdBeforeYear?: number
+  allowEmptyCreatedDates?: boolean
 
   /** Used to get the overall earliest created year for all lots of given artist */
   readonly earliestCreatedYear?: number
@@ -27,6 +28,7 @@ export const initialAuctionResultsFilterState: AuctionResultsFilters = {
   sizes: [],
   page: 1,
   sort: "DATE_DESC",
+  allowEmptyCreatedDates: true,
 }
 
 /**
@@ -172,6 +174,7 @@ const AuctionResultsFilterReducer = (
         "page",
         "createdAfterYear",
         "createdBeforeYear",
+        "allowEmptyCreatedDates",
       ]
       primitiveFilterTypes.forEach(filter => {
         if (name === filter) {

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -1,4 +1,4 @@
-import { Flex, LargeSelect, Spacer, Toggle } from "@artsy/palette"
+import { Checkbox, Flex, LargeSelect, Spacer, Toggle } from "@artsy/palette"
 import { FilterResetLink } from "Components/FilterResetLink"
 import React, { useMemo } from "react"
 import createLogger from "Utils/logger"
@@ -24,6 +24,7 @@ export const YearCreated: React.FC = () => {
     latestCreatedYear,
     createdAfterYear,
     createdBeforeYear,
+    allowEmptyCreatedDates,
   } = filterContext?.filters
   if (
     typeof earliestCreatedYear !== "number" ||
@@ -74,6 +75,15 @@ export const YearCreated: React.FC = () => {
           selected={`${createdBeforeYear}`}
         />
       </Flex>
+      <Spacer mt={0.5} />
+      <Checkbox
+        selected={allowEmptyCreatedDates}
+        onSelect={(allowEmpty: boolean) => {
+          filterContext.setFilter("allowEmptyCreatedDates", allowEmpty)
+        }}
+      >
+        Include unspecified dates
+      </Checkbox>
     </Toggle>
   )
 }

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -168,6 +168,7 @@ describe("AuctionResults", () => {
                   createdBeforeYear: 1973,
                   earliestCreatedYear: 1880,
                   latestCreatedYear: 1973,
+                  allowEmptyCreatedDates: true,
                 },
               })
               done()
@@ -261,6 +262,7 @@ describe("AuctionResults", () => {
                   createdBeforeYear: 1973,
                   earliestCreatedYear: 1880,
                   latestCreatedYear: 1973,
+                  allowEmptyCreatedDates: true,
                 },
               })
 

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.test.tsx
@@ -67,6 +67,23 @@ describe("AuctionResultsFilterContext", () => {
       })
     })
 
+    describe("#setFilter for allowEmptyCreatedDates", () => {
+      it("should set allowEmptyCreatedDates to false", done => {
+        getWrapper({
+          filters: {
+            allowEmptyCreatedDates: true,
+          },
+        })
+        act(() => {
+          context.setFilter("allowEmptyCreatedDates", false)
+          setTimeout(() => {
+            expect(context.filters.allowEmptyCreatedDates).toEqual(false)
+            done()
+          })
+        })
+      })
+    })
+
     describe("#setFilter for createdAfterYear", () => {
       it("should set createdBeforeYear if it is not already provided", done => {
         getWrapper({

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -16,6 +16,7 @@ export type ArtistAuctionResultsQueryVariables = {
     sizes?: ReadonlyArray<ArtworkSizes | null> | null;
     createdBeforeYear?: number | null;
     createdAfterYear?: number | null;
+    allowEmptyCreatedDates?: boolean | null;
 };
 export type ArtistAuctionResultsQueryResponse = {
     readonly artist: {
@@ -42,9 +43,10 @@ query ArtistAuctionResultsQuery(
   $sizes: [ArtworkSizes]
   $createdBeforeYear: Int
   $createdAfterYear: Int
+  $allowEmptyCreatedDates: Boolean
 ) {
   artist(id: $artistID) {
-    ...ArtistAuctionResults_artist_4Fv9NF
+    ...ArtistAuctionResults_artist_214CZC
     id
   }
 }
@@ -72,10 +74,10 @@ fragment ArtistAuctionResultItem_auctionResult on AuctionResult {
   }
 }
 
-fragment ArtistAuctionResults_artist_4Fv9NF on Artist {
+fragment ArtistAuctionResults_artist_214CZC on Artist {
   slug
   ...AuctionResultHeader_artist
-  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear) {
+  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {
     ...AuctionResultsCount_results
     createdYearRange {
       startAt
@@ -205,6 +207,12 @@ var v0 = [
     "name": "createdAfterYear",
     "type": "Int",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "allowEmptyCreatedDates",
+    "type": "Boolean",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -221,56 +229,61 @@ v2 = {
 },
 v3 = {
   "kind": "Variable",
+  "name": "allowEmptyCreatedDates",
+  "variableName": "allowEmptyCreatedDates"
+},
+v4 = {
+  "kind": "Variable",
   "name": "before",
   "variableName": "before"
 },
-v4 = {
+v5 = {
   "kind": "Variable",
   "name": "categories",
   "variableName": "categories"
 },
-v5 = {
+v6 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v6 = {
+v7 = {
   "kind": "Variable",
   "name": "last",
   "variableName": "last"
 },
-v7 = {
+v8 = {
   "kind": "Variable",
   "name": "organizations",
   "variableName": "organizations"
 },
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "sizes",
   "variableName": "sizes"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v12 = [
-  (v10/*: any*/),
+v13 = [
   (v11/*: any*/),
+  (v12/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -279,14 +292,14 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -318,6 +331,7 @@ return {
               (v2/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "Variable",
                 "name": "createdAfterYear",
@@ -328,11 +342,11 @@ return {
                 "name": "createdBeforeYear",
                 "variableName": "createdBeforeYear"
               },
-              (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
-              (v9/*: any*/)
+              (v9/*: any*/),
+              (v10/*: any*/)
             ]
           }
         ]
@@ -369,21 +383,22 @@ return {
               (v2/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "Variable",
                 "name": "earliestCreatedYear",
                 "variableName": "createdAfterYear"
               },
-              (v5/*: any*/),
               (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Variable",
                 "name": "latestCreatedYear",
                 "variableName": "createdBeforeYear"
               },
-              (v7/*: any*/),
               (v8/*: any*/),
-              (v9/*: any*/)
+              (v9/*: any*/),
+              (v10/*: any*/)
             ],
             "concreteType": "AuctionResultConnection",
             "plural": false,
@@ -462,7 +477,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v12/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -472,7 +487,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v12/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -482,7 +497,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v12/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -493,8 +508,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/),
-                      (v11/*: any*/)
+                      (v11/*: any*/),
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -611,7 +626,7 @@ return {
                         "concreteType": "AuctionResultPriceRealized",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
+                          (v14/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "cents_usd",
@@ -630,17 +645,17 @@ return {
                         "concreteType": "AuctionLotEstimate",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ]
                       },
-                      (v14/*: any*/)
+                      (v15/*: any*/)
                     ]
                   }
                 ]
               }
             ]
           },
-          (v14/*: any*/)
+          (v15/*: any*/)
         ]
       }
     ]
@@ -649,10 +664,10 @@ return {
     "operationKind": "query",
     "name": "ArtistAuctionResultsQuery",
     "id": null,
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_4Fv9NF\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  saleDate\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_4Fv9NF on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear) {\n    ...AuctionResultsCount_results\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  slug\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $sort: AuctionResultSorts\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_214CZC\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  title\n  dimension_text: dimensionText\n  organization\n  images {\n    thumbnail {\n      url\n    }\n  }\n  mediumText\n  categoryText\n  description\n  date_text: dateText\n  saleDate\n  price_realized: priceRealized {\n    display\n    cents_usd: centsUSD\n  }\n  estimate {\n    display\n  }\n}\n\nfragment ArtistAuctionResults_artist_214CZC on Artist {\n  slug\n  ...AuctionResultHeader_artist\n  auctionResultsConnection(first: $first, after: $after, before: $before, last: $last, sort: $sort, organizations: $organizations, categories: $categories, sizes: $sizes, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    ...AuctionResultsCount_results\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        title\n        dimension_text: dimensionText\n        images {\n          thumbnail {\n            url\n          }\n        }\n        description\n        date_text: dateText\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment AuctionResultHeader_artist on Artist {\n  slug\n}\n\nfragment AuctionResultsCount_results on AuctionResultConnection {\n  totalCount\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '3533ba4f21376e649037ad3c69678e74';
+(node as any).hash = '27e4d2154553949a4452db380d0a7f49';
 export default node;

--- a/src/__generated__/ArtistAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_artist.graphql.ts
@@ -109,6 +109,12 @@ const node: ReaderFragment = {
       "name": "createdBeforeYear",
       "type": "Int",
       "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "allowEmptyCreatedDates",
+      "type": "Boolean",
+      "defaultValue": null
     }
   ],
   "selections": [
@@ -129,6 +135,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "after",
           "variableName": "after"
+        },
+        {
+          "kind": "Variable",
+          "name": "allowEmptyCreatedDates",
+          "variableName": "allowEmptyCreatedDates"
         },
         {
           "kind": "Variable",
@@ -350,5 +361,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '6f8944f3a8b58c263cd259174ad63d40';
+(node as any).hash = '64781867ff4cd19aac913f6c8a5c8dec';
 export default node;


### PR DESCRIPTION
Add a checkbox to the year created filter toggle that allows users to filter results by the presence of date information.

Checkbox will be selected by default
<img width="1397" alt="Screen Shot 2020-04-14 at 5 06 08 PM" src="https://user-images.githubusercontent.com/12748344/79342110-bd3c7080-7efa-11ea-9247-c6f545bee275.png">


<img width="1290" alt="Screen Shot 2020-04-14 at 5 06 26 PM" src="https://user-images.githubusercontent.com/12748344/79342142-c4fc1500-7efa-11ea-8358-dfee527e802d.png">



Link to JIRA Ticket: https://artsyproduct.atlassian.net/browse/PURCHASE-1852

Metaphysics changes: https://github.com/artsy/metaphysics/pull/2314
Diffusion API changes: https://github.com/artsy/diffusion/pull/226
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.15.0-canary.3397.57718.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.15.0-canary.3397.57718.0
  # or 
  yarn add @artsy/reaction@26.15.0-canary.3397.57718.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
