### PR TITLE
Add a header to the conversation view on mobile

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -9,6 +9,7 @@ import {
   Serif,
 } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
+import { RouterLink } from "Artsy/Router/RouterLink"
 import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer, RelayProp } from "react-relay"
@@ -129,9 +130,9 @@ const Conversation: React.FC<ConversationProps> = props => {
         justifyContent="space-between"
         width="100%"
       >
-        <Link href={`/user/conversations`} underlineBehavior="none">
+        <RouterLink to={`/user/conversations`}>
           <ArrowLeftIcon />
-        </Link>
+        </RouterLink>
         <Sans size="3t" weight="medium">
           Inquiry with {conversation.to.name}
         </Sans>

--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -23,7 +23,7 @@ const StyledHeader = styled(Flex)`
   background: white;
   border-bottom: 1px solid ${color("black10")};
   height: 55px;
-  top: 60px;
+  top: 59px;
 `
 
 interface ItemProps {

--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -129,7 +129,9 @@ const Conversation: React.FC<ConversationProps> = props => {
         justifyContent="space-between"
         width="100%"
       >
-        <ArrowLeftIcon />
+        <Link href={`/user/conversations`} underlineBehavior="none">
+          <ArrowLeftIcon />
+        </Link>
         <Sans size="3t" weight="medium">
           Inquiry with {conversation.to.name}
         </Sans>

--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -1,12 +1,30 @@
-import { color, Flex, Image, Link, Sans, Serif } from "@artsy/palette"
+import {
+  ArrowLeftIcon,
+  color,
+  Flex,
+  Image,
+  InfoCircleIcon,
+  Link,
+  Sans,
+  Serif,
+} from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
 import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer, RelayProp } from "react-relay"
 import { graphql } from "relay-runtime"
+import styled from "styled-components"
 import { MessageFragmentContainer as Message } from "./Message"
 import { Reply } from "./Reply"
 import { fromToday, TimeSince } from "./TimeSince"
+
+const StyledHeader = styled(Flex)`
+  position: fixed;
+  background: white;
+  border-bottom: 1px solid ${color("black10")};
+  height: 55px;
+  top: 60px;
+`
 
 interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
@@ -104,59 +122,73 @@ export interface ConversationProps {
 const Conversation: React.FC<ConversationProps> = props => {
   const { conversation, relay } = props
   return (
-    <Flex flexDirection="column" width="100%" px={1}>
-      {conversation.items.map((i, idx) => (
-        <Item
-          item={i.item}
-          key={
-            i.item.__typename === "Artwork" || i.item.__typename === "Show"
-              ? i.item.id
-              : idx
+    <>
+      <StyledHeader
+        px={2}
+        alignItems="center"
+        justifyContent="space-between"
+        width="100%"
+      >
+        <ArrowLeftIcon />
+        <Sans size="3t" weight="medium">
+          Inquiry with {conversation.to.name}
+        </Sans>
+        <InfoCircleIcon />
+      </StyledHeader>
+      <Flex flexDirection="column" width="100%" px={1}>
+        {conversation.items.map((i, idx) => (
+          <Item
+            item={i.item}
+            key={
+              i.item.__typename === "Artwork" || i.item.__typename === "Show"
+                ? i.item.id
+                : idx
+            }
+          />
+        ))}
+        {groupMessages(conversation.messages.edges.map(edge => edge.node)).map(
+          (messageGroup, groupIndex) => {
+            const today = fromToday(messageGroup[0].createdAt)
+            return (
+              <React.Fragment
+                key={`group-${groupIndex}-${messageGroup[0].internalID}`}
+              >
+                <TimeSince
+                  style={{ alignSelf: "center" }}
+                  time={messageGroup[0].createdAt}
+                  exact
+                  mt={0.5}
+                  mb={1}
+                />
+                {messageGroup.map((message, messageIndex) => {
+                  const nextMessage = messageGroup[messageIndex + 1]
+                  return (
+                    <Message
+                      message={message}
+                      initialMessage={conversation.initialMessage}
+                      key={message.internalID}
+                      isFirst={groupIndex + messageIndex === 0}
+                      showTimeSince={
+                        message.createdAt &&
+                        today &&
+                        messageGroup.length - 1 === messageIndex
+                      }
+                      mb={
+                        nextMessage &&
+                        nextMessage.isFromUser !== message.isFromUser
+                          ? 1
+                          : undefined
+                      }
+                    />
+                  )
+                })}
+              </React.Fragment>
+            )
           }
-        />
-      ))}
-      {groupMessages(conversation.messages.edges.map(edge => edge.node)).map(
-        (messageGroup, groupIndex) => {
-          const today = fromToday(messageGroup[0].createdAt)
-          return (
-            <React.Fragment
-              key={`group-${groupIndex}-${messageGroup[0].internalID}`}
-            >
-              <TimeSince
-                style={{ alignSelf: "center" }}
-                time={messageGroup[0].createdAt}
-                exact
-                mt={0.5}
-                mb={1}
-              />
-              {messageGroup.map((message, messageIndex) => {
-                const nextMessage = messageGroup[messageIndex + 1]
-                return (
-                  <Message
-                    message={message}
-                    initialMessage={conversation.initialMessage}
-                    key={message.internalID}
-                    isFirst={groupIndex + messageIndex === 0}
-                    showTimeSince={
-                      message.createdAt &&
-                      today &&
-                      messageGroup.length - 1 === messageIndex
-                    }
-                    mb={
-                      nextMessage &&
-                      nextMessage.isFromUser !== message.isFromUser
-                        ? 1
-                        : undefined
-                    }
-                  />
-                )
-              })}
-            </React.Fragment>
-          )
-        }
-      )}
-      <Reply conversation={conversation} environment={relay.environment} />
-    </Flex>
+        )}
+        <Reply conversation={conversation} environment={relay.environment} />
+      </Flex>
+    </>
   )
 }
 


### PR DESCRIPTION
[PURCHASE-1857]

Add a header to the conversation view on mobile. For the scope of this ticket the info icon won't link to anything. The back button should link back to /user/conversations

Copy includes "Inquiry with" + Conversations.to.name from MP

Uses InfoCircleIcon

Figma link: https://www.figma.com/file/vtXzdPefblvRiAapA79fTh/Conversations?node-id=268%3A0

<img width="505" alt="Screen Shot 2020-04-22 at 3 24 09 PM" src="https://user-images.githubusercontent.com/5643895/80025586-e175ef80-84ae-11ea-8b04-40c2bad3cd62.png">

[PURCHASE-1857]: https://artsyproduct.atlassian.net/browse/PURCHASE-1857