### PR TITLE
Bump timeout of "ArtworkFilter/desktop/renders default UI items" spec

### DIFF
--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx
@@ -53,7 +53,7 @@ describe("ArtworkFilter", () => {
       expect(wrapper.find("ArtworkFilterArtworkGrid").length).toEqual(1)
       expect(wrapper.find("SortFilter").length).toEqual(1)
       expect(wrapper.find("Pagination").length).toEqual(1)
-    })
+    }, 10000)
 
     it("triggers #onFilterClick on filter click, passing back the changed value and current filter state", async () => {
       const onFilterClick = jest.fn()


### PR DESCRIPTION
This spec is flaky on CI. We could skip it but might be better to give the spec a bit more time to complete and follow-up on why it's slow.

```
FAIL  src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx (14.473s)
 ● ArtworkFilter › desktop › renders default UI items

   : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.

     49 |
     50 |   describe("desktop", () => {
   > 51 |     it("renders default UI items", async () => {
        |     ^
     52 |       const wrapper = await getWrapper()
     53 |       expect(wrapper.find("ArtworkFilterArtworkGrid").length).toEqual(1)
     54 |       expect(wrapper.find("SortFilter").length).toEqual(1)

     at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
     at Suite.it (src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx:51:5)
     at Suite.describe (src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx:50:3)
     at Object.describe (src/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.test.tsx:13:1)
```