### PR TITLE
[FX-1926] Minor ui dropdown fixes

### DIFF
--- a/src/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -20,8 +20,8 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
 }) => {
   const { trackEvent } = useTracking()
   const viewAllTopMargin = {
-    HeaderArtworksDropdown: "130px",
-    HeaderArtistsDropdown: "90px",
+    HeaderArtworksDropdown: "120px",
+    HeaderArtistsDropdown: "80px",
   }
 
   const handleClick = event => {
@@ -45,18 +45,19 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
     <Menu onClick={handleClick} width={width} m={0} py={0}>
       <Flex justifyContent="center">
         <SimpleLinksContainer
-          py={4}
+          mt={0.5}
+          py={3}
           mr={[3, 3, 3, "50px"]}
           viewAllTopMargin={viewAllTopMargin[contextModule]}
         >
-          <Box mr={[2, 2, 3, 3]} width={[110, 110, 110, 135, 150]}>
+          <Box mr={[1, 1, 2, 2]} width={[110, 110, 110, 135, 170]}>
             {menu.links.map(menuItem => {
               if (!menuItem.menu) {
                 return (
-                  <MenuItemContainer mb={1} key={menuItem.text}>
+                  <MenuItemContainer key={menuItem.text}>
                     <MenuItem
                       px={1}
-                      py={0}
+                      py={0.5}
                       href={menuItem.href}
                       textColor={color("black60")}
                       textWeight="regular"

--- a/src/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
@@ -17,7 +17,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
       {section.text === "Artist Nationality & Region" ? (
         <TwoColumnDropDownSection section={section} />
       ) : (
-        <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
+        <Box width={[110, 110, 110, 135, 170]} py={4} mr={[1, 1, 2, 2]}>
           <Sans size="2" mb={1} px={1}>
             {section.text}
           </Sans>

--- a/src/Components/NavBar/Menus/DropDownMenu/TwoColumnDropDownSection.tsx
+++ b/src/Components/NavBar/Menus/DropDownMenu/TwoColumnDropDownSection.tsx
@@ -17,10 +17,12 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
 
   return (
     <Flex>
-      <Box width={[110, 110, 110, 135, 150]} py={4} mr={[2, 2, 3, 3]}>
-        <Sans size="2" mb={1} px={1}>
-          {section.text}
-        </Sans>
+      <Box width={[110, 110, 110, 135, 170]} py={4} mr={[1, 1, 2, 2]}>
+        <Box width={[110, 110, 180, 180, 190]}>
+          <Sans size="2" mb={1} px={1}>
+            {section.text}
+          </Sans>
+        </Box>
         {section.menu &&
           nationalities.map((menuItem: SimpleLinkData) => {
             return (
@@ -39,7 +41,7 @@ export const TwoColumnDropDownSection: React.FC<TwoColumnDropDownSectionProps> =
             )
           })}
       </Box>
-      <Box width={[110, 110, 110, 135, 150]} pt="66px" pb={4} mr={[2, 2, 3, 3]}>
+      <Box width={[110, 110, 110, 135, 170]} pt="66px" pb={4} mr={[1, 1, 2, 2]}>
         {section.menu &&
           regions.map((menuItem: SimpleLinkData) => {
             return (

--- a/src/Components/NavBar/NavItem.tsx
+++ b/src/Components/NavBar/NavItem.tsx
@@ -98,7 +98,7 @@ export const NavItem: React.FC<NavItemProps> = ({
         className={className}
         display={display}
         position="relative"
-        style={{ cursor: "pointer" }}
+        style={{ cursor: "pointer", zIndex: 9 }}
         onClick={() => {
           trackClick()
           onClick && onClick()


### PR DESCRIPTION
Addresses: [FX-1926](https://artsyproduct.atlassian.net/browse/FX-1926)

This PR addresses the following:
- Ensures the link items on the far left have the same top/bottom padding as the rest of the link items.
- Ensures the link texts fit on two lines at larger breakpoints.
- Restores the cursor pointer on hover of Artworks (this is difficult to capture in a screenshot).

<img width="1677" alt="Screen Shot 2020-04-29 at 1 12 19 PM" src="https://user-images.githubusercontent.com/5201004/80625424-2e137a80-8a1b-11ea-9f62-2847398736f6.png">
