### PR TITLE
Enable faster PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ workflows:
             - yarn/workflow-queue
       - yarn/jest:
           args: --runInBand
+          only_test_changed: true
+          notify_slack_on_failure: true
+          context: slack-reaction-test-failures
           requires:
             - yarn/workflow-queue
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@5.1.0
+  yarn: artsy/yarn@dev:4ab104781797303488b75d3fd18e99ee
   codecov: codecov/codecov@1.0.5
   auto: artsy/auto@1.2.1
   aws-s3: circleci/aws-s3@1.0.15


### PR DESCRIPTION
As mentioned in https://artsy.slack.com/archives/C02BC3HEJ/p1588855759090600.

Test only what changed in a PR for faster PR cycle times.  

This does _not_ change the tests that are ran on master. That's still a full suite. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.31.8-canary.3493.59832.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.31.8-canary.3493.59832.0
  # or 
  yarn add @artsy/reaction@26.31.8-canary.3493.59832.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
