### PR TITLE
[Clientside Nav] Fix referrer edgecase

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -72,24 +72,28 @@ export class ArtworkApp extends React.Component<Props> {
       referrer,
     } = this.props
 
+    const path = window.location.pathname
     // FIXME: This breaks our global pageview tracking in the router level.
     // Can these props be tracked on mount using our typical @track() or
     // trackEvent() patterns as used in other apps?
     const properties = {
-      path: window.location.pathname,
+      path,
       acquireable: is_acquireable,
       offerable: is_offerable,
       availability,
       price_listed: !!listPrice,
       referrer,
+      url: sd.APP_URL + path,
     }
 
     if (typeof window.analytics !== "undefined") {
+      // See trackingMiddleware.ts
+      window.analytics.__artsyReferrer = referrer
       window.analytics.page(properties, { integrations: { Marketo: false } })
 
       // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
       if (sd.CLIENT_NAVIGATION_V5) {
-        trackExperimentViewed("client_navigation_v5")
+        trackExperimentViewed("client_navigation_v5", properties)
       }
     }
   }

--- a/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
+++ b/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
@@ -96,6 +96,10 @@ describe("trackingMiddleware", () => {
           },
           { integrations: { Marketo: false } }
         )
+
+        expect(window.analytics.__artsyReferrer).toEqual(
+          "http://testing.com/referrer"
+        )
       })
     })
   })

--- a/src/Artsy/Analytics/trackExperimentViewed.tsx
+++ b/src/Artsy/Analytics/trackExperimentViewed.tsx
@@ -1,18 +1,27 @@
 import * as Schema from "Artsy/Analytics"
 import { data as sd } from "sharify"
 
-export const trackExperimentViewed = (name: string) => {
+export const trackExperimentViewed = (name: string, trackingData) => {
   if (typeof window.analytics !== "undefined") {
     const variation = sd[name.toUpperCase()]
-    if (!Boolean(variation))
+    if (!Boolean(variation)) {
       return console.warn(`experiment value for ${name} not found, skipping`)
+    }
 
-    window.analytics.track(Schema.ActionType.ExperimentViewed, {
-      experiment_id: name,
-      experiment_name: name,
-      variation_id: variation,
-      variation_name: variation,
-      nonInteraction: 1,
-    })
+    window.analytics.track(
+      Schema.ActionType.ExperimentViewed,
+      {
+        experiment_id: name,
+        experiment_name: name,
+        variation_id: variation,
+        variation_name: variation,
+        nonInteraction: 1,
+      },
+      {
+        page: {
+          ...trackingData,
+        },
+      }
+    )
   }
 }

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -41,13 +41,14 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           })
 
           if (!foundExcludedPath) {
+            const url = sd.APP_URL + pathname
             const trackingData: {
               path: string
               referrer?: string
               url: string
             } = {
               path: pathname,
-              url: sd.APP_URL + pathname,
+              url,
             }
 
             if (referrer) {
@@ -64,11 +65,30 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
               trackingData.referrer = sd.APP_URL + referrer
             }
 
-            analytics.page(trackingData, { integrations: { Marketo: false } })
+            /**
+             * Store a global reference to the referrer. Since we're in an SPA
+             * context we'll need to use this to track referrers statefully across
+             * pages, since we don't do a hard reload.
+             *
+             * Attaching to the analytics object in the absence of a more
+             * "global" location.
+             *
+             * For our new reaction apps, all tracking goes through this location:
+             * https://github.com/damassi/force/blob/399919f7ef053701f0ed3b20b32dddf0490459b0/src/desktop/assets/analytics.coffee#L41
+             * which will read __artsyReferrer and update referrer appropriately.
+             */
+            const finalReferrer = trackingData.referrer
+            analytics.__artsyReferrer = finalReferrer
+
+            analytics.page(trackingData, {
+              integrations: {
+                Marketo: false,
+              },
+            })
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
             if (sd.CLIENT_NAVIGATION_V5) {
-              trackExperimentViewed("client_navigation_v5")
+              trackExperimentViewed("client_navigation_v5", trackingData)
             }
           }
 


### PR DESCRIPTION
When looking closely at analytics data an edge-case was discovered around referrer being lost in events other than page views. 

Since we're now in a single-page-app context, we need a way to store referrers as the user progresses across clicks:
1) Compute the referrer in our analytics middleware as we have been
1) Store the refer on the global segment.js `window.analytics` object under `window.analaytics.__artsyReferrer`. 
1) In force, where we funnel analytics calls from Reaction, check to see if `__artsyReferrer` is populated and manually set the `referrer` before a `track` call is fired. 