### PR TITLE
[NavBar Drop Down QA] add a new prop to control background color

### DIFF
--- a/src/Components/NavBar/Menus/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu.tsx
@@ -55,6 +55,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
                       textColor={color("black60")}
                       textWeight="regular"
                       fontSize="3t"
+                      hasLighterTextColor
                     >
                       {menuItem.text}
                     </MenuItem>

--- a/src/Components/NavBar/Menus/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownSection.tsx
@@ -32,6 +32,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
                   textColor={color("black60")}
                   textWeight="regular"
                   fontSize="3t"
+                  hasLighterTextColor
                 >
                   {menuItem.text}
                 </MenuItem>

--- a/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/TwoColumnDropDownSection.tsx
@@ -32,6 +32,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
                 textColor={color("black60")}
                 textWeight="regular"
                 fontSize="3t"
+                hasLighterTextColor
               >
                 {menuItem.text}
               </MenuItem>
@@ -50,6 +51,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
                 textColor={color("black60")}
                 textWeight="regular"
                 fontSize="3t"
+                hasLighterTextColor
               >
                 {menuItem.text}
               </MenuItem>


### PR DESCRIPTION
⚠️ **Blocked by: https://github.com/artsy/palette/pull/673**

This PR adds a new prop to control the `background-color` for MenuItems.

![image](https://user-images.githubusercontent.com/5201004/80413922-372b0d00-889e-11ea-9aaf-22f39a010414.png)

<img width="1678" alt="Screen Shot 2020-04-23 at 5 55 30 PM" src="https://user-images.githubusercontent.com/5201004/80414017-5e81da00-889e-11ea-8906-065813537678.png">
