### PR TITLE
Use cohesion v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.2",
-    "@artsy/cohesion": "0.2.8",
+    "@artsy/cohesion": "1.0.0",
     "@artsy/lint-changed": "3.0.4",
     "@artsy/palette": "8.2.1",
     "@babel/cli": "7.0.0",

--- a/src/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { Box, Button, Flex, Image, Sans, Serif, Spacer } from "@artsy/palette"
 import { ArtistHeader_artist } from "__generated__/ArtistHeader_artist.graphql"
 import { StyledLink } from "Apps/Artist/Components/StyledLink"
@@ -391,7 +391,7 @@ const handleOpenAuth = (mediator, artist) => {
   openAuthToFollowSave(mediator, {
     entity: artist,
     contextModule: ContextModule.artistHeader,
-    intent: AuthIntent.followArtist,
+    intent: Intent.followArtist,
   })
 }
 

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   ArrowDownIcon,
   ArrowUpIcon,
@@ -372,7 +372,7 @@ const renderPricing = (salePrice, saleDate, user, mediator, size) => {
               mode: ModalType.signup,
               copy: "Log in to see full auction records — for free",
               contextModule: ContextModule.auctionResults,
-              intent: AuthIntent.seePriceAuctionRecords,
+              intent: Intent.seePriceAuctionRecords,
             })
         }}
       >
@@ -408,7 +408,7 @@ const renderEstimate = (estimatedPrice, user, mediator, size) => {
               mode: ModalType.signup,
               copy: "Sign up to see full auction records — for free",
               contextModule: ContextModule.auctionResults,
-              intent: AuthIntent.seeEstimateAuctionRecords,
+              intent: Intent.seeEstimateAuctionRecords,
             })
         }}
       >
@@ -444,7 +444,7 @@ const renderRealizedPrice = (estimatedPrice, user, mediator, size) => {
               mode: ModalType.signup,
               copy: "Sign up to see full auction records — for free",
               contextModule: ContextModule.auctionResults,
-              intent: AuthIntent.seeRealizedPriceAuctionRecords,
+              intent: Intent.seeRealizedPriceAuctionRecords,
             })
         }}
       >

--- a/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { Box, EntityHeader, Sans, Spacer } from "@artsy/palette"
 import { RecommendedArtist_artist } from "__generated__/RecommendedArtist_artist.graphql"
 import { SystemContext } from "Artsy"
@@ -22,7 +22,7 @@ const handleOpenAuth = (mediator, artist) => {
   openAuthToFollowSave(mediator, {
     entity: artist,
     contextModule: ContextModule.relatedArtistsRail,
-    intent: AuthIntent.followArtist,
+    intent: Intent.followArtist,
   })
 }
 

--- a/src/Apps/Artist/Routes/Overview/Components/ZeroState.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ZeroState.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { Link, Message } from "@artsy/palette"
 import { useSystemContext } from "Artsy"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
@@ -13,7 +13,7 @@ export const ZeroState = props => {
     openAuthToFollowSave(mediator, {
       entity: artist,
       contextModule: ContextModule.worksForSaleRail,
-      intent: AuthIntent.followArtist,
+      intent: Intent.followArtist,
     })
   }
 

--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -20,7 +20,7 @@ import { ArtistBioFragmentContainer as ArtistBio } from "Components/ArtistBio"
 import { ArtistMarketInsightsFragmentContainer as ArtistMarketInsights } from "Components/ArtistMarketInsights"
 import { SelectedExhibitionFragmentContainer as SelectedExhibitions } from "Components/SelectedExhibitions"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { MIN_EXHIBITIONS } from "Components/SelectedExhibitions"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -87,7 +87,7 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
     openAuthToFollowSave(mediator, {
       entity: artist,
       contextModule: ContextModule.aboutTheWork,
-      intent: AuthIntent.followArtist,
+      intent: Intent.followArtist,
     })
   }
 

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -15,7 +15,7 @@ import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import Events from "Utils/Events"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   Box,
   EntityHeader,
@@ -57,7 +57,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
     openAuthToFollowSave(mediator, {
       entity: partner,
       contextModule: ContextModule.aboutTheWork,
-      intent: AuthIntent.followPartner,
+      intent: Intent.followPartner,
     })
   }
 

