### PR TITLE
Responsive conversations layout

### DIFF
--- a/src/Apps/Conversation/Components/Conversation.tsx
+++ b/src/Apps/Conversation/Components/Conversation.tsx
@@ -1,32 +1,21 @@
 import {
-  ArrowLeftIcon,
   color,
   Flex,
   Image,
-  InfoCircleIcon,
   Link,
   Sans,
   Serif,
   Spacer,
+  Box,
 } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
-import { RouterLink } from "Artsy/Router/RouterLink"
 import { DateTime } from "luxon"
 import React from "react"
 import { createFragmentContainer, RelayProp } from "react-relay"
 import { graphql } from "relay-runtime"
-import styled from "styled-components"
 import { MessageFragmentContainer as Message } from "./Message"
 import { Reply } from "./Reply"
 import { fromToday, TimeSince } from "./TimeSince"
-
-const StyledHeader = styled(Flex)`
-  position: fixed;
-  background: white;
-  border-bottom: 1px solid ${color("black10")};
-  height: 55px;
-  top: 59px;
-`
 
 interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
@@ -124,35 +113,23 @@ export interface ConversationProps {
 const Conversation: React.FC<ConversationProps> = props => {
   const { conversation, relay } = props
   return (
-    <>
-      <StyledHeader
-        px={2}
-        alignItems="center"
-        justifyContent="space-between"
-        width="100%"
-      >
-        <RouterLink to={`/user/conversations`}>
-          <ArrowLeftIcon />
-        </RouterLink>
-        <Sans size="3t" weight="medium">
-          Inquiry with {conversation.to.name}
-        </Sans>
-        <InfoCircleIcon />
-      </StyledHeader>
-      <Spacer mt="45px" />
-      <Flex flexDirection="column" width="100%" px={1}>
-        {conversation.items.map((i, idx) => (
-          <Item
-            item={i.item}
-            key={
-              i.item.__typename === "Artwork" || i.item.__typename === "Show"
-                ? i.item.id
-                : idx
-            }
-          />
-        ))}
-        {groupMessages(conversation.messages.edges.map(edge => edge.node)).map(
-          (messageGroup, groupIndex) => {
+    <Flex flexDirection="column" width="100%">
+      <Box>
+        <Spacer mt="45px" />
+        <Flex flexDirection="column" width="100%" px={1}>
+          {conversation.items.map((i, idx) => (
+            <Item
+              item={i.item}
+              key={
+                i.item.__typename === "Artwork" || i.item.__typename === "Show"
+                  ? i.item.id
+                  : idx
+              }
+            />
+          ))}
+          {groupMessages(
+            conversation.messages.edges.map(edge => edge.node)
+          ).map((messageGroup, groupIndex) => {
             const today = fromToday(messageGroup[0].createdAt)
             return (
               <React.Fragment
@@ -189,12 +166,12 @@ const Conversation: React.FC<ConversationProps> = props => {
                 })}
               </React.Fragment>
             )
-          }
-        )}
-        <Spacer mb={9} />
-        <Reply conversation={conversation} environment={relay.environment} />
-      </Flex>
-    </>
+          })}
+          <Spacer mb={9} />
+        </Flex>
+      </Box>
+      <Reply conversation={conversation} environment={relay.environment} />
+    </Flex>
   )
 }
 

--- a/src/Apps/Conversation/Components/ConversationSnippet.tsx
+++ b/src/Apps/Conversation/Components/ConversationSnippet.tsx
@@ -59,7 +59,7 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
         href={`/user/conversations/${conversation.internalID}`}
         underlineBehavior="none"
       >
-        <Flex alignItems="center" px={1} width="100%" height="120px">
+        <Flex alignItems="center" width="100%" height="120px">
           <StyledFlex alignItems="center" height="80px" width="80px">
             {imageURL ? (
               <StyledImage
@@ -82,21 +82,21 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
                 <Flex width="100%" justifyContent="space-between">
                   <Flex>
                     <Sans
-                      size="3"
+                      size="3t"
                       weight="medium"
                       mr="5px"
                       color={conversation.unread ? "black" : "black60"}
                     >
                       {partnerName}
                     </Sans>
-                    <Sans size="3" color={"black30"}>
-                      (message count)
+                    <Sans size="3t" color={"black30"}>
+                      {conversation.messagesConnection.totalCount}
                     </Sans>
                   </Flex>
                   <Flex>
                     <TimeSince
                       time={conversation.lastMessageAt}
-                      size="3"
+                      size="3t"
                       mr="5px"
                     />
                   </Flex>
@@ -114,7 +114,7 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
           </Flex>
         </Flex>
       </Link>
-      <Separator mx={1} width="auto" />
+      <Separator width="auto" />
     </Box>
   )
 }
@@ -152,6 +152,9 @@ export const ConversationSnippetFragmentContainer = createFragmentContainer(
               }
             }
           }
