### PR TITLE
Add Empty conversations view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/reaction",
-  "version": "26.27.6",
+  "version": "26.27.9",
   "description": "Force’s React Components",
   "main": "dist/index.js",
   "repository": "https://github.com/artsy/reaction.git",

--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -139,7 +139,7 @@ const Conversation: React.FC<ConversationProps> = props => {
         </Sans>
         <InfoCircleIcon />
       </StyledHeader>
-      <Spacer mt={"45px"} />
+      <Spacer mt="45px" />
       <Flex flexDirection="column" width="100%" px={1}>
         {conversation.items.map((i, idx) => (
           <Item

--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -7,6 +7,7 @@ import {
   Link,
   Sans,
   Serif,
+  Spacer,
 } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
 import { RouterLink } from "Artsy/Router/RouterLink"
@@ -138,6 +139,7 @@ const Conversation: React.FC<ConversationProps> = props => {
         </Sans>
         <InfoCircleIcon />
       </StyledHeader>
+      <Spacer mt={"45px"} />
       <Flex flexDirection="column" width="100%" px={1}>
         {conversation.items.map((i, idx) => (
           <Item

--- a/src/Apps/Conversation/Components/Conversations.tsx
+++ b/src/Apps/Conversation/Components/Conversations.tsx
@@ -3,6 +3,7 @@ import { Conversations_me } from "__generated__/Conversations_me.graphql"
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { ConversationSnippetFragmentContainer as ConversationSnippet } from "./ConversationSnippet"
+import { NoMessages } from "./NoMessages"
 
 interface ConversationsProps {
   me: Conversations_me
@@ -13,7 +14,7 @@ const Conversations: React.FC<ConversationsProps> = props => {
   const { me } = props
   const conversations = me.conversationsConnection.edges
   return (
-    <Box px={1}>
+    <Box px={1} height="calc(100vh - 180px)" style={{ overflow: "hidden" }}>
       <Sans size="6" weight="medium" ml={1}>
         Inbox
       </Sans>
@@ -23,7 +24,7 @@ const Conversations: React.FC<ConversationsProps> = props => {
           <ConversationSnippet conversation={edge.node} key={edge.cursor} />
         ))
       ) : (
-        <Sans size="2">No Conversations</Sans>
+        <NoMessages />
       )}
     </Box>
   )

--- a/src/Apps/Conversation/Components/NoMessages.tsx
+++ b/src/Apps/Conversation/Components/NoMessages.tsx
@@ -1,0 +1,21 @@
+import { Button, Flex, Sans } from "@artsy/palette"
+import { RouterLink } from "Artsy/Router/RouterLink"
+import React from "react"
+
+export const NoMessages = () => {
+  return (
+    <Flex
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+    >
+      <Sans size="6" weight="medium" mb={2}>
+        You don't have any messages yet.
+      </Sans>
+      <RouterLink to="/collect">
+        <Button>Explore Artworks</Button>
+      </RouterLink>
+    </Flex>
+  )
+}

--- a/src/Apps/Conversation/ConversationApp.tsx
+++ b/src/Apps/Conversation/ConversationApp.tsx
@@ -2,7 +2,9 @@ import { ConversationApp_me } from "__generated__/ConversationApp_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationsFragmentContainer as Conversations } from "Apps/Conversation/Components/Conversations"
 import { SystemContext } from "Artsy"
+import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "Components/ErrorPage"
+import { Match } from "found"
 import React, { useContext } from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -10,6 +12,7 @@ import { userHasLabFeature } from "Utils/user"
 
 interface ConversationAppProps {
   me: ConversationApp_me
+  match: Match
 }
 
 export const ConversationApp: React.FC<ConversationAppProps> = props => {
@@ -17,8 +20,14 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
   const { user } = useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "User Conversations View")
   if (isEnabled) {
+    const route = findCurrentRoute(props.match)
+    let maxWidth
+
+    if (route.displayFullPage) {
+      maxWidth = "100%"
+    }
     return (
-      <AppContainer>
+      <AppContainer maxWidth={maxWidth}>
         <Title>My Inquiries | Artsy</Title>
         <Conversations me={me} />
       </AppContainer>

--- a/src/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/Apps/Conversation/Routes/Conversation/index.tsx
@@ -3,7 +3,9 @@ import { Conversation_me } from "__generated__/Conversation_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationFragmentContainer as Conversation } from "Apps/Conversation/Components/Conversation"
 import { SystemContext } from "Artsy"
+import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "Components/ErrorPage"
+import { Match } from "found"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { userHasLabFeature } from "Utils/user"
@@ -11,6 +13,7 @@ import { userHasLabFeature } from "Utils/user"
 interface ConversationRouteProps {
   me: Conversation_me
   conversationID: string
+  match: Match
 }
 
 export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
@@ -18,8 +21,14 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
   const { user } = useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "User Conversations View")
   if (isEnabled) {
+    const route = findCurrentRoute(props.match)
+    let maxWidth
+
+    if (route.displayFullPage) {
+      maxWidth = "100%"
+    }
     return (
-      <AppContainer>
+      <AppContainer maxWidth={maxWidth}>
         <Title>Inbox | Artsy</Title>
         <Conversation conversation={me.conversation} />
       </AppContainer>

--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -79,9 +79,9 @@ describe("Conversation app", () => {
         }
         const component = await render(mockMe, userType)
         const text = component.text()
-        expect(text).toContain("No Conversations")
+        expect(text).toContain("You don't have any messages yet")
         const btn = component.find("Button")
-        expect(btn.length).toBe(0)
+        expect(btn.length).toBe(1)
       })
     })
   })

--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -5,6 +5,7 @@ import {
 import { MockedConversation } from "Apps/__tests__/Fixtures/Conversation"
 import { SystemContextProvider } from "Artsy"
 import { MockBoot, renderRelayTree } from "DevTools"
+import { Match } from "found"
 import React from "react"
 import { HeadProvider } from "react-head"
 import { graphql } from "react-relay"
@@ -26,6 +27,7 @@ const render = (me: ConversationAppTestQueryRawResponse["me"], user: User) =>
         me={{
           ...me,
         }}
+        match={({ route: { displayFullPage: true } } as unknown) as Match}
         {...props}
       />
     ),

--- a/src/Apps/Conversation/routes.tsx
+++ b/src/Apps/Conversation/routes.tsx
@@ -5,6 +5,7 @@ import { graphql } from "react-relay"
 export const conversationRoutes: RouteConfig[] = [
   {
     path: "/user/conversations",
+    displayFullPage: true,
     getComponent: () => loadable(() => import("./ConversationApp")),
     query: graphql`
       query routes_ConversationQuery {
@@ -24,6 +25,7 @@ export const conversationRoutes: RouteConfig[] = [
   },
   {
     path: "/user/conversations/:conversationID",
+    displayFullPage: true,
     getComponent: () => loadable(() => import("./Routes/Conversation")),
     prepareVariables: (params, _props) => {
       return {

--- a/src/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -1,6 +1,13 @@
-import { Match } from "found"
+import { Match, RouteConfig } from "found"
 
-export const findCurrentRoute = ({ routes, routeIndices }: Match) => {
+export const findCurrentRoute = ({
+  route,
+  routes,
+  routeIndices,
+}: Match & { route?: RouteConfig }) => {
+  if (route) {
+    return route
+  }
   let currentRoute = routes[routeIndices[0]]
   routeIndices.slice(1).forEach(routeIndex => {
     currentRoute = currentRoute.children[routeIndex]


### PR DESCRIPTION
<p align="center">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/3087225/80545665-eab8fd80-8981-11ea-9de0-94773662257f.png">
</p>

The picture says it all, doesn't it?

I did a better job of breaking down each change into its own commit so the commits should tell the story of the changes. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.27.13-canary.3461.59063.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.27.13-canary.3461.59063.0
  # or 
  yarn add @artsy/reaction@26.27.13-canary.3461.59063.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
