### PR TITLE
Updates mobile artwork filters layout

### DIFF
--- a/src/Components/v2/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
+++ b/src/Components/v2/ArtworkFilter/ArtworkFilterMobileActionSheet.tsx
@@ -1,8 +1,11 @@
-import { Box, Button, Sans, Spacer } from "@artsy/palette"
-import { MobileTopBar } from "Components/MobileTopBar"
+import { Box, Button, Sans, Flex, color } from "@artsy/palette"
 import React, { SFC } from "react"
 import styled from "styled-components"
-import { useArtworkFilterContext } from "./ArtworkFilterContext"
+import {
+  useArtworkFilterContext,
+  initialArtworkFilterState,
+} from "./ArtworkFilterContext"
+import { isEqual, omit } from "lodash"
 
 export const ArtworkFilterMobileActionSheet: SFC<{
   children: JSX.Element
@@ -10,27 +13,44 @@ export const ArtworkFilterMobileActionSheet: SFC<{
 }> = ({ children, onClose }) => {
   const filterContext = useArtworkFilterContext()
 
+  // This reflects our zero state for this UI which doesn't include the keyword
+  const isReset = isEqual(
+    omit(filterContext.filters, "reset", "keyword"),
+    initialArtworkFilterState
+  )
+
   return (
-    <Container mt={6}>
-      <MobileTopBar>
+    <Container>
+      <Header p={1}>
+        <Button variant="noOutline" size="small" onClick={onClose}>
+          Close
+        </Button>
+
+        <Title size="3" weight="medium" textAlign="center">
+          Filter
+        </Title>
+
         <Button
-          variant="noOutline"
           size="small"
+          variant="secondaryGray"
+          disabled={isReset}
           onClick={() => filterContext.resetFilters()}
         >
-          Reset
+          Clear all
         </Button>
-        <FilterTitle size="2" weight="medium">
-          Filter
-        </FilterTitle>
-        <Button variant="primaryBlack" size="small" onClick={() => onClose()}>
+      </Header>
+
+      <Content>
+        <Box width="100%" p={2}>
+          {children}
+        </Box>
+      </Content>
+
+      <Footer p={1}>
+        <Button variant="primaryBlack" width="100%" onClick={onClose}>
           Apply
         </Button>
-      </MobileTopBar>
-
-      <Spacer pt={1} mb={3} />
-
-      <Box p={2}>{children}</Box>
+      </Footer>
     </Container>
   )
 }
@@ -45,10 +65,28 @@ const Container = styled(Box)`
   width: 100%;
   height: 100%;
   background-color: white;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`
+
+const Header = styled(Flex)`
+  width: 100%;
+  align-items: center;
+  border-bottom: 1px solid ${color("black10")};
+`
+
+const Footer = styled(Flex)`
+  width: 100%;
+`
+
+const Content = styled(Flex)`
+  flex: 1;
+  width: 100%;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 `
 
-const FilterTitle = styled(Sans)`
-  width: min-content;
+const Title = styled(Sans)`
+  flex: 1;
 `

--- a/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.test.tsx
+++ b/src/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.test.tsx
@@ -32,13 +32,16 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
   it("contains correct UI elements", () => {
     const wrapper = getWrapper()
+
     expect(
       wrapper
         .find("Button")
         .first()
         .text()
-    ).toEqual("Reset")
+    ).toEqual("Close")
+
     expect(wrapper.html()).toContain("Filter")
+
     expect(
       wrapper
         .find("Button")
@@ -47,7 +50,7 @@ describe("ArtworkFilterMobileActionSheet", () => {
     ).toEqual("Apply")
   })
 
-  it("resets filters to defaults on `Reset` button click", done => {
+  it("resets filters to defaults on `Reset` button click", () => {
     const wrapper = getWrapper({
       filters: {
         ...initialArtworkFilterState,
@@ -56,15 +59,13 @@ describe("ArtworkFilterMobileActionSheet", () => {
     })
     wrapper
       .find("Button")
+      .findWhere(c => c.text() === "Clear all")
       .first()
       .simulate("click")
 
-    setTimeout(() => {
-      expect(context.filters).toEqual({
-        ...initialArtworkFilterState,
-        reset: true,
-      })
-      done()
+    expect(context.filters).toEqual({
+      ...initialArtworkFilterState,
+      reset: true,
     })
   })
 


### PR DESCRIPTION
Re: [FX-1938](https://artsyproduct.atlassian.net/browse/FX-1938)

Makes the mobile filters fullscreen and moves the "Apply" button to the bottom. Note that here I've just renamed "Cancel" to "Close" for the time being since we don't have a real notion of cancelling. If we want a proper cancel we'll have to just hold off on this until we can refactor the filters to actually be staged.

![](http://static.damonzucconi.com/_capture/tNt3u8zwEKtI.gif)

-----

Note that I'm punting on the scroll lock, which is a separate issue — refactoring the underlying nature of the Modal is... problematic. Closed PR here: https://github.com/artsy/palette/pull/675 — I'm thinking we just pull off `ModalBase` as it's own thing and use that here (and going forward to build Modals and slowly refactor the old one but I'm not thrilled by this prospect).