### PR TITLE
[Bugfix] Make /collection/id Header safer

### DIFF
--- a/src/Apps/Collect/Routes/Collection/Components/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/__tests__/Header.test.tsx
@@ -8,6 +8,7 @@ import { SystemContextProvider } from "Artsy"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
+import { cloneDeep } from "lodash"
 import React from "react"
 import sharify from "sharify"
 import { CollectionHeader, getFeaturedArtists, Props } from "../index"
@@ -64,6 +65,15 @@ describe("collections header", () => {
       </MockBoot>
     )
   }
+
+  it("doesnt blow up if missing merchandisableArtists or artistIDs", () => {
+    const noArtistsOrIDs = cloneDeep(props) as any
+    noArtistsOrIDs.collection.query.artistIDs = null
+    noArtistsOrIDs.artworks.merchandisableArtists = null
+    expect(() => {
+      mountComponent(noArtistsOrIDs)
+    }).not.toThrowError()
+  })
 
   it("renders the default collections header when there is no header image", () => {
     const component = mountComponent({

--- a/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -50,18 +50,21 @@ export const getFeaturedArtists = (
   collection: Header_collection,
   merchandisableArtists: Header_artworks["merchandisableArtists"]
 ): Header_artworks["merchandisableArtists"] => {
-  if (collection.query.artistIDs.length > 0) {
+  if (collection.query.artistIDs?.length > 0) {
     return filter(merchandisableArtists, artist =>
       collection.query.artistIDs.includes(artist.internalID)
     )
   }
 
-  if (merchandisableArtists.length > 0) {
+  if (merchandisableArtists?.length > 0) {
     const filteredArtistsIds = merchandisableArtists.filter(artist => {
       return !collection.featuredArtistExclusionIds.includes(artist.internalID)
     })
     return take(filteredArtistsIds, artistsCount)
   }
+
+  // No artists
+  return []
 }
 
 export const featuredArtistsEntityCollection: (


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/1579743055/?project=28316&referrer=slack

Noticed in #incident-83 that when ES went down, we were throwing an error on the collection page. This adds some safety around that, however a more holistic look should be given to this component as a whole. 