### PR TITLE
[FX-1905] Fix notification badge placement

### DIFF
--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, Sans } from "@artsy/palette"
+import { Box, color, Flex, Sans, space } from "@artsy/palette"
 import { NotificationsMenuQueryResponse } from "__generated__/NotificationsMenuQuery.graphql"
 import { SystemContext } from "Artsy"
 import cookie from "cookies-js"
@@ -109,6 +109,6 @@ const Container = styled(Flex)`
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 12px;
-  right: 40px;
+  top: ${space(1)}px;
+  right: 48px;
 `

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -110,5 +110,5 @@ const Container = styled(Flex)`
   justify-content: center;
   position: absolute;
   top: 12px;
-  right: 0;
+  right: 40px;
 `

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -159,7 +159,7 @@ export const menuData: MenuData = {
                 },
                 {
                   text: "Under $1,000",
-                  href: "/collect?price_range=50-1000",
+                  href: "/collect?price_range=%2A-1000",
                 },
               ],
             },


### PR DESCRIPTION
Addresses: [FX-1905](https://artsyproduct.atlassian.net/browse/FX-1905)

This fixes two minor Drop Down QA items:
-  Switch `Under $1,000` bucket for artworks from `https://www.artsy.net/collect?price_range=50-1000` to `https://www.artsy.net/collect?price_range=%2A-1000`
- Fix the notification badge placement

<img width="467" alt="Screen Shot 2020-04-20 at 5 20 34 PM" src="https://user-images.githubusercontent.com/5201004/79801542-48b76680-832c-11ea-9403-7e9c5d94725b.png">
