### PR TITLE
Change the filter order to prioritize more popular filters

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Flex, Sans, Spacer } from "@artsy/palette"
+import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import { isEmpty } from "lodash"
 import React, { FC } from "react"
 
@@ -53,12 +53,8 @@ export const WaysToBuyFilter: FC = () => {
   ]
 
   return (
-    <Flex flexDirection="column" alignItems="left" mt={-1} mb={1}>
-      <Box pt={1}>
-        <Sans size="2" weight="medium" color="black100">
-          Ways to buy
-        </Sans>
-        <Spacer mb={2} />
+    <Toggle label="Ways to buy" expanded>
+      <Flex flexDirection="column" my={1}>
         {checkboxes.map((checkbox, index) => {
           const props = {
             disabled: checkbox.disabled,
@@ -68,7 +64,7 @@ export const WaysToBuyFilter: FC = () => {
           }
           return <Checkbox {...props}>{checkbox.name}</Checkbox>
         })}
-      </Box>
-    </Flex>
+      </Flex>
+    </Toggle>
   )
 }

--- a/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import React from "react"
 
 import { ColorFilter } from "./ColorFilter"
@@ -13,17 +13,14 @@ import { WaysToBuyFilter } from "./WaysToBuyFilter"
 export const ArtworkFilters: React.FC = () => {
   return (
     <Box pr={2}>
-      <Box pb={2}>
-        <Separator />
-      </Box>
-      <WaysToBuyFilter />
       <MediumFilter />
       <PriceRangeFilter />
+      <WaysToBuyFilter />
       <GalleryFilter />
       <InstitutionFilter />
       <SizeRangeFilter />
-      <ColorFilter />
       <TimePeriodFilter />
+      <ColorFilter />
     </Box>
   )
 }


### PR DESCRIPTION
Based on [the specs](https://www.notion.so/artsy/Improve-filtering-on-mWeb-artist-pages-collections-collect-ef262fef2c484a328b80c78878f7d1e4#58636e780d2a4d53888c7e1bdbb62de7), it looks like we actually want the filter order to be the same across-the-board! Instead of adding in the functionality to customize, I just updated it in this one place.

Artist page:
<img width="302" alt="Screen Shot 2020-05-06 at 8 13 52 PM" src="https://user-images.githubusercontent.com/2081340/81240909-cb9c1a80-8fd6-11ea-9e3c-6a7cdb5103c3.png">

Collect page:
<img width="313" alt="Screen Shot 2020-05-06 at 8 14 09 PM" src="https://user-images.githubusercontent.com/2081340/81240912-cf2fa180-8fd6-11ea-9f3f-ffdf2cbdba76.png">

Collection page:
<img width="317" alt="Screen Shot 2020-05-06 at 8 14 24 PM" src="https://user-images.githubusercontent.com/2081340/81240921-d48cec00-8fd6-11ea-9e3e-de1648c5c6e6.png">

By default, the first three options will be expanded:
<img width="318" alt="Screen Shot 2020-05-06 at 8 20 06 PM" src="https://user-images.githubusercontent.com/2081340/81240984-fedea980-8fd6-11ea-9f08-573b5cf46793.png">
