### PR TITLE
Readd mobile inbox header

### DIFF
--- a/src/Apps/Conversation/Components/Conversations.tsx
+++ b/src/Apps/Conversation/Components/Conversations.tsx
@@ -1,4 +1,4 @@
-import { Box, media, color, space } from "@artsy/palette"
+import { Box, media, color } from "@artsy/palette"
 import { Conversations_me } from "__generated__/Conversations_me.graphql"
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"

--- a/src/Apps/Conversation/Components/Conversations.tsx
+++ b/src/Apps/Conversation/Components/Conversations.tsx
@@ -9,7 +9,6 @@ import styled from "styled-components"
 const Container = styled(Box)`
   min-height: 100vh;
   border-right: 1px solid ${color("black10")};
-  padding-top: ${space(2)}px;
   ${media.xs`
     border-right: none;
   `};

--- a/src/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/Apps/Conversation/Components/InboxHeaders.tsx
@@ -55,6 +55,22 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   )
 }
 
+export const MobileInboxHeader: FC<FlexProps> = props => {
+  return (
+    <Flex
+      justifyContent="flex-end"
+      flexDirection="column"
+      height="85px"
+      {...props}
+    >
+      <Sans size="6" weight="medium" ml={1}>
+        Inbox
+      </Sans>
+      <Separator mt={1} />
+    </Flex>
+  )
+}
+
 export const InboxHeader: FC<BorderedFlexProps> = props => {
   return (
     <BorderedFlex justifyContent="flex-end" flexDirection="column" {...props}>

--- a/src/Apps/Conversation/ConversationApp.tsx
+++ b/src/Apps/Conversation/ConversationApp.tsx
@@ -11,6 +11,8 @@ import { debounce } from "lodash"
 import { SystemContext } from "Artsy"
 import { userHasLabFeature } from "Utils/user"
 import { ErrorPage } from "Components/ErrorPage"
+import { Media } from "Utils/Responsive"
+import { FullHeader, MobileInboxHeader } from "./Components/InboxHeaders"
 
 interface ConversationAppProps {
   me: ConversationApp_me
@@ -60,6 +62,12 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
   return (
     <AppContainer maxWidth={maxWidth}>
       <Title>Conversations | Artsy</Title>
+      <Media at="xs">
+        <MobileInboxHeader />
+      </Media>
+      <Media greaterThan="xs">
+        <FullHeader partnerName={conversation.to.name} />
+      </Media>
       <Conversations me={me} />
       <Flex
         display={["none", "flex"]}
@@ -94,6 +102,9 @@ export const ConversationAppFragmentContainer = createFragmentContainer(
           edges {
             node {
               internalID
+              to {
+                name
+              }
             }
           }
         }

--- a/src/Apps/Conversation/ConversationApp.tsx
+++ b/src/Apps/Conversation/ConversationApp.tsx
@@ -66,7 +66,7 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
         <MobileInboxHeader />
       </Media>
       <Media greaterThan="xs">
-        <FullHeader partnerName={conversation.to.name} />
+        <FullHeader partnerName={conversation?.to?.name} />
       </Media>
       <Conversations me={me} />
       <Flex

--- a/src/__generated__/ConversationAppTestQuery.graphql.ts
+++ b/src/__generated__/ConversationAppTestQuery.graphql.ts
@@ -14,12 +14,12 @@ export type ConversationAppTestQueryRawResponse = {
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly internalID: string | null;
-                    readonly id: string | null;
-                    readonly lastMessage: string | null;
                     readonly to: {
                         readonly name: string;
                         readonly id: string | null;
                     };
+                    readonly id: string | null;
+                    readonly lastMessage: string | null;
                     readonly lastMessageAt: string | null;
                     readonly unread: boolean | null;
                     readonly items: ReadonlyArray<({
@@ -85,6 +85,10 @@ fragment ConversationApp_me on Me {
     edges {
       node {
         internalID
+        to {
+          name
+          id
+        }
         id
       }
     }
@@ -157,20 +161,20 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v1 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v2 = [
-  (v1/*: any*/),
-  (v0/*: any*/)
+  (v0/*: any*/),
+  (v1/*: any*/)
 ],
 v3 = [
   {
@@ -262,14 +266,6 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v0/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "lastMessage",
-                        "args": null,
-                        "storageKey": null
-                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -279,6 +275,14 @@ return {
                         "concreteType": "ConversationResponder",
                         "plural": false,
                         "selections": (v2/*: any*/)
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "lastMessage",
+                        "args": null,
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",
@@ -319,7 +323,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v1/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "Artwork",
@@ -371,7 +375,7 @@ return {
                                     "plural": false,
                                     "selections": (v2/*: any*/)
                                   },
-                                  (v1/*: any*/),
+                                  (v0/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -458,7 +462,7 @@ return {
               }
             ]
           },
-          (v0/*: any*/)
+          (v1/*: any*/)
         ]
       }
     ]
@@ -467,7 +471,7 @@ return {
     "operationKind": "query",
     "name": "ConversationAppTestQuery",
     "id": null,
-    "text": "query ConversationAppTestQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
+    "text": "query ConversationAppTestQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        to {\n          name\n          id\n        }\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/ConversationApp_me.graphql.ts
+++ b/src/__generated__/ConversationApp_me.graphql.ts
@@ -7,6 +7,9 @@ export type ConversationApp_me = {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly internalID: string | null;
+                readonly to: {
+                    readonly name: string;
+                };
             } | null;
         } | null> | null;
     } | null;
@@ -107,6 +110,24 @@ const node: ReaderFragment = {
                   "name": "internalID",
                   "args": null,
                   "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "to",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "ConversationResponder",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "name",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
                 }
               ]
             }
@@ -121,5 +142,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'd4c7e79711b6ea55474086ffe47c6b7a';
+(node as any).hash = 'edfa47e1542a594d34c232767151f3eb';
 export default node;

--- a/src/__generated__/routes_ConversationQuery.graphql.ts
+++ b/src/__generated__/routes_ConversationQuery.graphql.ts
@@ -28,6 +28,10 @@ fragment ConversationApp_me on Me {
     edges {
       node {
         internalID
+        to {
+          name
+          id
+        }
         id
       }
     }
@@ -100,20 +104,20 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v1 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v2 = [
-  (v1/*: any*/),
-  (v0/*: any*/)
+  (v0/*: any*/),
+  (v1/*: any*/)
 ],
 v3 = [
   {
@@ -205,14 +209,6 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v0/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "lastMessage",
-                        "args": null,
-                        "storageKey": null
-                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -222,6 +218,14 @@ return {
                         "concreteType": "ConversationResponder",
                         "plural": false,
                         "selections": (v2/*: any*/)
+                      },
+                      (v1/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "lastMessage",
+                        "args": null,
+                        "storageKey": null
                       },
                       {
                         "kind": "ScalarField",
@@ -262,7 +266,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v1/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "Artwork",
@@ -314,7 +318,7 @@ return {
                                     "plural": false,
                                     "selections": (v2/*: any*/)
                                   },
-                                  (v1/*: any*/),
+                                  (v0/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -401,7 +405,7 @@ return {
               }
             ]
           },
-          (v0/*: any*/)
+          (v1/*: any*/)
         ]
       }
     ]
@@ -410,7 +414,7 @@ return {
     "operationKind": "query",
     "name": "routes_ConversationQuery",
     "id": null,
-    "text": "query routes_ConversationQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
+    "text": "query routes_ConversationQuery {\n  me {\n    ...ConversationApp_me\n    id\n  }\n}\n\nfragment ConversationApp_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        to {\n          name\n          id\n        }\n        id\n      }\n    }\n  }\n  ...Conversations_me\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
I accidentally omitted the inbox header for `/conversations` on mobile in #3509. This readds that. 

<img width="654" alt="image" src="https://user-images.githubusercontent.com/3087225/81573569-a6126680-9372-11ea-9532-303a559f9f1f.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.36.1-canary.3510.60244.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.36.1-canary.3510.60244.0
  # or 
  yarn add @artsy/reaction@26.36.1-canary.3510.60244.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
