### PR TITLE
[DO NOT MERGE] Update circle to use canary label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   yarn: artsy/yarn@dev:da826a2455c0d9f9ce31f71db9b0601e
   codecov: codecov/codecov@1.0.5
-  auto: artsy/auto@1.2.1
+  auto: artsy/auto@dev:04d8f43a97aeb1524fb58fbefa30e5be
   aws-s3: circleci/aws-s3@1.0.15
 
 jobs:
@@ -51,10 +51,6 @@ workflows:
               ignore:
                 - master
           requires:
-            - yarn/jest
-            - yarn/relay
-            - lint-changed
-            - yarn/type-check
             - yarn/update-cache
       - auto/publish:
           context: npm-deploy


### PR DESCRIPTION
This is just to test to see if canaries deploy only w/ a label
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.36.7-canary.3516.60446.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.36.7-canary.3516.60446.0
  # or 
  yarn add @artsy/reaction@26.36.7-canary.3516.60446.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