+        }
+        messagesConnection {
+          totalCount
         }
       }
     `,

--- a/src/Apps/Conversation/Components/Conversations.tsx
+++ b/src/Apps/Conversation/Components/Conversations.tsx
@@ -1,9 +1,19 @@
-import { Box, Sans, Separator } from "@artsy/palette"
+import { Box, media, color, space } from "@artsy/palette"
 import { Conversations_me } from "__generated__/Conversations_me.graphql"
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { ConversationSnippetFragmentContainer as ConversationSnippet } from "./ConversationSnippet"
 import { NoMessages } from "./NoMessages"
+import styled from "styled-components"
+
+const Container = styled(Box)`
+  min-height: 100vh;
+  border-right: 1px solid ${color("black10")};
+  padding-top: ${space(2)}px;
+  ${media.xs`
+    border-right: none;
+  `};
+`
 
 interface ConversationsProps {
   me: Conversations_me
@@ -14,19 +24,19 @@ const Conversations: React.FC<ConversationsProps> = props => {
   const { me } = props
   const conversations = me.conversationsConnection.edges
   return (
-    <Box px={1} height="calc(100vh - 180px)">
-      <Sans size="6" weight="medium" ml={1}>
-        Inbox
-      </Sans>
-      <Separator mt={2} />
-      {conversations.length ? (
-        conversations.map(edge => (
-          <ConversationSnippet conversation={edge.node} key={edge.cursor} />
-        ))
-      ) : (
-        <NoMessages />
-      )}
-    </Box>
+    <>
+      <Container width={["100%", "375px"]}>
+        {conversations.length ? (
+          <Box px={[2, 3]}>
+            {conversations.map(edge => (
+              <ConversationSnippet conversation={edge.node} key={edge.cursor} />
+            ))}
+          </Box>
+        ) : (
+          <NoMessages />
+        )}
+      </Container>
+    </>
   )
 }
 
@@ -50,6 +60,7 @@ export const ConversationsFragmentContainer = createRefetchContainer(
           edges {
             cursor
             node {
+              id
               internalID
               lastMessage
               ...ConversationSnippet_conversation

--- a/src/Apps/Conversation/Components/Details.tsx
+++ b/src/Apps/Conversation/Components/Details.tsx
@@ -1,0 +1,17 @@
+import { Flex, FlexProps, color } from "@artsy/palette"
+import React, { FC } from "react"
+import styled from "styled-components"
+
+const BorderedFlex = styled(Flex)`
+  border-left: 1px solid ${color("black10")};
+  flex-shrink: 0;
+  margin-left: -1px;
+`
+
+export const Details: FC<FlexProps> = props => {
+  return (
+    <BorderedFlex flexShrink={0} {...props}>
+      Details...
+    </BorderedFlex>
+  )
+}

--- a/src/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/Apps/Conversation/Components/InboxHeaders.tsx
@@ -1,0 +1,111 @@
+import React, { FC } from "react"
+import styled from "styled-components"
+import {
+  Flex,
+  ArrowLeftIcon,
+  color,
+  Sans,
+  InfoCircleIcon,
+  Separator,
+  FlexProps,
+} from "@artsy/palette"
+import { RouterLink } from "Artsy/Router/RouterLink"
+import { Media } from "Utils/Responsive"
+
+interface BorderedFlexProps extends FlexProps {
+  bordered?: boolean
+}
+const BorderedFlex = styled(Flex)<BorderedFlexProps>`
+  ${props =>
+    props.bordered ? `border-right: 1px solid ${color("black10")};` : ""}
+  height: 100%;
+`
+
+const ConversationHeaderContainer = styled(Flex)`
+  position: fixed;
+  top: 59px;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid ${color("black10")};
+  background: white;
+`
+
+interface ConversationHeaderProps {
+  partnerName: string
+}
+export const ConversationHeader: FC<ConversationHeaderProps> = ({
+  partnerName,
+}) => {
+  return (
+    <ConversationHeaderContainer
+      height="55px"
+      px={2}
+      alignItems="center"
+      justifyContent="space-between"
+      width="100%"
+    >
+      <RouterLink to={`/user/conversations`}>
+        <ArrowLeftIcon />
+      </RouterLink>
+      <Sans size="3t" weight="medium">
+        Conversation with {partnerName}
+      </Sans>
+      <InfoCircleIcon />
+    </ConversationHeaderContainer>
+  )
+}
+
+export const InboxHeader: FC<BorderedFlexProps> = props => {
+  return (
+    <BorderedFlex justifyContent="flex-end" flexDirection="column" {...props}>
+      <Sans size="6" weight="medium" ml={1}>
+        Inbox
+      </Sans>
+      <Separator mt={1} />
+    </BorderedFlex>
+  )
+}
+
+export const DetailsHeader: FC<BorderedFlexProps> = props => {
+  return (
+    <Flex flexDirection="column" {...props}>
+      <Sans size="4" ml={2}>
+        Details
+      </Sans>
+      <Separator mt={1} />
+    </Flex>
+  )
+}
+
+export const FullHeader: FC<Partial<ConversationHeaderProps>> = props => {
+  return (
+    <Flex
+      height="85px"
+      width="100%"
+      justifyContent="space-between"
+      alignItems="flex-end"
+    >
+      <InboxHeader width="375px" bordered flexShrink={0} />
+      <BorderedFlex
+        bordered
+        flexDirection="column"
+        width="100%"
+        justifyContent="flex-end"
+      >
+        {props.partnerName ? (
+          <Sans size="4" ml={2}>
+            Conversation with {props.partnerName}
+          </Sans>
+        ) : (
+          <>{props.children}</>
+        )}
+        <Separator mt={1} />
+      </BorderedFlex>
+      <Flex flexShrink={0} height="100%" alignItems="flex-end">
+        <Media greaterThan="lg">
+          <DetailsHeader width="375px" />
+        </Media>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/Apps/Conversation/Components/Reply.tsx
+++ b/src/Apps/Conversation/Components/Reply.tsx
@@ -1,17 +1,22 @@
-import { Button, color, Flex, media } from "@artsy/palette"
+import { Button, color, Flex, media, FlexProps } from "@artsy/palette"
 import { Conversation_conversation } from "__generated__/Conversation_conversation.graphql"
 import React, { useRef, useState } from "react"
 import { Environment } from "react-relay"
 import styled from "styled-components"
 import { SendConversationMessage } from "../Mutation/SendConversationMessage"
+import { right, RightProps } from "styled-system"
 
-const StyledFlex = styled(Flex)`
+const StyledFlex = styled(Flex)<FlexProps & RightProps>`
+  ${right};
   border-top: 1px solid ${color("black10")};
   position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
   background: white;
+  bottom: 0;
+  left: 375px;
+  ${media.xs`
+    width: 100%;
+    left: 0;
+  `}
 `
 
 const FullWidthFlex = styled(Flex)<{ height?: string }>`
@@ -49,7 +54,7 @@ export const Reply: React.FC<ReplyProps> = props => {
   const textArea = useRef()
 
   return (
-    <StyledFlex p={1}>
+    <StyledFlex p={1} right={[0, null, null, null, "376px"]}>
       <FullWidthFlex width="100%">
         <StyledTextArea
           onInput={event => {

--- a/src/Apps/Conversation/Components/TimeSince.tsx
+++ b/src/Apps/Conversation/Components/TimeSince.tsx
@@ -24,7 +24,6 @@ const exactDate = (time: string) => {
   }
   const date = DateTime.fromISO(time)
   const daysSince = daysSinceDate(date)
-  console.log("days since", daysSince)
   if (daysSince === 0) {
     return `Today ${date.toFormat("t")}`
   } else if (daysSince === 1) {

--- a/src/Apps/Conversation/ConversationApp.tsx
+++ b/src/Apps/Conversation/ConversationApp.tsx
@@ -1,48 +1,93 @@
 import { ConversationApp_me } from "__generated__/ConversationApp_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationsFragmentContainer as Conversations } from "Apps/Conversation/Components/Conversations"
-import { SystemContext } from "Artsy"
 import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
-import { ErrorPage } from "Components/ErrorPage"
-import { Match } from "found"
-import React, { useContext } from "react"
+import { Match, Router } from "found"
+import React, { useEffect, useState } from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
-import { userHasLabFeature } from "Utils/user"
+import { Flex, Spinner, breakpoints } from "@artsy/palette"
+import { debounce } from "lodash"
 
 interface ConversationAppProps {
   me: ConversationApp_me
   match: Match
+  router: Router
+}
+
+const getViewWidth = () => {
+  return Math.max(
+    window.document.documentElement.clientWidth,
+    window.innerWidth || 0
+  )
 }
 
 export const ConversationApp: React.FC<ConversationAppProps> = props => {
-  const { me } = props
-  const { user } = useContext(SystemContext)
-  const isEnabled = userHasLabFeature(user, "User Conversations View")
-  if (isEnabled) {
-    const route = findCurrentRoute(props.match)
-    let maxWidth
+  const { me, router } = props
+  const [width, setWidth] = useState(0)
+  const route = findCurrentRoute(props.match)
+  let maxWidth
 
-    if (route.displayFullPage) {
-      maxWidth = "100%"
+  const conversation = me.conversationsConnection.edges[0]?.node
+
+  useEffect(() => {
+    setWidth(getViewWidth())
+    const listenForResize = debounce(() => {
+      setWidth(getViewWidth())
+    })
+    window.addEventListener("resize", listenForResize)
+    return () => window.removeEventListener("resize", listenForResize)
+  }, [])
+
+  useEffect(() => {
+    if (width > breakpoints.xs && conversation && router) {
+      router.replace(`/user/conversations/${conversation.internalID}`)
     }
-    return (
-      <AppContainer maxWidth={maxWidth}>
-        <Title>My Inquiries | Artsy</Title>
-        <Conversations me={me} />
-      </AppContainer>
-    )
-  } else {
-    // not allowed to see this view
-    return <ErrorPage code={404} />
+  }, [router, conversation, width])
+
+  if (route.displayFullPage) {
+    maxWidth = "100%"
   }
+  return (
+    <AppContainer maxWidth={maxWidth}>
+      <Title>Conversations | Artsy</Title>
+      <Conversations me={me} />
+      <Flex
+        display={["none", "flex"]}
+        height="100%"
+        width="100%"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Spinner />
+      </Flex>
+    </AppContainer>
+  )
 }
 
 export const ConversationAppFragmentContainer = createFragmentContainer(
   ConversationApp,
   {
     me: graphql`
