### PR TITLE
[Clientside Nav] Add search to referrer

### DIFF
--- a/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
+++ b/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
@@ -76,6 +76,7 @@ describe("trackingMiddleware", () => {
                 match: {
                   location: {
                     pathname: "/referrer",
+                    search: "?with=queryparams",
                   },
                 },
               },
@@ -91,14 +92,14 @@ describe("trackingMiddleware", () => {
         expect(global.analytics.page).toBeCalledWith(
           {
             path: pathToTest,
-            referrer: `http://testing.com/referrer`,
+            referrer: `http://testing.com/referrer?with=queryparams`,
             url: `http://testing.com${pathToTest}`,
           },
           { integrations: { Marketo: false } }
         )
 
         expect(window.analytics.__artsyReferrer).toEqual(
-          "http://testing.com/referrer"
+          "http://testing.com/referrer?with=queryparams"
         )
       })
     })

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -25,7 +25,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
         const { pathname } = payload
         const referrer = get(
           store.getState(),
-          state => state.found.match.location.pathname
+          state =>
+            state.found.match.location.pathname +
+            state.found.match.location.search
         )
 
         // Pluck segment analytics instance from force


### PR DESCRIPTION
We want to propagate queryParams across pages too, if they're there. 