### PR TITLE
Move cohesion to be a dev dep of reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.2",
+    "@artsy/cohesion": "0.2.0",
     "@artsy/lint-changed": "3.0.4",
     "@artsy/palette": "8.1.3",
     "@babel/cli": "7.0.0",
@@ -170,7 +171,6 @@
     "yalc": "1.0.0-pre.34"
   },
   "dependencies": {
-    "@artsy/cohesion": "0.2.0",
     "@artsy/detect-responsive-traits": "^0.0.5",
     "@artsy/fresnel": "^1.0.13",
     "@artsy/react-html-parser": "^3.0.2",


### PR DESCRIPTION
Given that cohesion is a direct dependency of force, including it as a direct dependency of reaction can lead to cases where it's duplicated in Force's bundle. I'm moving it to a dev dependency in reaction so that it'll still be installed and available when developing locally, but won't be included in the production output (and therefore duplicated in force). 

I haven't included it in this PR, but if there are other services that depend on reaction which should also use cohesion then we should add cohesion as a peer dep too. 