### PR TITLE
Refine 2FA enrollment design and experience

### DIFF
--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/ApiErrorModal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/ApiErrorModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Sans } from "@artsy/palette"
+import { Dialog } from "@artsy/palette"
 import React from "react"
 import { ApiError } from "../ApiError"
 
@@ -14,15 +14,14 @@ export const ApiErrorModal: React.FC<ApiErrorModalProps> = props => {
   const errorMessage = errors.map(error => error.message).join("\n")
 
   return (
-    <Modal
-      forcedScroll={false}
-      title="An error occurred"
+    <Dialog
       show={show}
-      onClose={onClose}
-    >
-      <Sans color="black60" textAlign="center" size="3t">
-        {errorMessage}
-      </Sans>
-    </Modal>
+      detail={errorMessage}
+      title="An error occurred"
+      primaryCta={{
+        action: onClose,
+        text: "OK",
+      }}
+    />
   )
 }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -104,7 +104,6 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
           <InnerForm secondFactor={secondFactor} {...formikProps} />
         )}
       </Formik>
-      >
     </Modal>
   )
 }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -157,14 +157,14 @@ const InnerForm: React.FC<InnerFormProps> = ({
             {secondFactor.otpSecret}
           </Sans>
         ) : (
-          <Button
-            size="small"
-            variant="secondaryGray"
-            onClick={() => setShowSecret(true)}
-          >
-            Show secret
-          </Button>
-        )}
+            <Button
+              size="small"
+              variant="secondaryGray"
+              onClick={() => setShowSecret(true)}
+            >
+              Show secret
+            </Button>
+          )}
       </Box>
       <Sans mt={2} color="black60" size="3">
         2. Enter the six-digit code from the application to complete the