-      fragment ConversationApp_me on Me {
+      fragment ConversationApp_me on Me
+        @argumentDefinitions(
+          first: { type: "Int", defaultValue: 10 }
+          last: { type: "Int" }
+          after: { type: "String" }
+          before: { type: "String" }
+        ) {
+        conversationsConnection(
+          first: $first
+          last: $last
+          before: $before
+          after: $after
+        ) {
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
         ...Conversations_me
       }
     `,

--- a/src/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/Apps/Conversation/Routes/Conversation/index.tsx
@@ -6,7 +6,7 @@ import { ConversationsFragmentContainer as Conversations } from "Apps/Conversati
 import { SystemContext } from "Artsy"
 import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "Components/ErrorPage"
-import { Match, Router } from "found"
+import { Match } from "found"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { userHasLabFeature } from "Utils/user"
@@ -21,11 +21,10 @@ interface ConversationRouteProps {
   me: Conversations_me & Conversation_me
   conversationID: string
   match: Match
-  router: Router
 }
 
 export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
-  const { me, router } = props
+  const { me } = props
   const { user } = useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "User Conversations View")
   if (isEnabled) {

--- a/src/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/Apps/Conversation/Routes/Conversation/index.tsx
@@ -1,23 +1,31 @@
-import { Title } from "@artsy/palette"
+import { Title, Flex } from "@artsy/palette"
 import { Conversation_me } from "__generated__/Conversation_me.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ConversationFragmentContainer as Conversation } from "Apps/Conversation/Components/Conversation"
+import { ConversationsFragmentContainer as Conversations } from "Apps/Conversation/Components/Conversations"
 import { SystemContext } from "Artsy"
 import { findCurrentRoute } from "Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "Components/ErrorPage"
-import { Match } from "found"
+import { Match, Router } from "found"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { userHasLabFeature } from "Utils/user"
-
+import { Media } from "Utils/Responsive"
+import { Conversations_me } from "__generated__/Conversations_me.graphql"
+import {
+  FullHeader,
+  ConversationHeader,
+} from "Apps/Conversation/Components/InboxHeaders"
+import { Details } from "../../Components/Details"
 interface ConversationRouteProps {
-  me: Conversation_me
+  me: Conversations_me & Conversation_me
   conversationID: string
   match: Match
+  router: Router
 }
 
 export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
-  const { me } = props
+  const { me, router } = props
   const { user } = useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "User Conversations View")
   if (isEnabled) {
@@ -30,7 +38,23 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
     return (
       <AppContainer maxWidth={maxWidth}>
         <Title>Inbox | Artsy</Title>
-        <Conversation conversation={me.conversation} />
+
+        <Media at="xs">
+          <ConversationHeader partnerName={me.conversation.to.name} />
+        </Media>
+        <Media greaterThan="xs">
+          <FullHeader partnerName={me.conversation.to.name} />
+        </Media>
+        <Flex>
+          <Media greaterThan="xs">
+            <Conversations me={me as any} />
+          </Media>
+          <Conversation conversation={me.conversation} />
+          <Details
+            display={["none", null, null, null, "flex"]}
+            width={["100%", "376px"]}
+          />
+        </Flex>
       </AppContainer>
     )
   } else {
@@ -45,7 +69,11 @@ export const ConversationFragmentContainer = createFragmentContainer(
     me: graphql`
       fragment Conversation_me on Me
         @argumentDefinitions(conversationID: { type: "String!" }) {
+        ...Conversations_me
         conversation(id: $conversationID) {
+          to {
+            name
+          }
           ...Conversation_conversation
         }
       }

--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -28,6 +28,7 @@ const render = (me: ConversationAppTestQueryRawResponse["me"], user: User) =>
           ...me,
         }}
         match={({ route: { displayFullPage: true } } as unknown) as Match}
