### PR TITLE
Expose static pages in search results/autocomplete

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -13,7 +13,7 @@ export interface Props {
   artworkCount: number
 }
 
-const MORE_TABS = ["tag", "city", "feature"]
+const MORE_TABS = ["tag", "city", "feature", "page"]
 
 const TAB_NAME_MAP = {
   artist: "Artists",

--- a/src/Apps/Search/routes.tsx
+++ b/src/Apps/Search/routes.tsx
@@ -27,7 +27,7 @@ const tabsToEntitiesMap = {
   categories: ["GENE"],
   articles: ["ARTICLE"],
   auctions: ["SALE"],
-  more: ["TAG", "CITY", "FEATURE"],
+  more: ["TAG", "CITY", "FEATURE", "PAGE"],
 }
 
 const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {


### PR DESCRIPTION
I noticed that, although we index them, we weren't exposing static pages in our search results/autocomplete.

This (along with https://github.com/artsy/metaphysics/pull/2316) fixes that! Pages show up under the `More` tab:

<img width="1151" alt="Screen Shot 2020-04-15 at 11 55 32 AM" src="https://user-images.githubusercontent.com/2081340/79359297-6e99d100-7f10-11ea-8f16-7c8d7c8de66b.png">