@@ -185,6 +185,7 @@ const InnerForm: React.FC<InnerFormProps> = ({
         <Button
           mt={2}
           loading={isSubmitting}
+          disabled={isSubmitting}
           width="100%"
           type="submit"
           onClick={handleSubmit}

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -145,8 +145,8 @@ const InnerForm: React.FC<InnerFormProps> = ({
         />
       </Box>
       <Sans mt={2} color="black60" size="3">
-        Use your app to scan the code below. If you can’t use a barcode, enter
-        the secret code manually.
+        1. Use your app to scan the code below. If you can’t use a barcode,
+        enter the secret code manually.
       </Sans>
       <Box mt={2} textAlign="center">
         <QRCode size={256} value={secondFactor.otpProvisioningURI} />
@@ -165,7 +165,7 @@ const InnerForm: React.FC<InnerFormProps> = ({
         )}
       </Sans>
       <Sans mt={2} color="black60" size="3">
-        Enter the six-digit code from the application to complete the
+        2. Enter the six-digit code from the application to complete the
         configuration.
       </Sans>
       <Box mt={2}>

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -151,9 +151,11 @@ const InnerForm: React.FC<InnerFormProps> = ({
       <Box mt={2} textAlign="center">
         <QRCode size={256} value={secondFactor.otpProvisioningURI} />
       </Box>
-      <Sans mt={2} color="black60" size="3t">
+      <Box mt={2} textAlign="center">
         {showSecret ? (
-          `secret: ${secondFactor.otpSecret}`
+          <Sans color="black60" size="3t">
+            {secondFactor.otpSecret}
+          </Sans>
         ) : (
           <Button
             size="small"
@@ -163,7 +165,7 @@ const InnerForm: React.FC<InnerFormProps> = ({
             Show secret
           </Button>
         )}
-      </Sans>
+      </Box>
       <Sans mt={2} color="black60" size="3">
         2. Enter the six-digit code from the application to complete the
         configuration.

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/__stories__/AppSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/__stories__/AppSecondFactor.story.tsx
@@ -25,7 +25,7 @@ const MockAppSecondFactor = ({ mockData, mockMutationResults, query }) => {
 }
 
 storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/AppSecondFactor",
+  "Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor",
   module
 ).add("Success", () => {
   const mockMutationResults = merge(

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -5,6 +5,11 @@ import { createFragmentContainer, graphql, RelayRefetchProp } from "react-relay"
 
 import { useSystemContext } from "Artsy"
 import { AppSecondFactorModal } from "./Modal"
+import { ApiError } from "../../ApiError"
+import { ApiErrorModal } from "../ApiErrorModal"
+import { DisableSecondFactor } from "../Mutation/DisableSecondFactor"
+import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
+import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
 
 import { AppSecondFactor_me } from "__generated__/AppSecondFactor_me.graphql"
 
@@ -13,14 +18,10 @@ interface AppSecondFactorProps extends BorderBoxProps {
   relayRefetch?: RelayRefetchProp
 }
 
-import { ApiError } from "../../ApiError"
-import { ApiErrorModal } from "../ApiErrorModal"
-import { DisableSecondFactor } from "../Mutation/DisableSecondFactor"
-import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
-
 export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
   const { me, relayRefetch } = props
   const [apiErrors, setApiErrors] = useState<ApiError[]>([])
+  const [showConfirmDisable, setShowConfirmDisable] = useState(false)
   const [showSetupModal, setShowSetupModal] = useState(false)
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
 
@@ -89,7 +90,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
                 {me.appSecondFactors[0].name || "Unnamed"}
               </Sans>
               <Button
-                onClick={disableSecondFactor}
+                onClick={() => setShowConfirmDisable(true)}
                 ml={1}
                 variant="secondaryOutline"
               >
@@ -118,6 +119,11 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
         onClose={() => setApiErrors([])}
         show={!!apiErrors.length}
         errors={apiErrors}
+      />
+      <DisableFactorConfirmation
+        show={showConfirmDisable}
+        onConfirm={disableSecondFactor}
+        onCancel={() => setShowConfirmDisable(false)}
       />
     </BorderBox>
   )

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -30,8 +30,9 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
   const { relayEnvironment } = useSystemContext()
 
   function onComplete() {
-    setShowSetupModal(false)
-    relayRefetch.refetch({})
+    relayRefetch.refetch({}, {}, () => {
+      setShowSetupModal(false)
+    })
   }
 
   function handleMutationError(errors: ApiError[]) {
@@ -79,7 +80,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     }
   }
 
-  const DisableButton = props =>
+  const DisableButton = props => (
     <Button
       onClick={() => setShowConfirmDisable(true)}
       variant="secondaryOutline"
@@ -88,9 +89,10 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
       {...props}
     >
       Disable
-  </Button>
+    </Button>
+  )
 
-  const SetupButton = props =>
+  const SetupButton = props => (
     <Button
       onClick={createSecondFactor}
       loading={isCreating}
@@ -99,6 +101,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     >
       {props.children}
     </Button>
+  )
 
   return (
     <BorderBox p={2} {...props}>
@@ -117,17 +120,19 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
         </Flex>
         <Flex alignItems="center">
           {me.appSecondFactors.length &&
-            me.appSecondFactors[0].__typename === "AppSecondFactor" ? (
-              <>
-                <Sans color="black60" size="3" weight="medium">
-                  {me.appSecondFactors[0].name || "Unnamed"}
-                </Sans>
-                <DisableButton ml={1} />
-                <SetupButton ml={1} variant="secondaryGray">Edit</SetupButton>
-              </>
-            ) : (
-              <SetupButton ml={1}>Set up</SetupButton>
-            )}
+          me.appSecondFactors[0].__typename === "AppSecondFactor" ? (
+            <>
+              <Sans color="black60" size="3" weight="medium">
+                {me.appSecondFactors[0].name || "Unnamed"}
+              </Sans>
+              <DisableButton ml={1} />
+              <SetupButton ml={1} variant="secondaryGray">
+                Edit
+              </SetupButton>
+            </>
+          ) : (
+            <SetupButton ml={1}>Set up</SetupButton>
+          )}
         </Flex>
       </Flex>
       <AppSecondFactorModal

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__stories__/BackupSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/__stories__/BackupSecondFactor.story.tsx
@@ -29,29 +29,26 @@ const MockBackupSecondFactor = ({ mockData }) => {
 }
 
 storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor",
+  "Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor",
   module
-).add("Disabled", () => {
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockBackupSecondFactor mockData={DisabledQueryResponse} />
-      </Box>
-    </Theme>
-  )
-})
-
-storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor",
-  module
-).add("Enabled", () => {
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockBackupSecondFactor
-          mockData={AppEnabledWithBackupCodesQueryResponse}
-        />
-      </Box>
-    </Theme>
-  )
-})
+)
+  .add("Disabled", () => {
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockBackupSecondFactor mockData={DisabledQueryResponse} />
+        </Box>
+      </Theme>
+    )
+  })
+  .add("Enabled", () => {
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockBackupSecondFactor
+            mockData={AppEnabledWithBackupCodesQueryResponse}
+          />
+        </Box>
+      </Theme>
+    )
+  })

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
@@ -18,21 +18,38 @@ export const BackupSecondFactor: React.FC<BackupSecondFactorProps> = props => {
   const { relayEnvironment } = useSystemContext()
 
   const [showModal, setShowModal] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isCreating, setCreating] = useState(false)
 
-  function createBackupSecondFactors() {
-    setIsSubmitting(true)
 
-    CreateBackupSecondFactors(relayEnvironment)
-      .then(() => {
-        setIsSubmitting(false)
-        setShowModal(true)
-      })
-      .catch(reason => {
-        console.error(reason)
-        setIsSubmitting(false)
-      })
+  async function createBackupSecondFactors() {
+    setCreating(true)
+
+    try {
+      await CreateBackupSecondFactors(relayEnvironment)
+      setShowModal(true)
+    } catch (e) {
+      console.error(e)
+    }
+
+    setCreating(false)
   }
+
+  const ShowButton = props =>
+    <Button
+      onClick={() => setShowModal(true)}
+      variant="secondaryOutline"
+      {...props}
+    >
+      Show
+    </Button>
+
+  const SetupButton = props =>
+    <Button
+      onClick={createBackupSecondFactors}
+      loading={isCreating}
+      disabled={isCreating}
+      {...props}
+    />
 
   return (
     <BorderBox p={20} {...props}>
@@ -52,27 +69,12 @@ export const BackupSecondFactor: React.FC<BackupSecondFactorProps> = props => {
               <Sans color="black60" size="3" weight="medium">
                 {me.backupSecondFactors.length} remaining
               </Sans>
-              <Button
-                ml={10}
-                variant="secondaryOutline"
-                onClick={() => setShowModal(true)}
-              >
-                Show
-              </Button>
-              <Button
-                loading={isSubmitting}
-                ml={10}
-                variant="secondaryGray"
-                onClick={createBackupSecondFactors}
-              >
-                Regenerate
-              </Button>
+              <ShowButton ml={1} />
+              <SetupButton ml={1} variant="secondaryGray">Regenerate</SetupButton>
             </>
           ) : (
-            <Button loading={isSubmitting} onClick={createBackupSecondFactors}>
-              Set up
-            </Button>
-          )}
+              <SetupButton ml={1}>Set up</SetupButton>
+            )}
         </Flex>
       </Flex>
       <Modal

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/DisableFactorConfirmation.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/DisableFactorConfirmation.tsx
@@ -1,0 +1,27 @@
+import { Dialog } from "@artsy/palette"
+import React from "react"
+
+interface DisableFactorConfirmationProps {
+  onConfirm: () => void
+  onCancel: () => void
+  show: boolean
+}
+
+export const DisableFactorConfirmation: React.FC<DisableFactorConfirmationProps> = props => {
+  const { onCancel, onConfirm, show } = props
+
+  return (
+    <Dialog
+      show={show}
+      title="Disable 2FA method?"
+      primaryCta={{
+        action: onConfirm,
+        text: "Disable",
+      }}
+      secondaryCta={{
+        action: onCancel,
+        text: "Cancel",
+      }}
+    />
+  )
+}

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Flex, Input, Modal, Sans, Spacer } from "@artsy/palette"
 import { FormikHelpers as FormikActions } from "formik"
