### PR TITLE
[FX-1925] Fix some minor issues and launch nav drop down menus

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -62,7 +62,6 @@ export const NavBar: React.FC = track(
     user,
     "User Conversations View"
   )
-  const canViewNewDropDown = userHasLabFeature(user, "Updated Navigation")
   const {
     links: [artworks, artists],
   } = menuData
@@ -116,83 +115,75 @@ export const NavBar: React.FC = track(
         */}
         <NavSection display={["none", "none", "flex"]}>
           <NavSection>
-            {canViewNewDropDown ? (
-              <NavItem
-                label="Artworks"
-                isFullScreenDropDown
-                Menu={({ setIsVisible }) => {
-                  return (
-                    <Box>
-                      <DropDownNavMenu
-                        width="100vw"
-                        menu={(artworks as MenuLinkData).menu}
-                        contextModule={
-                          AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+            <NavItem
+              label="Artworks"
+              isFullScreenDropDown
+              Menu={({ setIsVisible }) => {
+                return (
+                  <Box>
+                    <DropDownNavMenu
+                      width="100vw"
+                      menu={(artworks as MenuLinkData).menu}
+                      contextModule={
+                        AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+                      }
+                      onClick={() => {
+                        if (EXPERIMENTAL_APP_SHELL) {
+                          setIsVisible(false)
                         }
-                        onClick={() => {
-                          if (EXPERIMENTAL_APP_SHELL) {
-                            setIsVisible(false)
-                          }
-                        }}
-                      />
-                    </Box>
-                  )
-                }}
-              >
-                <Flex>
-                  Artworks
-                  <ChevronIcon
-                    direction="down"
-                    color={color("black100")}
-                    height="15px"
-                    width="15px"
-                    top="5px"
-                    left="4px"
-                  />
-                </Flex>
-              </NavItem>
-            ) : (
-              <NavItem href="/collect">Artworks</NavItem>
-            )}
+                      }}
+                    />
+                  </Box>
+                )
+              }}
+            >
+              <Flex>
+                Artworks
+                <ChevronIcon
+                  direction="down"
+                  color={color("black100")}
+                  height="15px"
+                  width="15px"
+                  top="5px"
+                  left="4px"
+                />
+              </Flex>
+            </NavItem>
 
-            {canViewNewDropDown ? (
-              <NavItem
-                label="Artists"
-                isFullScreenDropDown
-                Menu={({ setIsVisible }) => {
-                  return (
-                    <Box>
-                      <DropDownNavMenu
-                        width="100vw"
-                        menu={(artists as MenuLinkData).menu}
-                        contextModule={
-                          AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+            <NavItem
+              label="Artists"
+              isFullScreenDropDown
+              Menu={({ setIsVisible }) => {
+                return (
+                  <Box>
+                    <DropDownNavMenu
+                      width="100vw"
+                      menu={(artists as MenuLinkData).menu}
+                      contextModule={
+                        AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+                      }
+                      onClick={() => {
+                        if (EXPERIMENTAL_APP_SHELL) {
+                          setIsVisible(false)
                         }
-                        onClick={() => {
-                          if (EXPERIMENTAL_APP_SHELL) {
-                            setIsVisible(false)
-                          }
-                        }}
-                      />
-                    </Box>
-                  )
-                }}
-              >
-                <Flex>
-                  Artists
-                  <ChevronIcon
-                    direction="down"
-                    color={color("black100")}
-                    height="15px"
-                    width="15px"
-                    top="5px"
-                    left="4px"
-                  />
-                </Flex>
-              </NavItem>
-            ) : (
-              <NavItem href="/artists">Artists</NavItem>
-            )}
+                      }}
+                    />
+                  </Box>
+                )
+              }}
+            >
+              <Flex>
+                Artists
+                <ChevronIcon
+                  direction="down"
+                  color={color("black100")}
+                  height="15px"
+                  width="15px"
+                  top="5px"
+                  left="4px"
+                />
+              </Flex>
+            </NavItem>
 
             <NavItem href="/auctions">Auctions</NavItem>
             <NavItem href="/articles">Editorial</NavItem>

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -73,7 +73,7 @@ export const NavItem: React.FC<NavItemProps> = ({
     if (isString(navItemLabel) || label)
       trackEvent({
         action_type: AnalyticsSchema.ActionType.Hover,
-        subject: navItemLabel.toString() || label,
+        subject: label || navItemLabel.toString(),
       })
   }
 

--- a/src/Components/NavBar/__tests__/NavBar.test.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.test.tsx
@@ -51,8 +51,8 @@ describe("NavBar", () => {
 
   describe("desktop", () => {
     const defaultLinks = [
-      ["/collect", "Artworks"],
-      ["/artists", "Artists"],
+      [undefined, "ArtworksReveal more"],
+      [undefined, "ArtistsReveal more"],
       ["/auctions", "Auctions"],
       ["/articles", "Editorial"],
     ]


### PR DESCRIPTION
Addresses: [FX-1925](https://artsyproduct.atlassian.net/browse/FX-1925)

- Fixes analytics hover tracking for Artworks & Artists drop downs.
- Removes the feature flag so the Artworks & Artists menus are visible to all users.
- Fixes a NavBar test.

**Analytics Before:**
<img width="602" alt="Screen Shot 2020-04-28 at 4 38 03 PM" src="https://user-images.githubusercontent.com/5201004/80535763-52198200-896f-11ea-9bc4-1a72735e0533.png">

**Analytics After:**
<img width="593" alt="Screen Shot 2020-04-28 at 4 37 34 PM" src="https://user-images.githubusercontent.com/5201004/80535771-55ad0900-896f-11ea-9f87-393105a63f3c.png">

cc: @abhitip 