### PR TITLE
[FX-1819] Links to consign page in mobile nav

### DIFF
--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -55,6 +55,7 @@ export const MobileNavMenu: React.FC<Props> = props => {
             <MobileLink href="/fairs">Fairs</MobileLink>
             <MobileLink href="/shows">Shows</MobileLink>
             <MobileLink href="/institutions">Museums</MobileLink>
+            <MobileLink href="/consign">Consign</MobileLink>
             <MobileLink href="/gallery-partnerships">
               Artsy for Galleries
             </MobileLink>

--- a/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.test.tsx
@@ -68,7 +68,7 @@ describe("MobileNavMenu", () => {
 
       const simpleLinks = linkContainer.children(MobileLink)
 
-      expect(simpleLinks.length).toBe(7)
+      expect(simpleLinks.length).toBe(8)
       ;(menuData.links as SimpleLinkData[])
         .slice(2)
         .map(({ href, text }, index) => {

--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -440,6 +440,10 @@ export const menuData: MenuData = {
       href: "/institutions",
     },
     {
+      text: "Consign",
+      href: "/consign",
+    },
+    {
       text: "Artsy for Galleries",
       href: "/gallery-partnerships",
     },


### PR DESCRIPTION
Re: [FX-1819](https://artsyproduct.atlassian.net/browse/FX-1819)

![](http://static.damonzucconi.com/_capture/rnR7gfuSZ21u.png)

Same place as in the desktop hierarchy.

I don't really understand what this comment is specifically asking for — https://artsyproduct.atlassian.net/browse/FX-1819?focusedCommentId=27330 — should just be a separate issue.