### PR TITLE
Correct findCurrentRoute logic to unbreak artist page

### DIFF
--- a/src/Artsy/Router/Utils/__tests__/findCurrentRoute.test.ts
+++ b/src/Artsy/Router/Utils/__tests__/findCurrentRoute.test.ts
@@ -1,0 +1,54 @@
+import { findCurrentRoute } from "../findCurrentRoute"
+import { Match, Router, Location } from "found"
+
+describe("findCurrentRoute", () => {
+  const getMatch = (config: Partial<Match>): Match => ({
+    routes: [],
+    router: ({} as unknown) as Router,
+    context: {},
+    routeIndices: [0],
+    location: ({} as unknown) as Location,
+    params: {},
+    ...config,
+  })
+
+  it("should return a base nested route", () => {
+    const match = getMatch({
+      routeIndices: [0, 0],
+      routes: [
+        {
+          path: "/artist/:artistID",
+          children: [
+            {
+              path: "/",
+            },
+          ],
+        },
+      ],
+    })
+    expect(findCurrentRoute(match)).toHaveProperty("path", "/")
+  })
+
+  it("should return a non-zero nested route", () => {
+    const match = getMatch({
+      routeIndices: [0, 2],
+      routes: [
+        {
+          path: "/artist/:artistID",
+          children: [
+            {
+              path: "/",
+            },
+            {
+              path: "/works-for-sale",
+            },
+            {
+              path: "/cv",
+            },
+          ],
+        },
+      ],
+    })
+    expect(findCurrentRoute(match)).toHaveProperty("path", "/cv")
+  })
+})

--- a/src/Artsy/Router/Utils/__tests__/findCurrentRoute.test.ts
+++ b/src/Artsy/Router/Utils/__tests__/findCurrentRoute.test.ts
@@ -51,4 +51,40 @@ describe("findCurrentRoute", () => {
     })
     expect(findCurrentRoute(match)).toHaveProperty("path", "/cv")
   })
+
+  it("should return a deeply nested route", () => {
+    const match = getMatch({
+      routeIndices: [0, 3, 0],
+      routes: [
+        {
+          path: "/artist/:artistID",
+          children: [
+            {
+              path: "/",
+            },
+            {
+              path: "/works-for-sale",
+            },
+            {
+              path: "/cv",
+            },
+            {
+              baz: "/foo",
+              children: [
+                {
+                  path: "/bar",
+                  children: [
+                    {
+                      path: "/dont-match",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(findCurrentRoute(match)).toHaveProperty("path", "/bar")
+  })
 })

--- a/src/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -4,7 +4,6 @@ export const findCurrentRoute = ({
   routes,
   routeIndices,
 }: Match & { route?: RouteConfig }) => {
-  console.log(routes, routeIndices)
   let remainingRouteIndicies = [...routeIndices]
   let route: RouteConfig = routes[remainingRouteIndicies.shift()]
 

--- a/src/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -1,16 +1,16 @@
 import { Match, RouteConfig } from "found"
 
 export const findCurrentRoute = ({
-  route,
   routes,
   routeIndices,
 }: Match & { route?: RouteConfig }) => {
-  if (route) {
-    return route
+  console.log(routes, routeIndices)
+  let remainingRouteIndicies = [...routeIndices]
+  let route: RouteConfig = routes[remainingRouteIndicies.shift()]
+
+  while (remainingRouteIndicies.length > 0) {
+    route = route.children[remainingRouteIndicies.shift()]
   }
-  let currentRoute = routes[routeIndices[0]]
-  routeIndices.slice(1).forEach(routeIndex => {
-    currentRoute = currentRoute.children[routeIndex]
-  })
-  return currentRoute
+
+  return route
 }

--- a/src/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -1,9 +1,13 @@
 import { Match, RouteConfig } from "found"
 
 export const findCurrentRoute = ({
+  route: baseRoute,
   routes,
   routeIndices,
 }: Match & { route?: RouteConfig }) => {
+  if (!routeIndices || routeIndices.length === 0) {
+    return baseRoute
+  }
   let remainingRouteIndicies = [...routeIndices]
   let route: RouteConfig = routes[remainingRouteIndicies.shift()]
 


### PR DESCRIPTION
The acceptance tests started failing for force on a reaction renovate PR. @xtina-starr dug in and found out that the artist page was broken because the header wasn't being rendered. She dug in and noticed that it was because     `route.displayNavigationTabs` wasn't being set. 

When I started investigating, it turns out that when I updated the logic for `findCurrentRoute` I broke things. I updated it to just use `match.route`, but that's always just the top level route it seems. I updated it logic of that function to actually walk through the route indices and return the properly nested route. I also wrote a test. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.30.2-canary.3469.59299.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.30.2-canary.3469.59299.0
  # or 
  yarn add @artsy/reaction@26.30.2-canary.3469.59299.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
