### PR TITLE
Style updates to new nav drop down menu 

### DIFF
--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -32,7 +32,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   }
 
   return (
-    <Menu onClick={trackClick} width={width}>
+    <Menu onClick={trackClick} width={width} margin={0}>
       <Flex justifyContent="center">
         <SimpleLinksContainer py={4} mr={[4, 4, 4, 6]}>
           <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -36,7 +36,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   }
 
   return (
-    <Menu onClick={trackClick} width={width} margin={0} padding={0}>
+    <Menu onClick={trackClick} width={width} m={0} py={0}>
       <Flex justifyContent="center">
         <SimpleLinksContainer
           py={4}

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -36,7 +36,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   }
 
   return (
-    <Menu onClick={trackClick} width={width} margin={0}>
+    <Menu onClick={trackClick} width={width} margin={0} padding={0}>
       <Flex justifyContent="center">
         <SimpleLinksContainer
           py={4}

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -17,6 +17,10 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   contextModule,
 }) => {
   const { trackEvent } = useTracking()
+  const viewAllTopMargin = {
+    HeaderArtworksDropdown: "130px",
+    HeaderArtistsDropdown: "90px",
+  }
 
   const trackClick = event => {
     const link = event.target
@@ -34,7 +38,11 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   return (
     <Menu onClick={trackClick} width={width} margin={0}>
       <Flex justifyContent="center">
-        <SimpleLinksContainer py={4} mr={[4, 4, 4, 6]}>
+        <SimpleLinksContainer
+          py={4}
+          mr={[4, 4, 4, 6]}
+          viewAllTopMargin={viewAllTopMargin[contextModule]}
+        >
           <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>
             {menu.links.map(menuItem => {
               if (!menuItem.menu) {
@@ -69,13 +77,15 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 
 export const MenuItemContainer = styled(Box)``
 
-const SimpleLinksContainer = styled(Box)`
+const SimpleLinksContainer = styled(Box)<{ viewAllTopMargin: string }>`
   border-right: 1px solid ${color("black10")};
   ${MenuItemContainer} {
     &:last-child {
-      margin-top: 130px;
+      margin-top: ${p => p.viewAllTopMargin};
       text-decoration: underline;
-      color: ${color("black100")};
+      div div {
+        color: ${color("black100")};
+      }
     }
   }
 `

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -7,6 +7,7 @@ import {
   BellIcon,
   Box,
   Button,
+  ChevronIcon,
   color,
   EnvelopeIcon,
   Flex,
@@ -132,7 +133,17 @@ export const NavBar: React.FC = track(
                   )
                 }}
               >
-                Artworks
+                <Flex>
+                  Artworks
+                  <ChevronIcon
+                    direction="down"
+                    color={color("black100")}
+                    height="15px"
+                    width="15px"
+                    top="5px"
+                    left="4px"
+                  />
+                </Flex>
               </NavItem>
             ) : (
               <NavItem href="/collect">Artworks</NavItem>
@@ -155,7 +166,17 @@ export const NavBar: React.FC = track(
                   )
                 }}
               >
-                Artists
+                <Flex>
+                  Artists
+                  <ChevronIcon
+                    direction="down"
+                    color={color("black100")}
+                    height="15px"
+                    width="15px"
+                    top="5px"
+                    left="4px"
+                  />
+                </Flex>
               </NavItem>
             ) : (
               <NavItem href="/artists">Artists</NavItem>
@@ -172,7 +193,17 @@ export const NavBar: React.FC = track(
                 )
               }}
             >
-              More
+              <Flex>
+                More
+                <ChevronIcon
+                  direction="down"
+                  color={color("black100")}
+                  height="15px"
+                  width="15px"
+                  top="5px"
+                  left="4px"
+                />
+              </Flex>
             </NavItem>
           </NavSection>
 

--- a/src/__generated__/SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/SearchResultsEntityQuery.graphql.ts
@@ -2,7 +2,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "%future added value";
+export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PAGE" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "%future added value";
 export type SearchResultsEntityQueryVariables = {
     first?: number | null;
     last?: number | null;

--- a/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
+++ b/src/__generated__/routes_SearchResultsEntityQuery.graphql.ts
@@ -2,7 +2,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "%future added value";
+export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PAGE" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "%future added value";
 export type routes_SearchResultsEntityQueryVariables = {
     term: string;
     entities?: ReadonlyArray<SearchEntity | null> | null;


### PR DESCRIPTION
This PR depends on https://github.com/artsy/palette/pull/671 and addresses some minor style issues with the drop down menu:

- Adds the chevron to drop down menus in the nav bar.
- Ensure menu extends to the fullwidth of the screen.
- Remove top and bottom padding for fullwidth drop down menu.
- Fixes the styling for the "view all" links.

**Before:**
<img width="1242" alt="Screen Shot 2020-04-17 at 2 57 19 PM" src="https://user-images.githubusercontent.com/5201004/79606708-038efc80-80c0-11ea-8c84-a8515ce6e472.png">

**After:**
<img width="1606" alt="Screen Shot 2020-04-17 at 3 12 53 PM" src="https://user-images.githubusercontent.com/5201004/79606871-40f38a00-80c0-11ea-8c6c-64e5baf4d6f8.png">

