### PR TITLE
[Chore] Turns on exhaustive-deps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,10 +49,8 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/no-var-requires": 0,
-
     "react-hooks/rules-of-hooks": "error",
-    // FIXME: Fix issues with React Hooks:
-    "react-hooks/exhaustive-deps": 0,
+    "react-hooks/exhaustive-deps": "warn",
 
     // FIXME: Investigate / reenable these rules. Disabled to introduce eslint
     // into codebase.


### PR DESCRIPTION
Sets it to `warn` which is recommended.

There's 13 warnings right now, and I do think they could be auto-fixed. But I have seen missing dependencies paper over underlying bugs before so I'm reluctant to change them all at once.