### PR TITLE
Purchase auth triggers use Sign up rather than Log in form

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -253,7 +253,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       })
     } else {
       openAuthModal(mediator, {
-        mode: ModalType.login,
+        mode: ModalType.signup,
         redirectTo: location.href,
         contextModule: ContextModule.artworkSidebar,
         intent: Intent.buyNow,
@@ -344,7 +344,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
       })
     } else {
       openAuthModal(mediator, {
-        mode: ModalType.login,
+        mode: ModalType.signup,
         redirectTo: location.href,
         contextModule: ContextModule.artworkSidebar,
         intent: Intent.makeOffer,

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.test.tsx
@@ -27,7 +27,7 @@ import { MockBoot } from "DevTools"
 const commitMutation = _commitMutation as jest.Mock<any>
 
 describe("ArtworkSidebarCommercial", () => {
-  const user = { id: "blah" }
+  let user
   const mediator = { trigger: jest.fn() }
   const getWrapper = artwork => {
     return mount(
@@ -43,9 +43,38 @@ describe("ArtworkSidebarCommercial", () => {
   }
 
   beforeEach(() => {
+    user = { id: "blah" }
+    window.history.pushState({}, "Artwork Title", "/artwork/the-id")
     commitMutation.mockReset()
   })
 
+  describe("authentication", () => {
+    beforeEach(() => {
+      user = undefined
+    })
+
+    it("opens auth modal with expected args when clicking 'buy now' button", () => {
+      const component = getWrapper(ArtworkBuyNow)
+      component.find(Button).simulate("click")
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        mode: "signup",
+        redirectTo: "http://localhost/artwork/the-id",
+        contextModule: "artworkSidebar",
+        intent: "buyNow",
+      })
+    })
+
+    it("opens auth modal with expected args when clicking 'make offer' button", () => {
+      const component = getWrapper(ArtworkMakeOffer)
+      component.find(Button).simulate("click")
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        mode: "signup",
+        redirectTo: "http://localhost/artwork/the-id",
+        contextModule: "artworkSidebar",
+        intent: "makeOffer",
+      })
+    })
+  })
   it("displays if the artwork price includes tax", async () => {
     const artwork = Object.assign(
       {},


### PR DESCRIPTION
Updates "Buy now" and "Make offer" buttons to open "Sign up" form instead of "Log in" for anonymous users. 

Follow up to conversation: https://artsy.slack.com/archives/C9YNS4X32/p1589303325202200

Integrity PR should be merged once this is in Force: https://github.com/artsy/integrity/pull/127

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.36.8-canary.3518.60482.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.36.8-canary.3518.60482.0
  # or 
  yarn add @artsy/reaction@26.36.8-canary.3518.60482.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