-import React from "react"
+import React, { useState } from "react"
 import styled from "styled-components"
 
 import * as Yup from "yup"
@@ -32,6 +32,9 @@ const StyledInput = styled(Input)`
 export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props => {
   const { secondFactor, onComplete } = props
   const { relayEnvironment } = useSystemContext()
+  const [isSubmitting, setSubmitting] = useState(false)
+  const [isDelivering, setDelivering] = useState(false)
+
 
   if (!secondFactor || secondFactor.__typename !== "SmsSecondFactor") {
     return null
@@ -41,6 +44,8 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
     values: FormValues,
     actions: FormikActions<object>
   ) => {
+    setSubmitting(true)
+
     try {
       await EnableSecondFactor(relayEnvironment, {
         secondFactorID: secondFactor.internalID,
@@ -51,6 +56,8 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
     } catch (error) {
       handleMutationError(actions, error)
     }
+
+    setSubmitting(false)
   }
 
   const handleMutationError = (
@@ -83,6 +90,8 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
     actions: FormikActions<FormValues>
   ) => {
     return new Promise<boolean>(async (resolve, _reject) => {
+      setDelivering(true)
+
       try {
         await UpdateSmsSecondFactor(relayEnvironment, {
           secondFactorID: secondFactor.internalID,
@@ -108,6 +117,8 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
       } catch (error) {
         handleMutationError(actions, error)
       }
+
+      setDelivering(false)
     })
   }
 
@@ -149,7 +160,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
               {form.status.message}
             </Sans>
           )}
-          <Button display="block" width="100%" type="submit" mt={2}>
+          <Button loading={isDelivering} disabled={isDelivering} display="block" width="100%" type="submit" mt={2}>
             Next
           </Button>
         </Box>
@@ -195,7 +206,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
               Back
             </Button>
             <Spacer ml={1} />
-            <Button width="50%" type="submit">
+            <Button width="50%" loading={isSubmitting} disabled={isSubmitting} type="submit">
               Turn on
             </Button>
           </Flex>

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/__stories__/SmsSecondFactor.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/__stories__/SmsSecondFactor.story.tsx
@@ -29,118 +29,107 @@ const MockSmsSecondFactor = ({ mockData, mockMutationResults, query }) => {
 }
 
 storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor",
+  "Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor",
   module
-).add("Update Error", () => {
-  const mockMutationResults = merge(
-    CreateSmsSecondFactorMutationSuccessResponse,
-    UpdateSmsSecondFactorMutationErrorResponse
-  )
+)
+  .add("Update Error", () => {
+    const mockMutationResults = merge(
+      CreateSmsSecondFactorMutationSuccessResponse,
+      UpdateSmsSecondFactorMutationErrorResponse
+    )
 
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockSmsSecondFactor
-          mockData={DisabledQueryResponse}
-          mockMutationResults={mockMutationResults}
-          query={graphql`
-            query SmsSecondFactorStoryUpdateErrorQuery {
-              me {
-                ...SmsSecondFactor_me
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockSmsSecondFactor
+            mockData={DisabledQueryResponse}
+            mockMutationResults={mockMutationResults}
+            query={graphql`
+              query SmsSecondFactorStoryUpdateErrorQuery {
+                me {
+                  ...SmsSecondFactor_me
+                }
               }
-            }
-          `}
-        />
-      </Box>
-    </Theme>
-  )
-})
+            `}
+          />
+        </Box>
+      </Theme>
+    )
+  })
+  .add("Undeliverable", () => {
+    const mockMutationResults = merge(
+      CreateSmsSecondFactorMutationSuccessResponse,
+      UpdateSmsSecondFactorMutationSuccessResponse,
+      DeliverSmsSecondFactorMutationErrorResponse
+    )
 
-storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor",
-  module
-).add("Undeliverable", () => {
-  const mockMutationResults = merge(
-    CreateSmsSecondFactorMutationSuccessResponse,
-    UpdateSmsSecondFactorMutationSuccessResponse,
-    DeliverSmsSecondFactorMutationErrorResponse
-  )
-
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockSmsSecondFactor
-          mockData={DisabledQueryResponse}
-          mockMutationResults={mockMutationResults}
-          query={graphql`
-            query SmsSecondFactorStoryUndeliverableQuery {
-              me {
-                ...SmsSecondFactor_me
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockSmsSecondFactor
+            mockData={DisabledQueryResponse}
+            mockMutationResults={mockMutationResults}
+            query={graphql`
+              query SmsSecondFactorStoryUndeliverableQuery {
+                me {
+                  ...SmsSecondFactor_me
+                }
               }
-            }
-          `}
-        />
-      </Box>
-    </Theme>
-  )
-})
+            `}
+          />
+        </Box>
+      </Theme>
+    )
+  })
+  .add("Success", () => {
+    const mockMutationResults = merge(
+      CreateSmsSecondFactorMutationSuccessResponse,
+      DeliverSmsSecondFactorMutationSuccessResponse,
+      UpdateSmsSecondFactorMutationSuccessResponse,
+      EnableSmsSecondFactorMutationSuccessResponse
+    )
 
-storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor",
-  module
-).add("Success", () => {
-  const mockMutationResults = merge(
-    CreateSmsSecondFactorMutationSuccessResponse,
-    DeliverSmsSecondFactorMutationSuccessResponse,
-    UpdateSmsSecondFactorMutationSuccessResponse,
-    EnableSmsSecondFactorMutationSuccessResponse
-  )
-
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockSmsSecondFactor
-          mockData={DisabledQueryResponse}
-          mockMutationResults={mockMutationResults}
-          query={graphql`
-            query SmsSecondFactorStorySuccessQuery {
-              me {
-                ...SmsSecondFactor_me
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockSmsSecondFactor
+            mockData={DisabledQueryResponse}
+            mockMutationResults={mockMutationResults}
+            query={graphql`
+              query SmsSecondFactorStorySuccessQuery {
+                me {
+                  ...SmsSecondFactor_me
+                }
               }
-            }
-          `}
-        />
-      </Box>
-    </Theme>
-  )
-})
+            `}
+          />
+        </Box>
+      </Theme>
+    )
+  })
+  .add("Incorrect OTP code", () => {
+    const mockMutationResults = merge(
+      CreateSmsSecondFactorMutationSuccessResponse,
+      DeliverSmsSecondFactorMutationSuccessResponse,
+      UpdateSmsSecondFactorMutationSuccessResponse,
+      EnableSmsSecondFactorMutationErrorResponse
+    )
 
-storiesOf(
-  "UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor",
-  module
-).add("Incorrect OTP code", () => {
-  const mockMutationResults = merge(
-    CreateSmsSecondFactorMutationSuccessResponse,
-    DeliverSmsSecondFactorMutationSuccessResponse,
-    UpdateSmsSecondFactorMutationSuccessResponse,
-    EnableSmsSecondFactorMutationErrorResponse
-  )
-
-  return (
-    <Theme>
-      <Box maxWidth="800px">
-        <MockSmsSecondFactor
-          mockData={DisabledQueryResponse}
-          mockMutationResults={mockMutationResults}
-          query={graphql`
-            query SmsSecondFactorStoryErrorQuery {
-              me {
-                ...SmsSecondFactor_me
+    return (
+      <Theme>
+        <Box maxWidth="800px">
+          <MockSmsSecondFactor
+            mockData={DisabledQueryResponse}
+            mockMutationResults={mockMutationResults}
+            query={graphql`
+              query SmsSecondFactorStoryErrorQuery {
+                me {
+                  ...SmsSecondFactor_me
+                }
               }
-            }
-          `}
-        />
-      </Box>
-    </Theme>
-  )
-})
+            `}
+          />
+        </Box>
+      </Theme>
+    )
+  })

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -12,6 +12,7 @@ import { CreateSmsSecondFactor } from "./Mutation/CreateSmsSecondFactor"
 
 import { SmsSecondFactor_me } from "__generated__/SmsSecondFactor_me.graphql"
 import { ApiErrorModal } from "../ApiErrorModal"
+import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
 
 interface SmsSecondFactorProps extends BorderBoxProps {
   me: SmsSecondFactor_me
@@ -21,6 +22,7 @@ interface SmsSecondFactorProps extends BorderBoxProps {
 export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
   const { me, relayRefetch } = props
   const { relayEnvironment } = useSystemContext()
+  const [showConfirmDisable, setShowConfirmDisable] = useState(false)
   const [showSetupModal, setShowSetupModal] = useState(false)
   const [apiErrors, setApiErrors] = useState<ApiError[]>([])
 
@@ -88,7 +90,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
                 {me.smsSecondFactors[0].formattedPhoneNumber}
               </Sans>
               <Button
-                onClick={disableSecondFactor}
+                onClick={() => setShowConfirmDisable(true)}
                 ml={1}
                 variant="secondaryOutline"
               >
@@ -117,6 +119,11 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
         onClose={() => setApiErrors([])}
         show={!!apiErrors.length}
         errors={apiErrors}
+      />
+      <DisableFactorConfirmation
+        show={showConfirmDisable}
+        onConfirm={disableSecondFactor}
+        onCancel={() => setShowConfirmDisable(false)}
       />
     </BorderBox>
   )

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -31,8 +31,9 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
 
   function onComplete() {
-    setShowSetupModal(false)
-    relayRefetch.refetch({})
+    relayRefetch.refetch({}, {}, () => {
+      setShowSetupModal(false)
+    })
   }
 
   function handleMutationError(errors: ApiError[]) {
@@ -83,7 +84,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     }
   }
 
-  const DisableButton = props =>
+  const DisableButton = props => (
     <Button
       onClick={() => setShowConfirmDisable(true)}
       variant="secondaryOutline"
@@ -93,14 +94,16 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     >
       Disable
     </Button>
+  )
 
-  const SetupButton = props =>
+  const SetupButton = props => (
     <Button
       onClick={createSecondFactor}
       loading={isCreating}
       disabled={isCreating}
       {...props}
     />
+  )
 
   return (
     <BorderBox p={2} {...props}>
@@ -115,17 +118,19 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
         </Flex>
         <Flex alignItems="center">
           {me.smsSecondFactors.length &&
-            me.smsSecondFactors[0].__typename === "SmsSecondFactor" ? (
-              <>
-                <Sans color="black60" size="3" weight="medium">
-                  {me.smsSecondFactors[0].formattedPhoneNumber}
-                </Sans>
-                <DisableButton ml={1} />
-                <SetupButton ml={1} variant="secondaryGray">Edit</SetupButton>
-              </>
-            ) : (
-              <SetupButton ml={1}>Set up</SetupButton>
-            )}
+          me.smsSecondFactors[0].__typename === "SmsSecondFactor" ? (
+            <>
+              <Sans color="black60" size="3" weight="medium">
+                {me.smsSecondFactors[0].formattedPhoneNumber}
+              </Sans>
+              <DisableButton ml={1} />
+              <SetupButton ml={1} variant="secondaryGray">
+                Edit
+              </SetupButton>
+            </>
+          ) : (
+            <SetupButton ml={1}>Set up</SetupButton>
+          )}
         </Flex>
       </Flex>
       <SmsSecondFactorModal

--- a/src/Components/UserSettings/TwoFactorAuthentication/__stories__/TwoFactorAuthenticationStory.story.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/__stories__/TwoFactorAuthenticationStory.story.tsx
@@ -5,14 +5,17 @@ import React from "react"
 import { SystemContextProvider } from "Artsy"
 import { TwoFactorAuthenticationQueryRenderer } from "../"
 
-storiesOf("UserSettings/TwoFactorAuthentication", module).add("Live", () => {
-  return (
-    <SystemContextProvider>
-      <Theme>
-        <Box maxWidth="800px">
-          <TwoFactorAuthenticationQueryRenderer />
-        </Box>
-      </Theme>
-    </SystemContextProvider>
-  )
-})
+storiesOf("Components/UserSettings/TwoFactorAuthentication", module).add(
+  "Live",
+  () => {
+    return (
+      <SystemContextProvider>
+        <Theme>
+          <Box maxWidth="800px">
+            <TwoFactorAuthenticationQueryRenderer />
+          </Box>
+        </Theme>
+      </SystemContextProvider>
+    )
+  }
+)

--- a/src/Components/UserSettings/TwoFactorAuthentication/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Serif } from "@artsy/palette"
+import { Box, Flex, Serif, Sans } from "@artsy/palette"
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
@@ -28,9 +28,9 @@ const TwoFactorAuthentication: React.FC<TwoFactorAuthenticationProps> = props =>
           Two-factor Authentication
         </Serif>
         {me.hasSecondFactorEnabled && (
-          <Serif ml={1} size="4" color="green100">
+          <Sans ml={1} size="4" color="green100">
             Enabled
-          </Serif>
+          </Sans>
         )}
       </Flex>
       <Serif mt={1} size="3t" maxWidth="515px" color="black60">


### PR DESCRIPTION
Lots of small tweaks

- Add 2FA method disable confirmation prompt
- Update 2FA enrollment API modal to use Palette dialog
- Remove stray character in app authenticator 2FA enrollment modal
- Add step numbers to app authenticator 2FA enrollment modal
- Center show secret app authenticator 2FA enrollment button
- Set loading/disabled props on 2FA enrollment buttons …
- Wait until 2FA refetch completes before dismissing setup modal
- Update "Enabled" typography to Sans style

## Screen Recording

![Peek 2020-05-08 16-36](https://user-images.githubusercontent.com/123595/81447214-3a4db500-914a-11ea-87f6-040ab95dc407.gif)
![Peek 2020-05-08 16-37](https://user-images.githubusercontent.com/123595/81447211-3883f180-914a-11ea-9387-e9af67111c7f.gif)