+        router={{ replace: () => {} } as any}
         {...props}
       />
     ),
@@ -68,7 +69,7 @@ describe("Conversation app", () => {
         }
         const component = await render(mockMe, userType)
         const text = component.text()
-        expect(text).toContain("InboxAshkan Gallery(message count)")
+        expect(text).toContain("Ashkan Gallery12 months ago")
       })
     })
     describe("without previous conversations", () => {

--- a/src/Apps/__tests__/Fixtures/Conversation.ts
+++ b/src/Apps/__tests__/Fixtures/Conversation.ts
@@ -53,4 +53,15 @@ export const MockedConversation = {
       },
     ],
   },
+  messagesConnection: {
+    totalCount: 1,
+    edges: [
+      {
+        node: {
+          ...Message,
+        },
+        cursor: "message1",
+      },
+    ],
+  },
 } as const

--- a/src/__generated__/ConversationAppTestQuery.graphql.ts
+++ b/src/__generated__/ConversationAppTestQuery.graphql.ts
@@ -12,9 +12,9 @@ export type ConversationAppTestQueryRawResponse = {
     readonly me: ({
         readonly conversationsConnection: ({
             readonly edges: ReadonlyArray<({
-                readonly cursor: string;
                 readonly node: ({
                     readonly internalID: string | null;
+                    readonly id: string | null;
                     readonly lastMessage: string | null;
                     readonly to: {
                         readonly name: string;
@@ -48,8 +48,11 @@ export type ConversationAppTestQueryRawResponse = {
                             readonly id: string | null;
                         }) | null;
                     }) | null> | null;
-                    readonly id: string | null;
+                    readonly messagesConnection: ({
+                        readonly totalCount: number | null;
+                    }) | null;
                 }) | null;
+                readonly cursor: string;
             }) | null> | null;
             readonly pageInfo: {
                 readonly endCursor: string | null;
@@ -78,6 +81,14 @@ query ConversationAppTestQuery {
 }
 
 fragment ConversationApp_me on Me {
+  conversationsConnection(first: 10) {
+    edges {
+      node {
+        internalID
+        id
+      }
+    }
+  }
   ...Conversations_me
 }
 
@@ -116,6 +127,9 @@ fragment ConversationSnippet_conversation on Conversation {
       }
     }
   }
+  messagesConnection {
+    totalCount
+  }
 }
 
 fragment Conversations_me on Me {
@@ -123,10 +137,10 @@ fragment Conversations_me on Me {
     edges {
       cursor
       node {
+        id
         internalID
         lastMessage
         ...ConversationSnippet_conversation
-        id
       }
     }
     pageInfo {
@@ -143,20 +157,20 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v1 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v2 = [
-  (v0/*: any*/),
-  (v1/*: any*/)
+  (v1/*: any*/),
+  (v0/*: any*/)
 ],
 v3 = [
   {
@@ -233,13 +247,6 @@ return {
                 "plural": true,
                 "selections": [
                   {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "cursor",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
                     "kind": "LinkedField",
                     "alias": null,
                     "name": "node",
@@ -255,6 +262,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v0/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -311,7 +319,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
+                              (v0/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "Artwork",
@@ -363,7 +371,7 @@ return {
                                     "plural": false,
                                     "selections": (v2/*: any*/)
                                   },
-                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -380,8 +388,32 @@ return {
                           }
                         ]
                       },
-                      (v1/*: any*/)
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "messagesConnection",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "totalCount",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
                     ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
@@ -426,7 +458,7 @@ return {
               }
             ]
           },
-          (v1/*: any*/)
+          (v0/*: any*/)
         ]
       }
     ]
@@ -435,7 +467,7 @@ return {
     "operationKind": "query",
     "name": "ConversationAppTestQuery",
     "id": null,
-    "text": "query ConversationAppTestQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
+    "text": "query ConversationAppTestQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ConversationApp_me.graphql.ts
+++ b/src/__generated__/ConversationApp_me.graphql.ts
@@ -3,6 +3,13 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ConversationApp_me = {
+    readonly conversationsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"Conversations_me">;
     readonly " $refType": "ConversationApp_me";
 };
@@ -19,8 +26,94 @@ const node: ReaderFragment = {
   "name": "ConversationApp_me",
   "type": "Me",
   "metadata": null,
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "first",
+      "type": "Int",
+      "defaultValue": 10
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "last",
+      "type": "Int",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "after",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "before",
+      "type": "String",
+      "defaultValue": null
+    }
+  ],
   "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "conversationsConnection",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "after",
+          "variableName": "after"
+        },
+        {
+          "kind": "Variable",
+          "name": "before",
+          "variableName": "before"
+        },
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first"
+        },
+        {
+          "kind": "Variable",
+          "name": "last",
+          "variableName": "last"
+        }
+      ],
+      "concreteType": "ConversationConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ConversationEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Conversation",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "internalID",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     {
       "kind": "FragmentSpread",
       "name": "Conversations_me",
@@ -28,5 +121,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '354ef28cb5343963c0a7b97c145b37ad';
+(node as any).hash = 'd4c7e79711b6ea55474086ffe47c6b7a';
 export default node;

--- a/src/__generated__/ConversationSnippet_conversation.graphql.ts
+++ b/src/__generated__/ConversationSnippet_conversation.graphql.ts
@@ -34,6 +34,9 @@ export type ConversationSnippet_conversation = {
             readonly __typename: "%other";
         }) | null;
     } | null> | null;
