### PR TITLE
[mWeb] Show OTP prompt during login when 2FA-enabled

### DIFF
--- a/src/Components/Authentication/Types.ts
+++ b/src/Components/Authentication/Types.ts
@@ -11,6 +11,7 @@ export interface InputValues {
   name?: string
   email?: string
   password?: string
+  otp_attempt?: string
   accepted_terms_of_service?: boolean
 }
 

--- a/src/Components/Authentication/Validators.tsx
+++ b/src/Components/Authentication/Validators.tsx
@@ -12,6 +12,8 @@ const password = Yup.string()
 
 const loginPassword = Yup.string().required("Password required")
 
+const otpAttempt = Yup.string().required("Enter a code")
+
 const accepted_terms_of_service = Yup.boolean()
   .required("You must agree to our terms to continue.")
   .oneOf([true])
@@ -41,4 +43,5 @@ export const MobileSignUpValidator = {
 export const MobileLoginValidator = {
   email: Yup.object().shape({ email }),
   password: Yup.object().shape({ password: loginPassword }),
+  otpAttempt: Yup.object().shape({ otp_attempt: otpAttempt }),
 }

--- a/src/Components/Authentication/__tests__/Mobile/LoginForm.test.tsx
+++ b/src/Components/Authentication/__tests__/Mobile/LoginForm.test.tsx
@@ -97,6 +97,38 @@ describe("MobileLoginForm", () => {
       })
     })
 
+    it("calls handleSubmit with expected params when server requests a two-factor authentication code", done => {
+      props.error = "missing two-factor authentication code"
+      props.actions = {}
+      const wrapper = getWrapper()
+      const inputEmail = wrapper.find(QuickInput).instance() as QuickInput
+      inputEmail.onChange(ChangeEvents.email)
+      wrapper.find(SubmitButton).simulate("click")
+
+      setTimeout(() => {
+        wrapper.update()
+        const inputPass = wrapper.find(QuickInput).instance() as QuickInput
+        inputPass.onChange(ChangeEvents.password)
+        wrapper.find(SubmitButton).simulate("click")
+
+        setTimeout(() => {
+          wrapper.update()
+          const inputOtp = wrapper.find(QuickInput).instance() as QuickInput
+          inputOtp.onChange(ChangeEvents.otpAttempt)
+          wrapper.find(SubmitButton).simulate("click")
+
+          setTimeout(() => {
+            expect(props.handleSubmit.mock.calls[0][0]).toEqual({
+              email: "email@email.com",
+              password: "password",
+              otp_attempt: "123456",
+            })
+            done()
+          })
+        })
+      })
+    })
+
     it("fires reCAPTCHA event", done => {
       const wrapper = getWrapper()
       const inputEmail = wrapper.find(QuickInput).instance() as QuickInput

--- a/src/Components/Authentication/__tests__/fixtures.ts
+++ b/src/Components/Authentication/__tests__/fixtures.ts
@@ -9,6 +9,11 @@ export const ChangeEvents = {
     persist: jest.fn(),
     target: { type: "", name: "password", value: "password" },
   },
+  otpAttempt: {
+    currentTarget: { value: "123456" },
+    persist: jest.fn(),
+    target: { type: "", name: "otp_attempt", value: "123456" },
+  },
   accepted_terms_of_service: {
     currentTarget: { checked: true },
     persist: jest.fn(),

--- a/src/Components/Wizard/Wizard.tsx
+++ b/src/Components/Wizard/Wizard.tsx
@@ -125,20 +125,20 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     if (this.isLastStep) {
       onComplete && onComplete(values, actions)
     } else {
-      actions && actions.setSubmitting(false)
+      actions?.setSubmitting(false)
       // If exist, call onSubmit on the current step
       const onSubmit = this.currentStep.props.onSubmit
       if (onSubmit) {
-        actions.setSubmitting(true)
+        actions?.setSubmitting(true)
         const result = onSubmit(values, actions)
 
         if (result instanceof Boolean) {
-          actions.setSubmitting(false)
+          actions?.setSubmitting(false)
           return result
         } else {
           return (result as Promise<boolean>).then(shouldGoNext => {
             if (shouldGoNext) {
-              actions.setSubmitting(false)
+              actions?.setSubmitting(false)
               this.next(null, values)
             }
           })

--- a/src/Components/__stories__/Authentication.story.tsx
+++ b/src/Components/__stories__/Authentication.story.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import Colors from "Assets/Colors"
-import React, { Component, Fragment } from "react"
+import React, { Component, Fragment, useState } from "react"
 import styled from "styled-components"
 import Button from "../Buttons/Default"
 
@@ -11,9 +11,9 @@ import {
 } from "../Authentication/commonElements"
 import { ModalManager } from "../Authentication/Desktop/ModalManager"
 import { FormSwitcher } from "../Authentication/FormSwitcher"
-import { ModalType } from "../Authentication/Types"
+import { ModalType, SubmitHandler } from "../Authentication/Types"
 
-const submit = (values, actions) => {
+const submit: SubmitHandler = (values, actions) => {
   setTimeout(() => {
     alert(JSON.stringify(values, null, 1))
     actions.setSubmitting(false)
@@ -65,6 +65,36 @@ storiesOf("Components/Authentication/Desktop", module)
   ))
   .add("Sign Up", () => <ModalContainer options={{ mode: ModalType.signup }} />)
 
+const MobileLoginTwoFactorAuthDemo: React.FC = () => {
+  const [serverError, setServerError] = useState(null)
+
+  const handleSubmit: SubmitHandler = (values, actions) => {
+    setTimeout(() => {
+      if (values.otp_attempt === "123456") {
+        alert(JSON.stringify(values, null, 1))
+      } else if (values.otp_attempt) {
+        setServerError("invalid two-factor authentication code")
+      } else {
+        setServerError("missing two-factor authentication code")
+      }
+      actions.setSubmitting(false)
+    }, 1000)
+  }
+
+  return (
+    <FormSwitcher
+      error={serverError}
+      type={ModalType.login}
+      handleSubmit={handleSubmit}
+      isMobile
+      options={{
+        contextModule: ContextModule.header,
+        intent: AuthIntent.login,
+      }}
+    />
+  )
+}
+
 storiesOf("Components/Authentication/Mobile", module)
   .add("Login", () => (
     <MobileContainer>
@@ -77,6 +107,11 @@ storiesOf("Components/Authentication/Mobile", module)
           intent: AuthIntent.login,
         }}
       />
+    </MobileContainer>
+  ))
+  .add("Login (2FA)", () => (
+    <MobileContainer>
+      <MobileLoginTwoFactorAuthDemo />
     </MobileContainer>
   ))
   .add("Forgot Password", () => (


### PR DESCRIPTION
Add an OTP prompt to the mWeb login modal.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.30.3-canary.3472.59408.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.30.3-canary.3472.59408.0
  # or 
  yarn add @artsy/reaction@26.30.3-canary.3472.59408.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

### Screen Recording

![Peek 2020-04-30 18-32](https://user-images.githubusercontent.com/123595/80765435-06064300-8b11-11ea-8e78-1ca6ce785793.gif)
