### PR TITLE
Fixes relative paths for OSX

### DIFF
--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/__stories__/AppSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/__stories__/AppSecondFactor.story.tsx
@@ -11,7 +11,7 @@ import {
 } from "Components/UserSettings/TwoFactorAuthentication/__tests__/fixtures"
 import { MockRelayRenderer } from "DevTools"
 import { merge } from "lodash"
-import { AppSecondFactorFragmentContainer } from ".."
+import { AppSecondFactorFragmentContainer } from "../"
 
 const MockAppSecondFactor = ({ mockData, mockMutationResults, query }) => {
   return (

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__stories__/BackupSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__stories__/BackupSecondFactor.story.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { graphql } from "react-relay"
 
 import { MockRelayRenderer } from "DevTools"
-import { BackupSecondFactorFragmentContainer } from ".."
+import { BackupSecondFactorFragmentContainer } from "../"
 import {
   AppEnabledWithBackupCodesQueryResponse,
   CreateBackupSecondFactorsMutationSuccessResponse,

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__tests__/index.test.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { Button } from "@artsy/palette"
 import { mount } from "enzyme"
 import React from "react"
 
-import { BackupSecondFactor } from ".."
+import { BackupSecondFactor } from "../"
 import {
   AppEnabledWithBackupCodesQueryResponse,
   DisabledQueryResponse,

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/__stories__/SmsSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/__stories__/SmsSecondFactor.story.tsx
@@ -15,7 +15,7 @@ import {
 } from "Components/UserSettings/TwoFactorAuthentication/__tests__/fixtures"
 import { MockRelayRenderer } from "DevTools"
 import { merge } from "lodash"
-import { SmsSecondFactorFragmentContainer } from ".."
+import { SmsSecondFactorFragmentContainer } from "../"
 
 const MockSmsSecondFactor = ({ mockData, mockMutationResults, query }) => {
   return (

--- a/src/Components/UserSettings/TwoFactorAuthentication/__stories__/TwoFactorAuthenticationStory.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/__stories__/TwoFactorAuthenticationStory.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react"
 import React from "react"
 
 import { SystemContextProvider } from "Artsy"
-import { TwoFactorAuthenticationQueryRenderer } from ".."
+import { TwoFactorAuthenticationQueryRenderer } from "../"
 
 storiesOf("UserSettings/TwoFactorAuthentication", module).add("Live", () => {
   return (

--- a/src/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.test.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/__tests__/TwoFactorAuthentication.test.tsx
@@ -5,7 +5,7 @@ import { createTestEnv } from "DevTools/createTestEnv"
 
 import { TwoFactorAuthenticationQueryResponse } from "__generated__/TwoFactorAuthenticationQuery.graphql"
 import { createMockFetchQuery } from "DevTools"
-import { TwoFactorAuthenticationRefetchContainer } from ".."
+import { TwoFactorAuthenticationRefetchContainer } from "../"
 import {
   AppEnabledWithBackupCodesQueryResponse,
   AppEnabledWithoutBackupCodesQueryResponse,


### PR DESCRIPTION
The '..' imports cause Storybooks to not load with an exports is not defined error, as well as specs failing.