### PR TITLE
Hide recently viewed on marketing page

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -76,7 +76,7 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
                */
               !route.displayFullPage && (
                 <>
-                  <Flex flexDirection="row" alignItems="center">
+                  <Flex flexDirection="row" alignItems="center" my={3}>
                     <ChevronIcon
                       direction="left"
                       color="black"
@@ -108,17 +108,24 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
           </Col>
         </Row>
 
-        {typeof window !== "undefined" && (
-          <LazyLoadComponent threshold={1000}>
-            <Row>
-              <Col>
-                <RecentlyViewed />
-              </Col>
-            </Row>
-          </LazyLoadComponent>
+        {/* Fullpage is typically a stand-alone marketing page  */}
+        {!route.displayFullPage && typeof window !== "undefined" && (
+          <>
+            <LazyLoadComponent threshold={1000}>
+              <Row>
+                <Col>
+                  <RecentlyViewed />
+                </Col>
+              </Row>
+            </LazyLoadComponent>
+          </>
         )}
 
-        <Separator mt={6} mb={3} />
+        {route.displayFullPage ? (
+          <Spacer mb={3} />
+        ) : (
+          <Separator mt={6} mb={3} />
+        )}
 
         <Row>
           <Col>


### PR DESCRIPTION
Noticed that the recently viewed rail was still visible on /consign. We want to hide it on these types of marketing pages. 

<img width="1083" alt="Screen Shot 2020-04-24 at 10 31 20 AM" src="https://user-images.githubusercontent.com/236943/80240527-d3db7980-8616-11ea-8538-3b293ca5528b.png">
