### PR TITLE
Fixes static year in footer

### DIFF
--- a/src/Components/Footer.tsx
+++ b/src/Components/Footer.tsx
@@ -166,7 +166,7 @@ const UnstyledLink = styled.a`
 
 const PolicyLinks = () => (
   <>
-    <Serif size="2">© 2018 Artsy</Serif>
+    <Serif size="2">© {new Date().getFullYear()} Artsy</Serif>
     <Spacer mr={1} />
     <UnstyledLink href="https://www.artsy.net/terms">
       <Serif size="2">Terms of Use</Serif>


### PR DESCRIPTION
Simple thing I noticed clicking around — all the artwork/artist pages have 2018 in the footer.

![](http://static.damonzucconi.com/_capture/aoWB3hAFnbWK.png)

Welcome to the screaming twenties.