### PR TITLE
Add whitespace to before/after FAQ link

### DIFF
--- a/src/Components/Auction/PostRegistrationModal.tsx
+++ b/src/Components/Auction/PostRegistrationModal.tsx
@@ -45,13 +45,10 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         This auction requires Artsy to verify your identity before bidding.
         <br />
         <br />
-        For details about identity verification, please see the
-        <a
-          target="_blank"
-          href="/identity-verification-faq"
-        >
+        For details about identity verification, please see the{" "}
+        <a target="_blank" href="/identity-verification-faq">
           FAQ
-        </a>
+        </a>{" "}
         or contact verification@artsy.net.
         <br />
         <br />A link to complete identity verification has been sent to your


### PR DESCRIPTION
re-finishes https://artsyproduct.atlassian.net/browse/AUCT-952

This is just adding whitespace to before/after FAQ. See screenshot.

## Screenshot

<img width="1218" alt="faq-link" src="https://user-images.githubusercontent.com/386234/79771544-f0b53b80-82fc-11ea-89ae-fe7070e8610e.png">
