### PR TITLE
[mWeb] Support OTP prompt on mobile login modal via Formik setStatus

### DIFF
--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -32,9 +32,7 @@ interface LoginFormState {
 }
 
 class MobileLoginFormWithSystemContext extends Component<
-  FormProps & {
-    relayEnvironment: Environment
-  },
+  FormProps & { relayEnvironment: Environment },
   LoginFormState
 > {
   static getDerivedStateFromProps(nextProps, prevState): LoginFormState | null {
@@ -59,7 +57,7 @@ class MobileLoginFormWithSystemContext extends Component<
     return null
   }
 
-  static buildOtpStep = () => {
+  static buildOtpStep = (): StepElement => {
     return (
       <Step validationSchema={MobileLoginValidator.otpAttempt}>
         {({
@@ -112,7 +110,7 @@ class MobileLoginFormWithSystemContext extends Component<
     this.props.handleSubmit(values, formikBag)
   }
 
-  buildBaseSteps = () => {
+  buildBaseSteps = (): StepElement[] => {
     return [
       <Step
         validationSchema={MobileLoginValidator.email}
@@ -186,14 +184,42 @@ class MobileLoginFormWithSystemContext extends Component<
         {context => {
           const {
             wizard,
-            form: { handleSubmit, actions, values, status, isSubmitting },
+            form: {
+              handleSubmit,
+              actions,
+              values,
+              status,
+              setStatus,
+              isSubmitting,
+            },
           } = context
 
           const { currentStep, isLastStep, next } = wizard
 
+          if (
+            status &&
+            !status.success &&
+            status.error === "missing two-factor authentication code"
+          ) {
+            this.setState(
+              {
+                steps: steps.concat([
+                  MobileLoginFormWithSystemContext.buildOtpStep(),
+                ]),
+                hideBackButton: true,
+              },
+              () => {
+                setStatus(null)
+
+                next(values, actions)
+              }
+            )
+          }
+
           if (advanceWizardStep) {
-            next(values, actions)
-            this.setState({ advanceWizardStep: false })
+            this.setState({ advanceWizardStep: false }, () => {
+              next(values, actions)
+            })
           }
 
           return (

--- a/src/Components/__stories__/Authentication.story.tsx
+++ b/src/Components/__stories__/Authentication.story.tsx
@@ -20,6 +20,25 @@ const submit: SubmitHandler = (values, actions) => {
   }, 1000)
 }
 
+const submitWithOtpRequired: SubmitHandler = (values, actions) => {
+  setTimeout(() => {
+    if (values.otp_attempt === "123456") {
+      alert(JSON.stringify(values, null, 1))
+    } else if (values.otp_attempt) {
+      actions.setStatus({
+        success: false,
+        error: "invalid two-factor authentication code",
+      })
+    } else {
+      actions.setStatus({
+        success: false,
+        error: "missing two-factor authentication code",
+      })
+    }
+    actions.setSubmitting(false)
+  }, 1000)
+}
+
 const boundedSubmit = (type, options, values, actions) => {
   setTimeout(() => {
     alert(JSON.stringify(values, null, 1))
@@ -65,7 +84,7 @@ storiesOf("Components/Authentication/Desktop", module)
   ))
   .add("Sign Up", () => <ModalContainer options={{ mode: ModalType.signup }} />)
 
-const MobileLoginTwoFactorAuthDemo: React.FC = () => {
+const MobileLoginTwoFactorErrorPropAuthDemo: React.FC = () => {
   const [serverError, setServerError] = useState(null)
 
   const handleSubmit: SubmitHandler = (values, actions) => {
@@ -109,9 +128,22 @@ storiesOf("Components/Authentication/Mobile", module)
       />
     </MobileContainer>
   ))
-  .add("Login (2FA)", () => (
+  .add("Login (2FA with error prop)", () => (
     <MobileContainer>
-      <MobileLoginTwoFactorAuthDemo />
+      <FormSwitcher
+        type={ModalType.login}
+        handleSubmit={submitWithOtpRequired}
+        isMobile
+        options={{
+          contextModule: ContextModule.header,
+          intent: Intent.login,
+        }}
+      />
+    </MobileContainer>
+  ))
+  .add("Login (2FA with form status)", () => (
+    <MobileContainer>
+      <MobileLoginTwoFactorErrorPropAuthDemo />
     </MobileContainer>
   ))
   .add("Forgot Password", () => (


### PR DESCRIPTION
The mobile login modal supports external error messages via two paths:

- The `error` prop
- Formik actions via the `handleSubmit` handler

We added support for the former in https://github.com/artsy/reaction/pull/3472. This commit adds support for the latter, used in Force:

https://github.com/artsy/force/blob/51733c03c8e490fa8ff705268f86c472412890c1/src/desktop/apps/authentication/helpers.ts#L90-L96

Follow-up to #3472 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.30.5-canary.3476.59467.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.30.5-canary.3476.59467.0
  # or 
  yarn add @artsy/reaction@26.30.5-canary.3476.59467.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
