### PR TITLE
Move tracking code for buyers premium link click

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
@@ -1,6 +1,5 @@
 import { Box, Serif } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { SystemContextConsumer } from "Artsy"
 import React from "react"
 
 import { ArtworkSidebarAuctionPartnerInfo_artwork } from "__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql"
@@ -18,22 +17,18 @@ export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
       return null
     }
     return (
-      <SystemContextConsumer>
-        {() => (
-          <Box pb={3}>
-            {partner && (
-              <Serif size="2" weight="semibold" color="black100">
-                {partner.name}
-              </Serif>
-            )}
-            {sale_artwork && sale_artwork.estimate && (
-              <Serif size="2" color="black60">
-                Estimated value: {sale_artwork.estimate}
-              </Serif>
-            )}
-          </Box>
+      <Box pb={3}>
+        {partner && (
+          <Serif size="2" weight="semibold" color="black100">
+            {partner.name}
+          </Serif>
         )}
-      </SystemContextConsumer>
+        {sale_artwork && sale_artwork.estimate && (
+          <Serif size="2" color="black60">
+            Estimated value: {sale_artwork.estimate}
+          </Serif>
+        )}
+      </Box>
     )
   }
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
@@ -1,9 +1,7 @@
 import { Box, Serif } from "@artsy/palette"
-import { SystemContextConsumer } from "Artsy"
-import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
-import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { SystemContextConsumer } from "Artsy"
+import React from "react"
 
 import { ArtworkSidebarAuctionPartnerInfo_artwork } from "__generated__/ArtworkSidebarAuctionPartnerInfo_artwork.graphql"
 
@@ -11,16 +9,9 @@ export interface ArtworkSidebarAuctionPartnerInfoProps {
   artwork: ArtworkSidebarAuctionPartnerInfo_artwork
 }
 
-@track()
 export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
   ArtworkSidebarAuctionPartnerInfoProps
 > {
-  @track(() => ({
-    context_module: Schema.ContextModule.Sidebar,
-    action_type: Schema.ActionType.Click,
-    subject: Schema.Subject.AuctionBuyerPremium,
-    type: Schema.Type.Link,
-  }))
   render() {
     const { partner, sale_artwork, sale } = this.props.artwork
     if (sale.is_closed) {
@@ -28,7 +19,7 @@ export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
     }
     return (
       <SystemContextConsumer>
-        {({ mediator }) => (
+        {() => (
           <Box pb={3}>
             {partner && (
               <Serif size="2" weight="semibold" color="black100">

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
@@ -5,7 +5,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
 import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
+import { AnalyticsSchema } from "Artsy/Analytics"
 import {
   Box,
   Flex,
@@ -25,13 +25,15 @@ export interface ArtworkSidebarCurrentBidInfoProps {
 export class ArtworkSidebarCurrentBidInfo extends React.Component<
   ArtworkSidebarCurrentBidInfoProps
 > {
-  @track(() => ({
-    context_module: Schema.ContextModule.Sidebar,
-    action_type: Schema.ActionType.Click,
-    subject: Schema.Subject.AuctionBuyerPremium,
-    type: Schema.Type.Link,
-  }))
-  onClickBuyerPremium(mediator) {
+  @track(() => {
+    return {
+      context_module: AnalyticsSchema.ContextModule.Sidebar,
+      action_type: AnalyticsSchema.ActionType.Click,
+      subject: AnalyticsSchema.Subject.AuctionBuyerPremium,
+      type: AnalyticsSchema.Type.Link,
+    }
+  })
+  handleClickBuyerPremium(mediator) {
     const { artwork } = this.props
     mediator &&
       mediator.trigger &&
@@ -143,7 +145,7 @@ export class ArtworkSidebarCurrentBidInfo extends React.Component<
               <Serif size="2" color="black60">
                 <br />
                 This auction has a{" "}
-                <Link onClick={this.onClickBuyerPremium.bind(this, mediator)}>
+                <Link onClick={this.handleClickBuyerPremium}>
                   buyer's premium
                 </Link>
                 .<br />

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
@@ -145,7 +145,7 @@ export class ArtworkSidebarCurrentBidInfo extends React.Component<
               <Serif size="2" color="black60">
                 <br />
                 This auction has a{" "}
-                <Link onClick={this.handleClickBuyerPremium}>
+                <Link onClick={() => this.handleClickBuyerPremium(mediator)}>
                   buyer's premium
                 </Link>
                 .<br />

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
@@ -4,7 +4,8 @@ import { SystemContextConsumer } from "Artsy"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "Utils/get"
-
+import { track } from "Artsy/Analytics"
+import * as Schema from "Artsy/Analytics/Schema"
 import {
   Box,
   Flex,
@@ -20,9 +21,16 @@ export interface ArtworkSidebarCurrentBidInfoProps {
   artwork: ArtworkSidebarCurrentBidInfo_artwork
 }
 
+@track()
 export class ArtworkSidebarCurrentBidInfo extends React.Component<
   ArtworkSidebarCurrentBidInfoProps
 > {
+  @track(() => ({
+    context_module: Schema.ContextModule.Sidebar,
+    action_type: Schema.ActionType.Click,
+    subject: Schema.Subject.AuctionBuyerPremium,
+    type: Schema.Type.Link,
+  }))
   onClickBuyerPremium(mediator) {
     const { artwork } = this.props
     mediator &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,0 @@
-// @ts-ignore
-import React from "react"
-import components from "./Components"
-import utils from "./Utils"
-
-export default {
-  components,
-  utils,
-}


### PR DESCRIPTION
The tracking decorator for clicking on the buyers' premium link [did not move with its handler function](https://github.com/artsy/reaction/pull/2966/files#diff-c9ef16c3b323f531057622da216d4a53L24) in a recent change - h/t @sweir27 for quickly tracking it down. This fixes it. Should be fine to merge as-is but I'm working on adding a test as well.