### PR TITLE
Ensure storybook build is gated behind queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   yarn: artsy/yarn@5.1.0
   codecov: codecov/codecov@1.0.5
-  auto: artsy/auto@1.2.0
+  auto: artsy/auto@1.2.1
   aws-s3: circleci/aws-s3@1.0.15
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ workflows:
       - yarn/run:
           name: build-storybook
           script: "deploy-storybook"
+          requires:
+            - yarn/workflow-queue
           post-steps:
             - persist_to_workspace:
                 root: .


### PR DESCRIPTION
Storybook build wasn't gated and is sometimes causing the master build to fail (because the master build won't continue until other jobs on master have finished)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.31.7-canary.3492.59785.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.31.7-canary.3492.59785.0
  # or 
  yarn add @artsy/reaction@26.31.7-canary.3492.59785.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