+    readonly messagesConnection: {
+        readonly totalCount: number | null;
+    } | null;
     readonly " $refType": "ConversationSnippet_conversation";
 };
 export type ConversationSnippet_conversation$data = ConversationSnippet_conversation;
@@ -201,9 +204,27 @@ return {
           ]
         }
       ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "messagesConnection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "MessageConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "totalCount",
+          "args": null,
+          "storageKey": null
+        }
+      ]
     }
   ]
 };
 })();
-(node as any).hash = '51a731d89429f7b46a9000aed66aec62';
+(node as any).hash = '7c190393600756ef1792697f632a80cc';
 export default node;

--- a/src/__generated__/Conversation_me.graphql.ts
+++ b/src/__generated__/Conversation_me.graphql.ts
@@ -4,8 +4,12 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Conversation_me = {
     readonly conversation: {
+        readonly to: {
+            readonly name: string;
+        };
         readonly " $fragmentRefs": FragmentRefs<"Conversation_conversation">;
     } | null;
+    readonly " $fragmentRefs": FragmentRefs<"Conversations_me">;
     readonly " $refType": "Conversation_me";
 };
 export type Conversation_me$data = Conversation_me;
@@ -46,13 +50,36 @@ const node: ReaderFragment = {
       "plural": false,
       "selections": [
         {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "to",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ConversationResponder",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "name",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
           "kind": "FragmentSpread",
           "name": "Conversation_conversation",
           "args": null
         }
       ]
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "Conversations_me",
+      "args": null
     }
   ]
 };
