### PR TITLE
[FX-1894] change top artists

### DIFF
--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -373,36 +373,40 @@ export const menuData: MenuData = {
               title: "Top Artists",
               links: [
                 {
-                  text: "Pablo Picasso",
-                  href: "/artist/pablo-picasso",
-                },
-                {
-                  text: "Andy Warhol",
-                  href: "/artist/andy-warhol",
-                },
-                {
                   text: "Yayoi Kusama",
                   href: "/artist/yayoi-kusama",
+                },
+                {
+                  text: "Roy Lichtenstein",
+                  href: "/artist/roy-lichtenstein",
+                },
+                {
+                  text: "Cindy Sherman",
+                  href: "/artist/cindy-sherman",
                 },
                 {
                   text: "Keith Haring",
                   href: "/artist/keith-haring",
                 },
                 {
-                  text: "Takashi Murakami",
-                  href: "/artist/takashi-murakami",
+                  text: "David Hockney",
+                  href: "/artist/david-hockney",
                 },
                 {
-                  text: "Jean-Michel Basquiat",
-                  href: "/artist/jean-michel-basquiat",
+                  text: "Katherine Bernhardt",
+                  href: "/artist/katherine-bernhardt",
                 },
                 {
-                  text: "Salvador Dalí",
-                  href: "/artist/salvador-dali",
+                  text: "Kehinde Wiley",
+                  href: "/artist/kehinde-wiley",
                 },
                 {
-                  text: "Tracey Emin",
-                  href: "/artist/tracey-emin",
+                  text: "Ed Ruscha",
+                  href: "/artist/ed-ruscha",
+                },
+                {
+                  text: "Banksy",
+                  href: "/artist/banksy",
                 },
               ],
             },


### PR DESCRIPTION
Addresses: [FX-1894](https://artsyproduct.atlassian.net/browse/FX-1894)

This PR updates the existing Top Artists URL/copy with Artists from the Focused 20 list to aid in improving our microfunnels for those artists.

<img width="1676" alt="Screen Shot 2020-04-29 at 3 52 54 PM" src="https://user-images.githubusercontent.com/5201004/80640614-a8e79000-8a31-11ea-853f-181c6066dc35.png">
