### PR TITLE
Ensure notification badge proprely aligned

### DIFF
--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -85,6 +85,7 @@ export const NavItem: React.FC<NavItemProps> = ({
 
   return (
     <Box
+      position={showOverlay ? "relative" : "static"}
       onMouseEnter={() => setIsVisible(true)}
       onMouseLeave={() => setIsVisible(false)}
     >

--- a/src/Components/NavBar/NotificationsBadge.tsx
+++ b/src/Components/NavBar/NotificationsBadge.tsx
@@ -110,5 +110,5 @@ const Container = styled(Flex)`
   justify-content: center;
   position: absolute;
   top: ${space(1)}px;
-  right: 48px;
+  left: 15px;
 `


### PR DESCRIPTION
Thanks to @xtina-starr for pairing on this 🙏 

For some context, I noticed in staging that the notification bubble was appearing above the new inbox conversation icon (which is behind a feature flag). 

Here it is rendering in the incorrect position: 

<img width="189" alt="image" src="https://user-images.githubusercontent.com/3087225/80539201-197ca700-8975-11ea-8dd1-cf67fcec2926.png">


@xtina-starr and I paired on potentially just adding the notion of a notification badge to the icon in palette but decided it was best just to fix the issue in reaction and revisit this. 

The notification badge gets shifted to an incorrect position whenever we add a new header icon because it's just set absolutely. This change adds a conditional relative positioning to the `NavItem` (only if it actually has a notification badge, otherwise it'll break large menu dropdowns)

To be clear, we don't necessarily believe this is the best fix, but it seems like we need to do another pass on this component at some point so this'll stop us from having to do the absolute positioning offset battle. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.27.12-canary.3459.59023.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.27.12-canary.3459.59023.0
  # or 
  yarn add @artsy/reaction@26.27.12-canary.3459.59023.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