-(node as any).hash = '18150510f9877cb7750c9445cf147f55';
+(node as any).hash = '0a5275d37558df9dbd891eaca35402e1';
 export default node;

--- a/src/__generated__/ConversationsQuery.graphql.ts
+++ b/src/__generated__/ConversationsQuery.graphql.ts
@@ -68,6 +68,9 @@ fragment ConversationSnippet_conversation on Conversation {
       }
     }
   }
+  messagesConnection {
+    totalCount
+  }
 }
 
 fragment Conversations_me_pbnwq on Me {
@@ -75,10 +78,10 @@ fragment Conversations_me_pbnwq on Me {
     edges {
       cursor
       node {
+        id
         internalID
         lastMessage
         ...ConversationSnippet_conversation
-        id
       }
     }
     pageInfo {
@@ -143,20 +146,20 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v4 = [
-  (v2/*: any*/),
-  (v3/*: any*/)
+  (v3/*: any*/),
+  (v2/*: any*/)
 ],
 v5 = [
   {
@@ -242,6 +245,7 @@ return {
                     "concreteType": "Conversation",
                     "plural": false,
                     "selections": [
+                      (v2/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -305,7 +309,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v3/*: any*/),
+                              (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "Artwork",
@@ -357,7 +361,7 @@ return {
                                     "plural": false,
                                     "selections": (v4/*: any*/)
                                   },
-                                  (v2/*: any*/),
+                                  (v3/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -374,7 +378,24 @@ return {
                           }
                         ]
                       },
-                      (v3/*: any*/)
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "messagesConnection",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "totalCount",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -420,7 +441,7 @@ return {
               }
             ]
           },
-          (v3/*: any*/)
+          (v2/*: any*/)
         ]
       }
     ]
@@ -429,7 +450,7 @@ return {
     "operationKind": "query",
     "name": "ConversationsQuery",
     "id": null,
-    "text": "query ConversationsQuery(\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...Conversations_me_pbnwq\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversations_me_pbnwq on Me {\n  conversationsConnection(first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      cursor\n      node {\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
+    "text": "query ConversationsQuery(\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...Conversations_me_pbnwq\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me_pbnwq on Me {\n  conversationsConnection(first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/Conversations_me.graphql.ts
+++ b/src/__generated__/Conversations_me.graphql.ts
@@ -7,6 +7,7 @@ export type Conversations_me = {
         readonly edges: ReadonlyArray<{
             readonly cursor: string;
             readonly node: {
+                readonly id: string;
                 readonly internalID: string | null;
                 readonly lastMessage: string | null;
                 readonly " $fragmentRefs": FragmentRefs<"ConversationSnippet_conversation">;
@@ -119,6 +120,13 @@ const node: ReaderFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
                   "name": "internalID",
                   "args": null,
                   "storageKey": null
@@ -182,5 +190,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'e94e07540fbe2e24b795e52d48c2b76f';
+(node as any).hash = '9a2f916205ca98143386672e8d86d642';
 export default node;

--- a/src/__generated__/routes_ConversationQuery.graphql.ts
+++ b/src/__generated__/routes_ConversationQuery.graphql.ts
@@ -24,6 +24,14 @@ query routes_ConversationQuery {
 }
 
 fragment ConversationApp_me on Me {
+  conversationsConnection(first: 10) {
+    edges {
+      node {
+        internalID
+        id
+      }
+    }
+  }
   ...Conversations_me
 }
 
@@ -62,6 +70,9 @@ fragment ConversationSnippet_conversation on Conversation {
       }
     }
   }
+  messagesConnection {
+    totalCount
+  }
 }
 
 fragment Conversations_me on Me {
@@ -69,10 +80,10 @@ fragment Conversations_me on Me {
     edges {
       cursor
       node {
+        id
         internalID
         lastMessage
         ...ConversationSnippet_conversation
-        id
       }
     }
     pageInfo {
@@ -89,20 +100,20 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v1 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v2 = [
-  (v0/*: any*/),
-  (v1/*: any*/)
+  (v1/*: any*/),
+  (v0/*: any*/)
 ],
 v3 = [
   {
@@ -179,13 +190,6 @@ return {
                 "plural": true,
                 "selections": [
                   {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "cursor",
-                    "args": null,
-                    "storageKey": null
-                  },
-                  {
                     "kind": "LinkedField",
                     "alias": null,
                     "name": "node",
@@ -201,6 +205,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v0/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -257,7 +262,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
+                              (v0/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "Artwork",
@@ -309,7 +314,7 @@ return {
                                     "plural": false,
                                     "selections": (v2/*: any*/)
                                   },
-                                  (v0/*: any*/),
+                                  (v1/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -326,8 +331,32 @@ return {
                           }
                         ]
                       },
-                      (v1/*: any*/)
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "messagesConnection",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "totalCount",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
                     ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
@@ -372,7 +401,7 @@ return {
               }
             ]
           },
-          (v1/*: any*/)
+          (v0/*: any*/)
         ]
       }
     ]
@@ -381,7 +410,7 @@ return {
     "operationKind": "query",
     "name": "routes_ConversationQuery",
     "id": null,
-    "text": "query routes_ConversationQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
+    "text": "query routes_ConversationQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_DetailQuery.graphql.ts
+++ b/src/__generated__/routes_DetailQuery.graphql.ts
@@ -27,6 +27,46 @@ query routes_DetailQuery(
   }
 }
 
+fragment ConversationSnippet_conversation on Conversation {
+  internalID
+  to {
+    name
+    id
+  }
+  lastMessage
+  lastMessageAt
+  unread
+  items {
+    item {
+      __typename
+      ... on Artwork {
+        date
+        title
+        artistNames
+        image {
+          url
+        }
+      }
+      ... on Show {
+        fair {
+          name
+          id
+        }
+        name
+        coverImage {
+          url
+        }
+      }
+      ... on Node {
+        id
+      }
+    }
+  }
+  messagesConnection {
+    totalCount
+  }
+}
+
 fragment Conversation_conversation on Conversation {
   id
   internalID
@@ -94,9 +134,34 @@ fragment Conversation_conversation on Conversation {
 }
 
 fragment Conversation_me_3oGfhn on Me {
+  ...Conversations_me
   conversation(id: $conversationID) {
+    to {
+      name
+      id
+    }
     ...Conversation_conversation
     id
+  }
+}
+
+fragment Conversations_me on Me {
+  conversationsConnection(first: 10) {
+    edges {
+      cursor
+      node {
+        id
+        internalID
+        lastMessage
+        ...ConversationSnippet_conversation
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      startCursor
+    }
   }
 }
 
@@ -131,32 +196,152 @@ var v0 = [
 v1 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "cursor",
   "args": null,
   "storageKey": null
 },
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "internalID",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "email",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v5 = [
+  (v4/*: any*/),
+  (v2/*: any*/)
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "unread",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "date",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artistNames",
+  "args": null,
+  "storageKey": null
+},
+v11 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v12 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": (v11/*: any*/)
+},
+v13 = {
+  "kind": "InlineFragment",
+  "type": "Show",
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "fair",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Fair",
+      "plural": false,
+      "selections": (v5/*: any*/)
+    },
+    (v4/*: any*/),
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "coverImage",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": (v11/*: any*/)
+    }
+  ]
+},
+v14 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "endCursor",
+  "args": null,
+  "storageKey": null
+},
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "hasNextPage",
+  "args": null,
+  "storageKey": null
+},
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "hasPreviousPage",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "startCursor",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "email",
+  "args": null,
+  "storageKey": null
+},
+v19 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -166,22 +351,6 @@ v5 = [
     "kind": "Literal",
     "name": "sort",
     "value": "DESC"
-  }
-],
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "__typename",
-  "args": null,
-  "storageKey": null
-},
-v7 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "url",
-    "args": null,
-    "storageKey": null
   }
 ];
 return {
@@ -234,6 +403,141 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "conversationsConnection",
+            "storageKey": "conversationsConnection(first:10)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
+              }
+            ],
+            "concreteType": "ConversationConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "plural": true,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "lastMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "to",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ConversationResponder",
+                        "plural": false,
+                        "selections": (v5/*: any*/)
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "lastMessageAt",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "items",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ConversationItem",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "item",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": null,
+                            "plural": false,
+                            "selections": [
+                              (v7/*: any*/),
+                              (v2/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "type": "Artwork",
+                                "selections": [
+                                  (v8/*: any*/),
+                                  (v9/*: any*/),
+                                  (v10/*: any*/),
+                                  (v12/*: any*/)
+                                ]
+                              },
+                              (v13/*: any*/)
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "messagesConnection",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "totalCount",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
+                  (v17/*: any*/)
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "conversation",
             "storageKey": null,
             "args": [
@@ -246,22 +550,6 @@ return {
             "concreteType": "Conversation",
             "plural": false,
             "selections": [
-              (v1/*: any*/),
-              (v2/*: any*/),
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "from",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ConversationInitiator",
-                "plural": false,
-                "selections": [
-                  (v3/*: any*/),
-                  (v4/*: any*/),
-                  (v1/*: any*/)
-                ]
-              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -271,15 +559,31 @@ return {
                 "concreteType": "ConversationResponder",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v2/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "initials",
                     "args": null,
                     "storageKey": null
-                  },
-                  (v1/*: any*/)
+                  }
+                ]
+              },
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "from",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ConversationInitiator",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v18/*: any*/),
+                  (v2/*: any*/)
                 ]
               },
               {
@@ -296,19 +600,13 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "unread",
-                "args": null,
-                "storageKey": null
-              },
+              (v6/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "messages",
                 "storageKey": "messages(first:30,sort:\"DESC\")",
-                "args": (v5/*: any*/),
+                "args": (v19/*: any*/),
                 "concreteType": "MessageConnection",
                 "plural": false,
                 "selections": [
@@ -321,34 +619,10 @@ return {
                     "concreteType": "PageInfo",
                     "plural": false,
                     "selections": [
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "startCursor",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "endCursor",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "hasPreviousPage",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "hasNextPage",
-                        "args": null,
-                        "storageKey": null
-                      }
+                      (v17/*: any*/),
+                      (v14/*: any*/),
+                      (v16/*: any*/),
+                      (v15/*: any*/)
                     ]
                   },
                   {
@@ -369,8 +643,8 @@ return {
                         "concreteType": "Message",
                         "plural": false,
                         "selections": [
-                          (v1/*: any*/),
                           (v2/*: any*/),
+                          (v3/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -401,8 +675,8 @@ return {
                             "concreteType": "MessageInitiator",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
-                              (v4/*: any*/)
+                              (v4/*: any*/),
+                              (v18/*: any*/)
                             ]
                           },
                           {
@@ -414,8 +688,8 @@ return {
                             "concreteType": "Attachment",
                             "plural": true,
                             "selections": [
-                              (v1/*: any*/),
                               (v2/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -439,16 +713,10 @@ return {
                               }
                             ]
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ]
                       },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "cursor",
-                        "args": null,
-                        "storageKey": null
-                      }
+                      (v1/*: any*/)
                     ]
                   }
                 ]
@@ -457,7 +725,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "messages",
-                "args": (v5/*: any*/),
+                "args": (v19/*: any*/),
                 "handle": "connection",
                 "key": "Messages_messages",
                 "filters": []
@@ -480,33 +748,15 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v1/*: any*/),
+                      (v7/*: any*/),
+                      (v2/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "type": "Artwork",
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "artistNames",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -514,55 +764,17 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "image",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": (v7/*: any*/)
-                          }
+                          (v12/*: any*/)
                         ]
                       },
