### PR TITLE
Add data-test attrs for artist page

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -142,7 +142,7 @@ export class LargeArtistHeader extends Component<Props> {
 
     return (
       <HorizontalPadding>
-        <Box width="100%">
+        <Box width="100%" data-test={ContextModule.artistHeader}>
           {hasImages && (
             <>
               <Carousel
@@ -278,7 +278,7 @@ export class SmallArtistHeader extends Component<Props> {
     const isAdmin = userIsAdmin(user)
 
     return (
-      <Flex flexDirection="column">
+      <Flex flexDirection="column" data-test={ContextModule.artistHeader}>
         {hasImages && (
           <Fragment>
             <Carousel

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -7,8 +7,8 @@ import useDeepCompareEffect from "use-deep-compare-effect"
 import { AuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import { TableSidebar } from "./Components/TableSidebar"
 
+import { ContextModule } from "@artsy/cohesion"
 import { Box, Spacer } from "@artsy/palette"
-
 import { AnalyticsSchema } from "Artsy"
 import { LoadingArea } from "Components/LoadingArea"
 import { isEqual } from "lodash"
@@ -180,7 +180,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
           </Media>
         </Col>
 
-        <Col sm={9}>
+        <Col sm={9} data-test={ContextModule.auctionResults}>
           <AuctionResultsControls
             artist={artist}
             toggleMobileActionSheet={toggleMobileActionSheet}

--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -103,6 +103,7 @@ const RecommendedArtist: FC<RecommendedArtistProps & {
       <Carousel
         height="240px"
         data={artistData}
+        contextModule={ContextModule.relatedArtistsRail}
         options={{ pageDots: false }}
         render={artwork => {
           const aspect_ratio = get(artwork, a => a.node.image.aspect_ratio, 1)

--- a/src/Apps/Artist/Routes/Overview/Components/WorksForSaleRail.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/WorksForSaleRail.tsx
@@ -35,6 +35,7 @@ const WorksForSaleRail: React.FC<WorksForSaleRailProps & {
       height="240px"
       data={artistData}
       options={{ pageDots: false }}
+      contextModule={ContextModule.worksForSaleRail}
       render={artwork => {
         const aspect_ratio = get(artwork, a => a.node.image.aspect_ratio, 1)
         return (

--- a/src/Components/Carousel.tsx
+++ b/src/Components/Carousel.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Box, ChevronIcon, color, Flex, space } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
@@ -44,6 +45,11 @@ interface CarouselProps {
    * The width of the carousel
    */
   width?: string
+
+  /**
+   * For analytics, describes the context for rail content
+   */
+  contextModule?: ContextModule
 
   /**
    * Callback when forward / backward arrows are clicked
@@ -99,7 +105,7 @@ export class Carousel extends React.Component<CarouselProps> {
 
   render() {
     return (
-      <Box width="100%">
+      <Box width="100%" data-test={this.props.contextModule}>
         <Media greaterThan="xs">
           <LargeCarousel {...this.props} />
         </Media>


### PR DESCRIPTION
Minor updates to pass `contextModule` to carousel, and to use the prop as a `data-test` attr for integrity. 