--- a/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -22,7 +22,7 @@ import { ErrorModal } from "Components/Modal/ErrorModal"
 import createLogger from "Utils/logger"
 import { openAuthModal } from "Utils/openAuthModal"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { RequestConditionReport_artwork } from "__generated__/RequestConditionReport_artwork.graphql"
 import { RequestConditionReport_me } from "__generated__/RequestConditionReport_me.graphql"
 import {
@@ -106,7 +106,7 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
       mode: ModalType.login,
       redirectTo: location.href,
       contextModule: ContextModule.aboutTheWork,
-      intent: AuthIntent.requestConditionReport,
+      intent: Intent.requestConditionReport,
     })
   }
 

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -6,7 +6,7 @@ import { FollowIcon } from "Components/FollowIcon"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { ArtworkSidebarArtists_artwork } from "__generated__/ArtworkSidebarArtists_artwork.graphql"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { openAuthToFollowSave } from "Utils/openAuthModal"
@@ -34,7 +34,7 @@ export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
     openAuthToFollowSave(mediator, {
       entity: artist,
       contextModule: ContextModule.artworkSidebar,
-      intent: AuthIntent.followArtist,
+      intent: Intent.followArtist,
     })
   }
 

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   Box,
   Button,
@@ -256,7 +256,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         mode: ModalType.login,
         redirectTo: location.href,
         contextModule: ContextModule.artworkSidebar,
-        intent: AuthIntent.buyNow,
+        intent: Intent.buyNow,
       })
     }
   }
@@ -347,7 +347,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         mode: ModalType.login,
         redirectTo: location.href,
         contextModule: ContextModule.artworkSidebar,
-        intent: AuthIntent.makeOffer,
+        intent: Intent.makeOffer,
       })
     }
   }

--- a/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { breakpoints, EntityHeader, ReadMore } from "@artsy/palette"
 import {
   Box,
@@ -40,7 +40,7 @@ const handleOpenAuth = (mediator, artist) => {
   openAuthToFollowSave(mediator, {
     entity: artist,
     contextModule: ContextModule.featuredArtistsRail,
-    intent: AuthIntent.followArtist,
+    intent: Intent.followArtist,
   })
 }
 

--- a/src/Components/ArtistCard.tsx
+++ b/src/Components/ArtistCard.tsx
@@ -1,4 +1,4 @@
-import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
+import { AuthContextModule, Intent } from "@artsy/cohesion"
 import { ArtistCard_artist } from "__generated__/ArtistCard_artist.graphql"
 import { Mediator } from "Artsy"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
@@ -151,7 +151,7 @@ const handleOpenAuth = (props: ArtistCardProps) => {
   openAuthToFollowSave(props.mediator, {
     entity: props.artist,
     contextModule: props.contextModule,
-    intent: AuthIntent.followArtist,
+    intent: Intent.followArtist,
   })
 }
 

--- a/src/Components/Artwork/Fillwidth.tsx
+++ b/src/Components/Artwork/Fillwidth.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { AuthContextModule } from "@artsy/cohesion"
 import { Fillwidth_artworks } from "__generated__/Fillwidth_artworks.graphql"
 import { Mediator } from "Artsy"
 import { find } from "lodash"
@@ -16,7 +16,7 @@ interface Props extends React.HTMLAttributes<FillwidthContainer> {
   gutter?: number
   size?: any
   artworks: Fillwidth_artworks
-  contextModule: ContextModule
+  contextModule: AuthContextModule
   mediator?: Mediator
 }
 

--- a/src/Components/Artwork/Save.tsx
+++ b/src/Components/Artwork/Save.tsx
@@ -1,4 +1,4 @@
-import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
+import { AuthContextModule, Intent } from "@artsy/cohesion"
 import { Save_artwork } from "__generated__/Save_artwork.graphql"
 import { SaveArtworkMutation } from "__generated__/SaveArtworkMutation.graphql"
 import * as Artsy from "Artsy"
@@ -136,7 +136,7 @@ export class SaveButton extends React.Component<SaveProps, SaveState> {
           slug: this.props.artwork.slug,
           name: this.props.artwork.title,
         },
-        intent: AuthIntent.saveArtwork,
+        intent: Intent.saveArtwork,
       })
     }
   }

--- a/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
+++ b/src/Components/Authentication/__tests__/Desktop/ModalManager.test.tsx
@@ -3,7 +3,7 @@ import { ModalType } from "Components/Authentication/Types"
 import { mount, ReactWrapper } from "enzyme"
 import React from "react"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   ModalManager,
   ModalManagerProps,