-                      {
-                        "kind": "InlineFragment",
-                        "type": "Show",
-                        "selections": [
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "fair",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Fair",
-                            "plural": false,
-                            "selections": [
-                              (v3/*: any*/),
-                              (v1/*: any*/)
-                            ]
-                          },
-                          (v3/*: any*/),
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "coverImage",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "plural": false,
-                            "selections": (v7/*: any*/)
-                          }
-                        ]
-                      }
+                      (v13/*: any*/)
                     ]
                   }
                 ]
               }
             ]
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ]
       }
     ]
@@ -571,7 +783,7 @@ return {
     "operationKind": "query",
     "name": "routes_DetailQuery",
     "id": null,
-    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  conversation(id: $conversationID) {\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
+    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messages(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...Conversations_me\n  conversation(id: $conversationID) {\n    to {\n      name\n      id\n    }\n    ...Conversation_conversation\n    id\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Changes:
- Redirect to first conversation when `/conversations` opened on desktop
- Added
- Refactored inbox header to be responsive
- Refactored layout to be responsive
- Added details stub

Full view (details panel not yet implemented)

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/3087225/81564936-86754100-9366-11ea-9011-1ce2ba354afe.png">

md view

<img width="947" alt="image" src="https://user-images.githubusercontent.com/3087225/81564972-93923000-9366-11ea-9926-fbfaa1a44552.png">

Still quite a bit of work to do so expect a lot of fast follows. 