### PR TITLE
[Refactor] Modernize SystemContext, make app shell width configurable 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/auto-config": "1.0.2",
     "@artsy/cohesion": "0.2.0",
     "@artsy/lint-changed": "3.0.4",
-    "@artsy/palette": "8.1.3",
+    "@artsy/palette": "8.2.0",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.7.2",
     "@babel/plugin-proposal-class-properties": "7.3.4",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,8 @@
     "semi": false,
     "singleQuote": false,
     "trailingComma": "es5",
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "arrowParens": "avoid"
   },
   "jest": {
     "cacheDirectory": ".cache/jest",

--- a/src/Apps/Components/AppContainer.tsx
+++ b/src/Apps/Components/AppContainer.tsx
@@ -1,8 +1,17 @@
-import { breakpoints } from "@artsy/palette"
-import styled from "styled-components"
+import { Box, breakpoints } from "@artsy/palette"
+import { useSystemContext } from "Artsy"
+import React from "react"
 
-export const AppContainer = styled.div`
-  width: 100%;
-  max-width: ${breakpoints.xl}px;
-  margin: auto;
-`
+interface AppContainerProps {
+  children: React.ReactNode
+}
+
+export const AppContainer: React.FC<AppContainerProps> = ({ children }) => {
+  const { appMaxWidth = breakpoints.xl } = useSystemContext()
+
+  return (
+    <Box width="100%" maxWidth={appMaxWidth} m="auto">
+      {children}
+    </Box>
+  )
+}

--- a/src/Artsy/Router/Boot.tsx
+++ b/src/Artsy/Router/Boot.tsx
@@ -1,17 +1,18 @@
 import { Grid, injectGlobalStyles, Theme, themeProps } from "@artsy/palette"
 import * as Sentry from "@sentry/browser"
-import * as Artsy from "Artsy"
-import { track } from "Artsy/Analytics"
+import { SystemContextProvider, track } from "Artsy"
 import { RouteConfig } from "found"
-import React from "react"
+import React, { useEffect } from "react"
 import { HeadProvider } from "react-head"
 import { Environment } from "relay-runtime"
 import { data as sd } from "sharify"
 import { Provider as StateProvider } from "unstated"
 import { BreakpointVisualizer } from "Utils/BreakpointVisualizer"
 import Events from "Utils/Events"
+import { getENV } from "Utils/getENV"
 import { ErrorBoundary } from "./ErrorBoundary"
 
+import { useSystemContext } from "Artsy/SystemContext"
 import {
   MatchingMediaQueries,
   MediaContextProvider,
@@ -19,74 +20,70 @@ import {
 } from "Utils/Responsive"
 
 export interface BootProps {
+  children: React.ReactNode
   context: object
-  user: User
+  headTags?: JSX.Element[]
   onlyMatchMediaQueries?: MatchingMediaQueries
   relayEnvironment: Environment
   routes: RouteConfig
-  headTags?: JSX.Element[]
+  user: User
 }
 
-// FIXME: When we update to latest @types/styled-components `suppressMultiMountWarning`
-// issue will be fixed
-const { GlobalStyles } = injectGlobalStyles<{
-  suppressMultiMountWarning: boolean
-}>()
+const { GlobalStyles } = injectGlobalStyles()
 
-@track(null, {
-  dispatch: data => {
-    Events.postEvent(data)
-  },
-})
-export class Boot extends React.Component<BootProps> {
-  componentDidMount() {
-    const env = sd.NODE_ENV || (process.env && process.env.NODE_ENV)
-    if (env === "production") {
+export const Boot = track(null, {
+  dispatch: Events.postEvent,
+})((props: BootProps) => {
+  const { appMaxWidth } = useSystemContext()
+  /**
+   * Let our end-to-end tests know that the app is hydrated and ready to go; and
+   * if in prod, initialize Sentry.
+   */
+  useEffect(() => {
+    document.body.setAttribute("data-test", "AppReady") //
+
+    if (getENV("NODE_ENV") === "production") {
       Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
     }
+  }, [])
 
-    // Let our end-to-end tests know that the app is hydrated and ready to go
-    document.body.setAttribute("data-test", "AppReady")
+  const {
+    children,
+    context,
+    headTags = [],
+    onlyMatchMediaQueries,
+    ...rest
+  } = props
+
+  const contextProps = {
+    ...rest,
+    ...context,
   }
 
-  render() {
-    const { children, context, headTags = [], ...props } = this.props
-    const contextProps = {
-      ...props,
-      ...context,
-    }
-
-    return (
-      <Theme>
-        <HeadProvider headTags={headTags}>
-          <StateProvider>
-            <Artsy.SystemContextProvider {...contextProps}>
-              <ErrorBoundary>
-                <MediaContextProvider onlyMatch={props.onlyMatchMediaQueries}>
-                  <ResponsiveProvider
-                    mediaQueries={themeProps.mediaQueries}
-                    initialMatchingMediaQueries={
-                      props.onlyMatchMediaQueries as any
-                    }
-                  >
-                    <Grid fluid>
-                      <GlobalStyles suppressMultiMountWarning />
-                      {children}
-                      {process.env.NODE_ENV === "development" && (
-                        <BreakpointVisualizer />
-                      )}
-                    </Grid>
-                  </ResponsiveProvider>
-                </MediaContextProvider>
-              </ErrorBoundary>
-            </Artsy.SystemContextProvider>
-          </StateProvider>
-        </HeadProvider>
-      </Theme>
-    )
-  }
-}
-
-// Tests
-GlobalStyles.displayName = "GlobalStyles"
-Grid.displayName = "Grid"
+  return (
+    <Theme>
+      <HeadProvider headTags={headTags}>
+        <StateProvider>
+          <SystemContextProvider {...contextProps}>
+            <ErrorBoundary>
+              <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                <ResponsiveProvider
+                  mediaQueries={themeProps.mediaQueries}
+                  initialMatchingMediaQueries={onlyMatchMediaQueries as any}
+                >
+                  <Grid fluid maxWidth={appMaxWidth}>
+                    <GlobalStyles />
+                    {children}
+                    {process.env.NODE_ENV === "development" && (
+                      <BreakpointVisualizer />
+                    )}
+                  </Grid>
+                </ResponsiveProvider>
+              </MediaContextProvider>
+            </ErrorBoundary>
+          </SystemContextProvider>
+        </StateProvider>
+      </HeadProvider>
+    </Theme>
+  )
+})

--- a/src/Artsy/Router/RenderStatus.tsx
+++ b/src/Artsy/Router/RenderStatus.tsx
@@ -13,11 +13,7 @@ import { PageLoader } from "./PageLoader"
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
 export const RenderPending = () => {
-  const {
-    isFetching,
-    setIsFetching,
-    EXPERIMENTAL_APP_SHELL,
-  } = useSystemContext()
+  const { isFetching, dispatch, EXPERIMENTAL_APP_SHELL } = useSystemContext()
 
   /**
    * First, set fetching to ensure that components that are listening for this
@@ -26,7 +22,10 @@ export const RenderPending = () => {
    * duration of the fetch.
    */
   if (!isFetching) {
-    setIsFetching(true)
+    dispatch({
+      type: "setFetching",
+      payload: true,
+    })
   }
 
   if (isFetching) {
@@ -73,10 +72,13 @@ export const RenderPending = () => {
 export const RenderReady: React.FC<{
   elements: React.ReactNode
 }> = props => {
-  const { isFetching, setIsFetching } = useSystemContext()
+  const { isFetching, dispatch } = useSystemContext()
 
   if (isFetching) {
-    setIsFetching(false)
+    dispatch({
+      type: "setFetching",
+      payload: false,
+    })
   }
 
   if (!isFetching) {
@@ -93,10 +95,13 @@ export const RenderError: React.FC<{
 }> = props => {
   logger.error(props.error.data)
 
-  const { isFetching, setIsFetching } = useSystemContext()
+  const { isFetching, dispatch } = useSystemContext()
 
   if (isFetching) {
-    setIsFetching(false)
+    dispatch({
+      type: "setFetching",
+      payload: false,
+    })
   }
 
   const message =

--- a/src/Artsy/Router/__tests__/buildClientApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildClientApp.test.tsx
@@ -5,6 +5,7 @@ import { createMockNetworkLayer } from "DevTools"
 import { mount } from "enzyme"
 import React from "react"
 import { graphql } from "react-relay"
+import { Boot } from "../Boot"
 
 jest.mock("Components/NavBar", () => ({
   NavBar: () => <div />,
@@ -87,7 +88,7 @@ describe("buildClientApp", () => {
     const wrapper = mount(<ClientApp />)
     expect(
       (wrapper
-        .find("Boot")
+        .find(Boot)
         .props() as any).relayEnvironment.relaySSRMiddleware.cache.values()
     ).toContain("found window cache")
   })
@@ -98,13 +99,12 @@ describe("buildClientApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
+              "dispatch",
               "isFetching",
               "mediator",
               "relayEnvironment",
               "router",
               "routes",
-              "setIsFetching",
-              "setRouter",
               "user",
             ])
             setImmediate(done)

--- a/src/Artsy/Router/__tests__/buildServerApp.test.tsx
+++ b/src/Artsy/Router/__tests__/buildServerApp.test.tsx
@@ -129,14 +129,12 @@ describe("buildServerApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
+              "dispatch",
               "isFetching",
               "mediator",
-              "onlyMatchMediaQueries",
               "relayEnvironment",
               "router",
               "routes",
-              "setIsFetching",
-              "setRouter",
               "user",
             ])
             setImmediate(done)

--- a/src/Artsy/Router/buildAppRoutes.tsx
+++ b/src/Artsy/Router/buildAppRoutes.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from "react"
 
 import { AppShell } from "Apps/Components/AppShell"
 import { useSystemContext } from "Artsy/SystemContext"
-import { catchLinks } from "./Utils/catchLinks"
+import { interceptLinks } from "./interceptLinks"
 
 interface RouteList {
   routes: RouteConfig
@@ -23,36 +23,20 @@ export function buildAppRoutes(routeList: RouteList[]): RouteConfig[] {
     match: Match
     router: Router
   }> = props => {
-    const { router, setRouter } = useSystemContext()
+    const { router, dispatch } = useSystemContext()
 
     // Store global reference to router instance
     useEffect(() => {
       if (props.router !== router) {
-        setRouter(props.router)
+        dispatch({
+          type: "setRouter",
+          payload: props.router,
+        })
       }
 
-      /**
-       * Intercept <a> tags on page and if contained within router route
-       * manifest, navigate via router versus doing a hard jump between pages.
-       */
-      catchLinks(window, href => {
-        // FIXME: PR upstream; `matchRoutes` is missing from type definition
-        // @ts-ignore
-        const foundUrl = props.router.matcher.matchRoutes(routes, href)
-
-        if (foundUrl) {
-          const location = props.router.createLocation(href)
-          const previousHref = window.location.href
-
-          props.router.push({
-            ...location,
-            state: {
-              previousHref,
-            },
-          })
-        } else {
-          window.location.assign(href)
-        }
+      interceptLinks({
+        router: props.router,
+        routes,
       })
     }, [])
 

--- a/src/Artsy/Router/interceptLinks.ts
+++ b/src/Artsy/Router/interceptLinks.ts
@@ -1,0 +1,33 @@
+import { RouteConfig, Router } from "found"
+import { catchLinks } from "./Utils/catchLinks"
+
+interface InterceptLinksProps {
+  router: Router
+  routes: RouteConfig
+}
+
+/**
+ * Intercept <a> tags on page and if contained within router route
+ * manifest, navigate via router versus doing a hard jump between pages.
+ */
+export function interceptLinks({ router, routes }: InterceptLinksProps) {
+  catchLinks(window, href => {
+    // FIXME: PR upstream; `matchRoutes` is missing from type definition
+    // @ts-ignore
+    const foundUrl = router.matcher.matchRoutes(routes, href)
+
+    if (foundUrl) {
+      const location = router.createLocation(href)
+      const previousHref = window.location.href
+
+      router.push({
+        ...location,
+        state: {
+          previousHref,
+        },
+      })
+    } else {
+      window.location.assign(href)
+    }
+  })
+}

--- a/src/Artsy/__tests__/SystemContext.test.tsx
+++ b/src/Artsy/__tests__/SystemContext.test.tsx
@@ -41,11 +41,10 @@ describe("Artsy context", () => {
         <Artsy.SystemContextConsumer>
           {props => {
             expect(Object.keys(props).sort()).toEqual([
+              "dispatch",
               "isFetching",
               "relayEnvironment",
               "router",
-              "setIsFetching",
-              "setRouter",
               "user",
             ])
             setImmediate(done)

--- a/src/Artsy/__tests__/systemContextState.test.tsx
+++ b/src/Artsy/__tests__/systemContextState.test.tsx
@@ -1,0 +1,26 @@
+import { systemContextReducer } from "../systemContextState"
+
+describe("systemContextState", () => {
+  describe("setAppMaxWidth", () => {
+    it("sets width based upon breakpoint keys", () => {
+      const state = systemContextReducer(
+        {},
+        { type: "setAppMaxWidth", payload: "md" }
+      )
+      expect(state.appMaxWidth).toEqual(900)
+    })
+
+    it("sets max width to 100%", () => {
+      const state = systemContextReducer(
+        {},
+        { type: "setAppMaxWidth", payload: "100%" }
+      )
+      expect(state.appMaxWidth).toEqual("100%")
+    })
+
+    it("sets default max width to xl breakpoint if payload not passed", () => {
+      const state = systemContextReducer({}, { type: "setAppMaxWidth" })
+      expect(state.appMaxWidth).toEqual(1192)
+    })
+  })
+})

--- a/src/Artsy/systemContextState.tsx
+++ b/src/Artsy/systemContextState.tsx
@@ -1,0 +1,77 @@
+import { Breakpoint, breakpoints } from "@artsy/palette"
+import { Router } from "found"
+
+const initialState = {
+  /**
+   * Sets the max width of the app shell container. Defaults to breakpoints.xl
+   */
+  appMaxWidth: breakpoints.xl,
+
+  /**
+   * Toggle for setting global fetch state, typically set in RenderStatus
+   */
+  isFetching: false,
+
+  /**
+   * The current router instance
+   */
+  router: null,
+
+  /**
+   * The currently signed-in user.
+   *
+   * Unless explicitely set to `null`, this will default to use the `USER_ID`
+   * and `USER_ACCESS_TOKEN` environment variables if available.
+   */
+  user: null,
+}
+
+export type State = Partial<typeof initialState>
+
+export type Action =
+  | { type: "setAppMaxWidth"; payload?: Breakpoint | "100%" }
+  | { type: "setFetching"; payload: boolean }
+  | { type: "setRouter"; payload: Router }
+  | { type: "setUser"; payload: User }
+
+export function systemContextReducer(prevState: State, action: Action): State {
+  const getNewState = () => {
+    switch (action.type) {
+      case "setAppMaxWidth": {
+        let appMaxWidth
+
+        // Full-screen
+        if (action.payload === "100%") {
+          appMaxWidth = action.payload
+          // Passing a specific breakpoint
+        } else if (breakpoints[action.payload]) {
+          appMaxWidth = breakpoints[action.payload]
+          // Default breakpoint
+        } else {
+          appMaxWidth = breakpoints.xl
+        }
+        return {
+          appMaxWidth,
+        }
+      }
+      case "setFetching": {
+        return {
+          isFetching: action.payload,
+        }
+      }
+      case "setRouter": {
+        return {
+          router: action.payload,
+        }
+      }
+      case "setUser": {
+        return {
+          user: action.payload,
+        }
+      }
+    }
+  }
+
+  const state = { ...prevState, ...getNewState() }
+  return state
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     p-each-series "^2.1.0"
     p-limit "^2.2.2"
 
-"@artsy/palette@8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-8.1.3.tgz#f858fd7ba5f17d62287c772ef66635a5f8637007"
-  integrity sha512-INWqPSvlbVGM1uUr3Q1Qak3aOSo1eNAvR+Y4f8IbAd34yBoQ2WTLv66OYfqRoWpdOtzFHoRB7005VY38PViDtA==
+"@artsy/palette@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-8.2.0.tgz#16f30116b069e081688507496175b549304c5fc8"
+  integrity sha512-C6Wj44eJ9M8+KGM+36I4H8a7FmCVDOLc7wdA2X37hQPzzvgtmr7UzXGw3ilD7ZVNRG4UMmjj8Nf7DOKuw7DZdg==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
This PR does a couple cleanup-y type things: 
- Converts `Boot` to an FC 
- Updates `SystemContext` to to be a bit more modern, and moves state updates to a reducer
- Adds a new action `setAppMaxWidth` which allows us to modify the outside container width to each of our breakpoints, or `100%`
- Moves our mechanism for catching a-tag links in the new app-shell context (similar to gatsby-catch-links) out of route construction and into its own file. 