@@ -42,7 +42,7 @@ describe("ModalManager", () => {
 
     manager.openModal({
       mode: ModalType.login,
-      intent: AuthIntent.login,
+      intent: Intent.login,
       contextModule: ContextModule.header,
     })
 
@@ -66,7 +66,7 @@ describe("ModalManager", () => {
 
     manager.openModal({
       mode: ModalType.login,
-      intent: AuthIntent.login,
+      intent: Intent.login,
       contextModule: ContextModule.header,
     })
 
@@ -79,7 +79,7 @@ describe("ModalManager", () => {
 
     manager.openModal({
       mode: ModalType.login,
-      intent: AuthIntent.login,
+      intent: Intent.login,
       contextModule: ContextModule.header,
     })
 
@@ -96,7 +96,7 @@ describe("ModalManager", () => {
 
     manager.openModal({
       mode: ModalType.login,
-      intent: AuthIntent.signup,
+      intent: Intent.signup,
       copy: "Foobar",
       contextModule: ContextModule.header,
     })

--- a/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
+++ b/src/Components/Authentication/__tests__/FormSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { Link } from "@artsy/palette"
 import QuickInput from "Components/QuickInput"
 import { mount } from "enzyme"
@@ -29,7 +29,7 @@ describe("FormSwitcher", () => {
           contextModule: ContextModule.header,
           copy: "Foo Bar",
           destination: "/collect",
-          intent: AuthIntent.followArtist,
+          intent: Intent.followArtist,
           redirectTo: "/foo",
           triggerSeconds: 1,
         }}

--- a/src/Components/Follow.tsx
+++ b/src/Components/Follow.tsx
@@ -6,7 +6,12 @@
  * and two specialised components that use composition to achieve the desired functionality.
  */
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import {
+  Intent,
+  ContextModule,
+  AuthContextModule,
+  AuthIntent,
+} from "@artsy/cohesion"
 import { Follow_artist } from "__generated__/Follow_artist.graphql"
 import { FollowArtistMutation } from "__generated__/FollowArtistMutation.graphql"
 import * as Artsy from "Artsy"
@@ -31,7 +36,7 @@ interface Props
   style?: any
   relay: RelayProp
   artist: Follow_artist
-  contextModule: ContextModule
+  contextModule: AuthContextModule
 }
 
 export const StyledFollowButton = styled.div`
@@ -97,9 +102,12 @@ export class FollowButton extends React.Component<Props, null> {
         },
       })
     } else {
-      const options = {
+      const options: {
+        contextModule: AuthContextModule
+        intent: AuthIntent
+      } = {
         contextModule: contextModule || ContextModule.relatedArtistsRail,
-        intent: AuthIntent.followArtist,
+        intent: Intent.followArtist,
       }
 
       if (mediator) {

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { Box, ButtonProps } from "@artsy/palette"
 import { FollowArtistButtonMutation } from "__generated__/FollowArtistButtonMutation.graphql"
 import * as Artsy from "Artsy"
@@ -86,7 +86,7 @@ export class FollowArtistButton extends React.Component<Props, State> {
     } else if (onOpenAuthModal) {
       onOpenAuthModal(ModalType.signup, {
         contextModule: ContextModule.intextTooltip,
-        intent: AuthIntent.followArtist,
+        intent: Intent.followArtist,
         copy: "Sign up to follow artists",
         afterSignUpAction: {
           action: "follow",

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { FollowGeneButtonMutation } from "__generated__/FollowGeneButtonMutation.graphql"
 import * as Artsy from "Artsy"
 import { ModalOptions, ModalType } from "Components/Authentication/Types"
@@ -72,7 +72,7 @@ export class FollowGeneButton extends React.Component<Props> {
       onOpenAuthModal &&
         onOpenAuthModal(ModalType.signup, {
           contextModule: ContextModule.intextTooltip,
-          intent: AuthIntent.followGene,
+          intent: Intent.followGene,
           copy: "Sign up to follow categories",
           afterSignUpAction: {
             action: "follow",

--- a/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   Box,
   ChevronIcon,
@@ -242,7 +242,7 @@ export const MobileSubmenuLink: React.FC<any> = ({ children, menu }) => {
 const AuthenticateLinks: React.FC = () => {
   const authLink = (type: ModalType) => {
     return getMobileAuthLink(type, {
-      intent: AuthIntent[type],
+      intent: Intent[type],
       contextModule: ContextModule.header,
     })
   }

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -37,7 +37,7 @@ import { openAuthModal } from "Utils/openAuthModal"
 import { NavItem } from "./NavItem"
 import { NotificationsBadge } from "./NotificationsBadge"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { AnalyticsSchema } from "Artsy"
 import { track, useTracking } from "Artsy/Analytics"
 import Events from "Utils/Events"
@@ -285,7 +285,7 @@ export const NavBar: React.FC = track(
                 onClick={() => {
                   openAuthModal(mediator, {
                     mode: ModalType.login,
-                    intent: AuthIntent.login,
+                    intent: Intent.login,
                     contextModule: ContextModule.header,
                   })
                 }}
@@ -297,7 +297,7 @@ export const NavBar: React.FC = track(
                 onClick={() => {
                   openAuthModal(mediator, {
                     mode: ModalType.signup,
-                    intent: AuthIntent.signup,
+                    intent: Intent.signup,
                     contextModule: ContextModule.header,
                   })
                 }}

--- a/src/Components/Publishing/Banner/Banner.tsx
+++ b/src/Components/Publishing/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { ModalType } from "Components/Authentication/Types"
 import { debounce } from "lodash"
 import React, { Component } from "react"
@@ -60,7 +60,7 @@ export class BannerWrapper extends Component<{ article: ArticleData }, State> {
     const textColor = layout === "video" ? "black" : "white"
     const href = getMobileAuthLink(ModalType.signup, {
       action: "editorialSignup",
-      intent: AuthIntent.viewEditorial,
+      intent: Intent.viewEditorial,
       contextModule: ContextModule.minimalCTABanner,
       redirectTo: getArticleFullHref(slug),
     })

--- a/src/Components/__stories__/Authentication.story.tsx
+++ b/src/Components/__stories__/Authentication.story.tsx
@@ -4,7 +4,7 @@ import React, { Component, Fragment } from "react"
 import styled from "styled-components"
 import Button from "../Buttons/Default"
 
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import {
   Footer,
   TermsOfServiceCheckbox,
@@ -74,7 +74,7 @@ storiesOf("Components/Authentication/Mobile", module)
         isMobile
         options={{
           contextModule: ContextModule.header,
-          intent: AuthIntent.login,
+          intent: Intent.login,
         }}
       />
     </MobileContainer>
@@ -87,7 +87,7 @@ storiesOf("Components/Authentication/Mobile", module)
         isMobile
         options={{
           contextModule: ContextModule.header,
-          intent: AuthIntent.forgot,
+          intent: Intent.forgot,
         }}
       />
     </MobileContainer>
@@ -100,7 +100,7 @@ storiesOf("Components/Authentication/Mobile", module)
         isMobile
         options={{
           contextModule: ContextModule.header,
-          intent: AuthIntent.signup,
+          intent: Intent.signup,
         }}
       />
     </MobileContainer>

--- a/src/Utils/__tests__/openAuthModal.test.ts
+++ b/src/Utils/__tests__/openAuthModal.test.ts
@@ -1,4 +1,4 @@
-import { AuthIntent, ContextModule } from "@artsy/cohesion"
+import { Intent, ContextModule } from "@artsy/cohesion"
 import { ModalType } from "Components/Authentication/Types"
 import {
   AuthModalOptions,
@@ -15,7 +15,7 @@ const artistArgs: AuthModalOptions = {
     slug: "andy-warhol",
     name: "Andy Warhol",
   },
-  intent: AuthIntent.followArtist,
+  intent: Intent.followArtist,
 }
 
 const partnerArgs: AuthModalOptions = {
@@ -24,7 +24,7 @@ const partnerArgs: AuthModalOptions = {
     slug: "david-zwirner",
     name: "David Zwirner",
   },
-  intent: AuthIntent.followPartner,
+  intent: Intent.followPartner,
 }
 
 const artworkArgs: AuthModalOptions = {
@@ -33,7 +33,7 @@ const artworkArgs: AuthModalOptions = {
     slug: "andy-warhol-skull",
     name: "Skull",
   },
-  intent: AuthIntent.saveArtwork,
+  intent: Intent.saveArtwork,
 }
 
 describe("openAuth Helpers", () => {
@@ -53,7 +53,7 @@ describe("openAuth Helpers", () => {
     it("calls the mediator with expected args", () => {
       openAuthModal(mediator, {
         mode: ModalType.signup,
-        intent: AuthIntent.signup,
+        intent: Intent.signup,
         contextModule: ContextModule.header,
         copy: "Sign up to do cool stuff",
       })

--- a/src/Utils/openAuthModal.ts
+++ b/src/Utils/openAuthModal.ts
@@ -1,4 +1,4 @@
-import { AuthContextModule, AuthIntent } from "@artsy/cohesion"
+import { AuthContextModule, AuthIntent, Intent } from "@artsy/cohesion"
 import { Mediator } from "Artsy/SystemContext"
 import { ModalOptions, ModalType } from "Components/Authentication/Types"
 import qs from "qs"
@@ -24,15 +24,15 @@ export const openAuthToFollowSave = (
   let handled = false
 
   if (sd.IS_MOBILE) {
-    const intent = getMobileAuthIntent(options)
+    const intent = getMobileIntent(options)
     if (intent) {
       openMobileAuth(intent)
       handled = true
     }
   } else if (mediator) {
-    const intent = getDesktopAuthIntent(options)
+    const intent = getDesktopIntent(options)
     if (intent) {
-      mediator.trigger("open:auth", {
+      openAuthModal(mediator, {
         mode: ModalType.signup,
         ...intent,
       })
@@ -59,12 +59,12 @@ function openMobileAuth(intent) {
   window.location.assign(href)
 }
 
-function getMobileAuthIntent(options: AuthModalOptions): ModalOptions {
+function getMobileIntent(options: AuthModalOptions): ModalOptions {
   switch (options.intent) {
-    case AuthIntent.followArtist:
-    case AuthIntent.followPartner:
+    case Intent.followArtist:
+    case Intent.followPartner:
       return getMobileIntentToFollow(options)
-    case AuthIntent.saveArtwork:
+    case Intent.saveArtwork:
       return getMobileIntentToSaveArtwork(options)
     default:
       return undefined
@@ -76,7 +76,7 @@ function getMobileIntentToFollow({
   entity,
   intent,
 }: AuthModalOptions): ModalOptions {
-  const kind = intent === AuthIntent.followArtist ? "artist" : "profile"
+  const kind = intent === Intent.followArtist ? "artist" : "profile"
   return {
     action: "follow",
     contextModule,
@@ -107,7 +107,7 @@ function getDesktopIntentToFollow({
   entity,
   intent,
 }: AuthModalOptions): ModalOptions {
-  const kind = intent === AuthIntent.followArtist ? "artist" : "profile"
+  const kind = intent === Intent.followArtist ? "artist" : "profile"
   return {
     mode: ModalType.signup,
     contextModule,
@@ -139,12 +139,12 @@ function getDesktopIntentToSaveArtwork({
   }
 }
 
-function getDesktopAuthIntent(options: AuthModalOptions): ModalOptions {
+function getDesktopIntent(options: AuthModalOptions): ModalOptions {
   switch (options.intent) {
-    case AuthIntent.followArtist:
-    case AuthIntent.followPartner:
+    case Intent.followArtist:
+    case Intent.followPartner:
       return getDesktopIntentToFollow(options)
-    case AuthIntent.saveArtwork:
+    case Intent.saveArtwork:
       return getDesktopIntentToSaveArtwork(options)
     default:
       return undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
   integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
 
-"@artsy/cohesion@0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-0.2.8.tgz#c0f62c75dc196a7cfd3e2d27672895c8e1daa366"
-  integrity sha512-4vdmWkBoHwl/MJMRFLKtYlba5k+9Aa0kcpFgtgcrjTYVgZRj/WqLdTVNJl3t3iUcKpHC/gtFq4O123SsKlPEcQ==
+"@artsy/cohesion@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.0.0.tgz#8ca91910a707f4b4c195b4836b0d7f40b3e31c76"
+  integrity sha512-/XF1p6EgikXugwY3AEnVAeZj5qt6bFdyTtt1I8sm5cx8PJqL0pBTpIvNx/1Cy6814awad3DnG/8NkxCNc/LnhQ==
 
 "@artsy/detect-responsive-traits@^0.0.5":
   version "0.0.5"


### PR DESCRIPTION
Fixes breaking changes from Cohesion v1, renames `AuthIntent` enum to `Intent`.

https://github.com/artsy/cohesion/pull/31
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.30.3-canary.3474.59395.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.30.3-canary.3474.59395.0
  # or 
  yarn add @artsy/reaction@26.30.3-canary.3474.59395.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
