### PR TITLE
[Consignments] Hide recently sold data point if missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "emit-types": "tsc --declaration --emitDeclarationOnly --listEmittedFiles --jsx react --outDir dist",
     "find-unused-fields": "ts-node scripts/find-unused-fields",
     "integrate": "./scripts/quicklink-to-project.sh",
-    "lint": "eslint src --cache  --ext ts,tsx --ignore-pattern 'src/__generated__'",
+    "lint": "eslint --cache  --ext ts,tsx --ignore-pattern 'src/__generated__'",
     "omg": "om g",
     "prepare": "patch-package",
     "prepublishOnly": "yarn clean && yarn relay && yarn compile && yarn emit-types",

--- a/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -28,15 +28,16 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
 
           <Spacer my={4} />
 
-          <Flex
-            justifyContent={["center", "center"]}
-            flexWrap="wrap"
-            alignItems="center"
-          >
+          <Flex justifyContent={["center", "center"]} flexWrap="wrap">
             {artist.targetSupply.microfunnel.artworks.map(
               ({ artwork, realizedPrice }, key) => {
                 return (
-                  <Box p={2} key={key} textAlign="left">
+                  <Flex
+                    p={2}
+                    key={key}
+                    flexDirection="column"
+                    style={{ textAlign: "left" }}
+                  >
                     <FillwidthItem
                       artwork={artwork}
                       targetHeight={150}
@@ -45,10 +46,12 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
                       width={150 * artwork.image.aspectRatio}
                       contextModule={ContextModule.artistRecentlySold}
                     />
-                    <Sans size="2" weight="medium">
-                      Sold for {realizedPrice}
-                    </Sans>
-                  </Box>
+                    {realizedPrice && (
+                      <Sans size="2" weight="medium">
+                        Sold for {realizedPrice}
+                      </Sans>
+                    )}
+                  </Flex>
                 )
               }
             )}

--- a/src/Apps/Artist/Routes/Consign/__tests__/ConsignRoute.test.tsx
+++ b/src/Apps/Artist/Routes/Consign/__tests__/ConsignRoute.test.tsx
@@ -138,7 +138,7 @@ describe("ConsignRoute", () => {
   })
 
   describe("ArtistConsignPageViews", () => {
-    it("includes artist name in pageviews title", async () => {
+    it("includes artist name in pageview title", async () => {
       const wrapper = await getWrapper()
       expect(wrapper.find("ArtistConsignPageViews").text()).toContain(
         "Alex Katz"


### PR DESCRIPTION
Related PR: https://github.com/artsy/metaphysics/pull/2348

We don't want to show the realized price point if missing. 

#trivial 