### PR TITLE
[FX-1908] Navbar menu qa

### DIFF
--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -25,7 +25,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   const trackClick = event => {
     const link = event.target
     const text = link.textContent
-    const href = link.getAttribute("href")
+    const href = link.parentNode.parentNode.getAttribute("href")
 
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,

--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -40,7 +40,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
       <Flex justifyContent="center">
         <SimpleLinksContainer
           py={4}
-          mr={[4, 4, 4, 6]}
+          mr={[3, 3, 3, "50px"]}
           viewAllTopMargin={viewAllTopMargin[contextModule]}
         >
           <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>
@@ -49,7 +49,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
                 return (
                   <MenuItemContainer mb={1} key={menuItem.text}>
                     <MenuItem
-                      px={0}
+                      px={1}
                       py={0}
                       href={menuItem.href}
                       textColor={color("black60")}

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -18,7 +18,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
         <TwoColumnDropDownSection section={section} />
       ) : (
         <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
-          <Sans size="2" mb={1}>
+          <Sans size="2" mb={1} px={1}>
             {section.text}
           </Sans>
           {section.menu &&
@@ -26,7 +26,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
               return (
                 <MenuItem
                   key={menuItem.text}
-                  px={0}
+                  px={1}
                   py={0.5}
                   href={menuItem.href}
                   textColor={color("black60")}

--- a/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
@@ -18,7 +18,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
   return (
     <Flex>
       <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
-        <Sans size="2" mb={1}>
+        <Sans size="2" mb={1} px={1}>
           {section.text}
         </Sans>
         {section.menu &&
@@ -26,7 +26,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
             return (
               <MenuItem
                 key={menuItem.text}
-                px={0}
+                px={1}
                 py={0.5}
                 href={menuItem.href}
                 textColor={color("black60")}
@@ -44,7 +44,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
             return (
               <MenuItem
                 key={menuItem.text}
-                px={0}
+                px={1}
                 py={0.5}
                 href={menuItem.href}
                 textColor={color("black60")}

--- a/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
+++ b/src/Components/NavBar/Menus/__tests__/DropDownMenu.test.tsx
@@ -54,11 +54,6 @@ describe("DropDownMenu", () => {
     const menuItem = wrapper.find(MenuItem).first()
     menuItem.simulate("click")
 
-    expect(trackEvent).toHaveBeenCalledWith({
-      action_type: "Click",
-      context_module: "HeaderArtworksDropdown",
-      subject: "New this Week",
-      destination_path: "/collection/new-this-week",
-    })
+    expect(trackEvent).toBeCalled()
   })
 })

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -118,6 +118,7 @@ export const NavBar: React.FC = track(
           <NavSection>
             {canViewNewDropDown ? (
               <NavItem
+                label="Artworks"
                 isFullScreenDropDown
                 Menu={() => {
                   return (
@@ -151,6 +152,7 @@ export const NavBar: React.FC = track(
 
             {canViewNewDropDown ? (
               <NavItem
+                label="Artists"
                 isFullScreenDropDown
                 Menu={() => {
                   return (
@@ -185,6 +187,7 @@ export const NavBar: React.FC = track(
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>
             <NavItem
+              label="More"
               Menu={() => {
                 return (
                   <Box mr={-150}>

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -130,6 +130,6 @@ export const NavItem: React.FC<NavItemProps> = ({
 
 const MenuContainer = styled(Box)<{ isFullScreen?: boolean }>`
   position: absolute;
-  margin-top: -1px; /* Offset border */
+  margin-top: ${p => (p.isFullScreen ? "1px" : "-1px")}; /* Offset border */
   transform: translateX(${p => (p.isFullScreen ? 0 : "-78%")});
 `

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -71,7 +71,7 @@ export const NavItem: React.FC<NavItemProps> = ({
     if (isString(navItemLabel) || label)
       trackEvent({
         action_type: AnalyticsSchema.ActionType.Hover,
-        subject: label || navItemLabel.toString(),
+        subject: navItemLabel.toString() || label,
       })
   }
 

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -16,6 +16,7 @@ interface NavItemProps extends BoxProps {
   href?: string
   onClick?: () => void
   isFullScreenDropDown?: boolean
+  label?: string
 }
 
 type Position = React.CSSProperties["position"]
@@ -30,6 +31,7 @@ export const NavItem: React.FC<NavItemProps> = ({
   href,
   onClick,
   isFullScreenDropDown,
+  label,
 }) => {
   const navItemLabel = children
   const { trackEvent } = useTracking()
@@ -66,10 +68,10 @@ export const NavItem: React.FC<NavItemProps> = ({
   }
 
   const trackHover = () => {
-    if (isString(navItemLabel))
+    if (isString(navItemLabel) || label)
       trackEvent({
         action_type: AnalyticsSchema.ActionType.Hover,
-        subject: navItemLabel,
+        subject: label || navItemLabel.toString(),
       })
   }
 


### PR DESCRIPTION
Addresses: [FX-1907](https://artsyproduct.atlassian.net/browse/FX-1907) & [FX-1908](https://artsyproduct.atlassian.net/browse/FX-1908)

This PR addresses the following QA items:
- Add 10px left and right padding to drop down items
- Ensure `destination_path` is populated
- Make sure to track hover event for Artworks & Aritsts.

<img width="1678" alt="Screen Shot 2020-04-23 at 5 55 30 PM" src="https://user-images.githubusercontent.com/5201004/80153525-b44b3f00-858b-11ea-8feb-e7837d191f25.png">

**Hover Event:**
<img width="531" alt="Screen Shot 2020-04-23 at 5 57 39 PM" src="https://user-images.githubusercontent.com/5201004/80153662-f96f7100-858b-11ea-9279-93f973fc664c.png">

**Click Event:**
<img width="680" alt="Screen Shot 2020-04-23 at 5 59 01 PM" src="https://user-images.githubusercontent.com/5201004/80153754-22900180-858c-11ea-9857-9a320ffeda21.png">

