### PR TITLE
Fallback to base route if no route found through index

### DIFF
--- a/src/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -15,5 +15,9 @@ export const findCurrentRoute = ({
     route = route.children[remainingRouteIndicies.shift()]
   }
 
+  if (!route) {
+    route = baseRoute
+  }
+
   return route
 }


### PR DESCRIPTION
There was an issue on conversations that caused `/user/conversation/:id` to 500. 

The issue is related to `findCurrentRoute` returning `null`. I did some work on this function a while back to make it a bit more robust, but in this case the `routesIndicies` is behaving in a way that I don't expect. It's returning `[ 1 ]` but `routes` is an array of only 1 element... which is the element that we're accessing. 

This might be due to how the routing in conversations is structured. It's a flat array instead of nested like on artist pages. 