### PR TITLE
Fix auction results layout on mobile

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -207,56 +207,34 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
   )
 
   return (
-    <Box data-test={ContextModule.auctionResults}>
-      <Col xs="4">
-        <Flex
-          alignItems="center"
-          justifyContent="center"
-          height="80px"
-          width="80px"
-        >
-          {imageUrl ? (
-            <StyledImage
-              src={imageUrl}
-              Fallback={() => renderFallbackImage()}
-            />
-          ) : (
-            renderFallbackImage()
-          )}
-        </Flex>
-      </Col>
-      <Col xs="6">
-        <Flex alignItems="center" width="100%" height="100%">
-          <Box>
-            {renderPricing(
-              salePrice,
-              saleDate,
-              props.user,
-              props.mediator,
-              "xs"
-            )}
-            <Sans size="2" weight="medium" color="black60">
-              {title}
-              {title && date_text && ", "}
-              {date_text}
-            </Sans>
-            <Sans size="2" color="black60" mt="5px">
-              Sold on {dateOfSale}
-            </Sans>
-          </Box>
-        </Flex>
-      </Col>
-      <Col xs="2">
-        <Flex
-          justifyContent="flex-end"
-          width="100%"
-          alignItems="center"
-          height="100%"
-        >
-          <div>{expanded ? <ArrowUpIcon /> : <ArrowDownIcon />}</div>
-        </Flex>
-      </Col>
-    </Box>
+    <Flex data-test={ContextModule.auctionResults} width="100%">
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        height="80px"
+        width="80px"
+      >
+        {imageUrl ? (
+          <StyledImage src={imageUrl} Fallback={() => renderFallbackImage()} />
+        ) : (
+          renderFallbackImage()
+        )}
+      </Flex>
+      <Flex ml={2} flexDirection="column" justifyContent="center" width="100%">
+        {renderPricing(salePrice, saleDate, props.user, props.mediator, "xs")}
+        <Sans size="2" weight="medium" color="black60">
+          {title}
+          {title && date_text && ", "}
+          {date_text}
+        </Sans>
+        <Sans size="2" color="black60" mt="5px">
+          Sold on {dateOfSale}
+        </Sans>
+      </Flex>
+      <Flex justifyContent="flex-end" alignItems="center" height="100%">
+        <div>{expanded ? <ArrowUpIcon /> : <ArrowDownIcon />}</div>
+      </Flex>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
Before

<img width="431" alt="image" src="https://user-images.githubusercontent.com/3087225/81214959-9bd51e80-8fa6-11ea-9c0a-ee62935acbbd.png">

After

<img width="359" alt="image" src="https://user-images.githubusercontent.com/3087225/81214999-aa233a80-8fa6-11ea-98a9-038b4fcbce22.png">

I don't know exactly _why_ this broke. I'm assuming some extra spacing squeezed through somewhere that caused the column layout to fail. I ripped all that out and simplified the layout. 
