### PR TITLE
Wires up OrderedSets and FeaturedLinks to real data

### DIFF
--- a/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -1,8 +1,10 @@
 import React from "react"
 import styled from "styled-components"
-import { space, SpaceProps } from "styled-system"
-import { Box, Sans, Serif, Image, Flex } from "@artsy/palette"
+import { SpaceProps, space } from "styled-system"
+import { Box, Flex, ResponsiveImage, Sans, Serif, color } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "Artsy/Router/RouterLink"
+import { FeatureFeaturedLink_featuredLink } from "__generated__/FeatureFeaturedLink_featuredLink.graphql"
 
 const Container = styled(RouterLink)`
   ${space}
@@ -13,12 +15,6 @@ const Container = styled(RouterLink)`
 
 const Figure = styled(Box)`
   position: relative;
-`
-
-const Cover = styled(Image)`
-  display: block;
-  width: 100%;
-  height: 100%;
 `
 
 const Title = styled(Sans)`
@@ -40,29 +36,25 @@ const MetaCell = styled(Flex)`
 
 export interface FeatureFeaturedLinkProps extends SpaceProps {
   wide?: boolean
-  featuredLink: {
-    title: string
-    href: string
-    subtitle?: string
-    description?: string
-    image: {
-      width: number
-      height: number
-      url: string
-    }
-  }
+  featuredLink: FeatureFeaturedLink_featuredLink
 }
 
 export const FeatureFeaturedLink: React.FC<FeatureFeaturedLinkProps> = ({
   wide,
-  featuredLink: { title, href, subtitle, description, image },
+  featuredLink,
+  featuredLink: { href, title, subtitle, description, image },
   ...rest
 }) => {
   return (
     <Container to={href} {...rest}>
       {image ? (
         <Figure>
-          <Cover src={image.url} />
+          <ResponsiveImage
+            maxWidth="100%"
+            src={image.cropped.src}
+            ratio={image.cropped.height / image.cropped.width}
+            style={{ backgroundColor: color("black10") }}
+          />
 
           <Title size="6" color="white100" p={2} pt={9}>
             {title}
@@ -70,7 +62,7 @@ export const FeatureFeaturedLink: React.FC<FeatureFeaturedLinkProps> = ({
         </Figure>
       ) : (
         <Sans size="6" color="black100" my={2}>
-          {title}
+          {title || "—"}
         </Sans>
       )}
 
@@ -90,3 +82,25 @@ export const FeatureFeaturedLink: React.FC<FeatureFeaturedLinkProps> = ({
     </Container>
   )
 }
+
+export const FeatureFeaturedLinkFragmentContainer = createFragmentContainer(
+  FeatureFeaturedLink,
+  {
+    featuredLink: graphql`
+      fragment FeatureFeaturedLink_featuredLink on FeaturedLink {
+        href
+        title
+        subtitle
+        # TODO: Placeholder value
+        description: subtitle
+        image {
+          cropped(width: 800, height: 600, version: ["wide"]) {
+            src: url
+            width
+            height
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Feature/Components/FeatureHeader.tsx
+++ b/src/Apps/Feature/Components/FeatureHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import { Flex, Sans, color, Image, Spacer } from "@artsy/palette"
+import { Box, Flex, Image, Join, Sans, Spacer, color } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FeatureHeader_feature } from "__generated__/FeatureHeader_feature.graphql"
 
@@ -48,18 +48,17 @@ export const FeatureHeader: React.FC<FeatureHeaderProps> = ({
       )}
 
       <Meta p={6} flexBasis={image ? "50%" : "100%"}>
-        <Sans size="10" element="h1" textAlign="center">
-          {name}
-        </Sans>
-
-        <Spacer my={1} />
-
-        {/* TODO: Doesn't exist in schema yet, aliased `description` */}
-        {subheadline && (
-          <Sans size="4" textAlign="center">
-            {subheadline}
+        <Join separator={<Spacer my={1} />}>
+          <Sans size="10" element="h1" textAlign="center">
+            {name}
           </Sans>
-        )}
+
+          {subheadline && (
+            <Sans size="4" textAlign="center">
+              <Box dangerouslySetInnerHTML={{ __html: subheadline }} />
+            </Sans>
+          )}
+        </Join>
       </Meta>
     </Container>
   )
@@ -71,7 +70,8 @@ export const FeatureHeaderFragmentContainer = createFragmentContainer(
     feature: graphql`
       fragment FeatureHeader_feature on Feature {
         name
-        subheadline: description
+        # TODO: Placeholder value
+        subheadline: description(format: HTML)
         image {
           url
         }

--- a/src/Apps/Feature/Components/FeatureSet.tsx
+++ b/src/Apps/Feature/Components/FeatureSet.tsx
@@ -79,7 +79,7 @@ export const FeatureSetFragmentContainer = createFragmentContainer(FeatureSet, {
       description
       itemType
       # TODO: Handle pagination
-      orderedItems: orderedItemsConnection(first: 50) {
+      orderedItems: orderedItemsConnection(first: 20) {
         edges {
           node {
             __typename

--- a/src/Apps/Feature/Components/__tests__/fixtures.ts
+++ b/src/Apps/Feature/Components/__tests__/fixtures.ts
@@ -11,18 +11,18 @@ export const FEATURE_HEADER = {
 }
 
 export const FEATURED_LINK = {
-  __typename: "FeaturedLink",
-  id: "RmVhdHVyZWRMaW5rOjVkZmY1YzAwNTk4NDE3MDAwZTBkYWRjNw==",
-  href: "https://www.artsy.net/feature/discover-art-from-dusseldorf",
-  title: "Christine Sun Kim",
-  subtitle: "Greene Naftali",
-  description:
-    "This is a brief statement about the works. Brief statement about the works. This is a brief statement about the works and another. This is a brief statement about the works.",
+  " $fragmentRefs": null,
+  " $refType": null,
+  href: "/artwork/auguste-rodin-le-baiser-the-kiss",
+  title: "Auguste Rodin",
+  subtitle: "Le Baiser (The Kiss), ca. 1886",
+  description: "Le Baiser (The Kiss), ca. 1886",
   image: {
-    title: "Dusseldorf",
-    width: 1024,
-    height: 910,
-    url:
-      "https://d32dm0rphc51dk.cloudfront.net/96ObvNmUJVWL2RVrlWleFA/large_rectangle.jpg",
+    cropped: {
+      src:
+        "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fill&width=800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FMK8cjqHtGvEWmCMFz6-ZGA%2Fwide.jpg",
+      width: 800,
+      height: 600,
+    },
   },
 }

--- a/src/Apps/Feature/FeatureApp.tsx
+++ b/src/Apps/Feature/FeatureApp.tsx
@@ -3,7 +3,9 @@ import { AppContainer } from "Apps/Components/AppContainer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FeatureHeaderFragmentContainer as FeatureHeader } from "./Components/FeatureHeader"
 import { FeatureApp_feature } from "__generated__/FeatureApp_feature.graphql"
-import { Box, Sans, Spacer } from "@artsy/palette"
+import { Box, Join, Sans, Spacer } from "@artsy/palette"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { FeatureSetFragmentContainer as FeatureSet } from "./Components/FeatureSet"
 
 interface FeatureAppProps {
   feature: FeatureApp_feature
@@ -11,33 +13,42 @@ interface FeatureAppProps {
 
 const FeatureApp: React.FC<FeatureAppProps> = ({ feature }) => {
   return (
-    <AppContainer maxWidth="100%">
+    <>
       <Box height="100vh">
         <FeatureHeader feature={feature} />
       </Box>
 
-      <Box maxWidth={["100%", 460]} mx="auto" my={3} px={3}>
-        <Sans size="4">
-          {/* Feature#description */}
-          Art-world spaces have paused, museums and galleries have closed their
-          doors, exhibitions have canceled, and auctions and fairs have been
-          postponed. Still, even in times of crisis, art can bring us closer and
-          keep us connected across time and place. And in times of crises, art
-          continues to move us and keeps going, and and keeps us connected.
-        </Sans>
+      <AppContainer>
+        <HorizontalPadding>
+          {(feature.description || feature.callOut) && (
+            <Box maxWidth={["100%", 460]} mx="auto" my={3} px={3}>
+              <Join separator={<Spacer my={3} />}>
+                {feature.description && (
+                  <Sans size="4">
+                    <Box
+                      dangerouslySetInnerHTML={{ __html: feature.description }}
+                    />
+                  </Sans>
+                )}
 
-        <Spacer my={3} />
+                {feature.callOut && (
+                  <Sans size="6">
+                    <Box
+                      dangerouslySetInnerHTML={{ __html: feature.callOut }}
+                    />
+                  </Sans>
+                )}
+              </Join>
+            </Box>
+          )}
 
-        <Sans size="6">
-          {/* Feature#callOut */}
-          Featuring: Greene Naftali, Petzel, Andrew Kreps, Skarstedt, CLEARING,
-          The Journal Gallery, CANADA, Company Gallery, Van Doren Waxter, Jack
-          Hanley, Matthew Marks, Gavin Brown, Perrotin, James Fuentes, Gagosian,
-          David Zwirnir, Galerie Lelong, Sikkema Jenkins, Two Palms, Pace,
-          Lisson, Hauser &amp; Wirth
-        </Sans>
-      </Box>
-    </AppContainer>
+          {feature.sets.edges.length > 0 &&
+            feature.sets.edges.map(
+              ({ node: set }) => set && <FeatureSet key={set.id} set={set} />
+            )}
+        </HorizontalPadding>
+      </AppContainer>
+    </>
   )
 }
 
@@ -46,6 +57,18 @@ export default createFragmentContainer(FeatureApp, {
   feature: graphql`
     fragment FeatureApp_feature on Feature {
       ...FeatureHeader_feature
+      description(format: HTML)
+      # TODO: Placeholder value
+      callOut: description(format: HTML)
+      # TODO: Handle pagination
+      sets: setsConnection(first: 50) {
+        edges {
+          node {
+            id
+            ...FeatureSet_set
+          }
+        }
+      }
     }
   `,
 })

--- a/src/Apps/Feature/FeatureApp.tsx
+++ b/src/Apps/Feature/FeatureApp.tsx
@@ -61,7 +61,7 @@ export default createFragmentContainer(FeatureApp, {
       # TODO: Placeholder value
       callOut: description(format: HTML)
       # TODO: Handle pagination
-      sets: setsConnection(first: 50) {
+      sets: setsConnection(first: 20) {
         edges {
           node {
             id

--- a/src/__generated__/FeatureApp_feature.graphql.ts
+++ b/src/__generated__/FeatureApp_feature.graphql.ts
@@ -3,6 +3,16 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FeatureApp_feature = {
+    readonly description: string | null;
+    readonly callOut: string | null;
+    readonly sets: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+                readonly " $fragmentRefs": FragmentRefs<"FeatureSet_set">;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"FeatureHeader_feature">;
     readonly " $refType": "FeatureApp_feature";
 };
@@ -14,7 +24,15 @@ export type FeatureApp_feature$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
+return {
   "kind": "Fragment",
   "name": "FeatureApp_feature",
   "type": "Feature",
@@ -22,11 +40,77 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "description",
+      "args": (v0/*: any*/),
+      "storageKey": "description(format:\"HTML\")"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "callOut",
+      "name": "description",
+      "args": (v0/*: any*/),
+      "storageKey": "description(format:\"HTML\")"
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "sets",
+      "name": "setsConnection",
+      "storageKey": "setsConnection(first:50)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "OrderedSetConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "OrderedSetEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "OrderedSet",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": "FeatureSet_set",
+                  "args": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "kind": "FragmentSpread",
       "name": "FeatureHeader_feature",
       "args": null
     }
   ]
 };
-(node as any).hash = '76d11c95bc3f546cf83bc71a5f10873c';
+})();
+(node as any).hash = '791fe186cfa7fb5c6f11084b88b576d0';
 export default node;

--- a/src/__generated__/FeatureApp_feature.graphql.ts
+++ b/src/__generated__/FeatureApp_feature.graphql.ts
@@ -57,12 +57,12 @@ return {
       "kind": "LinkedField",
       "alias": "sets",
       "name": "setsConnection",
-      "storageKey": "setsConnection(first:50)",
+      "storageKey": "setsConnection(first:20)",
       "args": [
         {
           "kind": "Literal",
           "name": "first",
-          "value": 50
+          "value": 20
         }
       ],
       "concreteType": "OrderedSetConnection",
@@ -112,5 +112,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '791fe186cfa7fb5c6f11084b88b576d0';
+(node as any).hash = '8d8153fd1cb50909c8f85109ca0e4d3e';
 export default node;

--- a/src/__generated__/FeatureFeaturedLink_featuredLink.graphql.ts
+++ b/src/__generated__/FeatureFeaturedLink_featuredLink.graphql.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FeatureFeaturedLink_featuredLink = {
+    readonly href: string | null;
+    readonly title: string | null;
+    readonly subtitle: string | null;
+    readonly description: string | null;
+    readonly image: {
+        readonly cropped: {
+            readonly src: string | null;
+            readonly width: number | null;
+            readonly height: number | null;
+        } | null;
+    } | null;
+    readonly " $refType": "FeatureFeaturedLink_featuredLink";
+};
+export type FeatureFeaturedLink_featuredLink$data = FeatureFeaturedLink_featuredLink;
+export type FeatureFeaturedLink_featuredLink$key = {
+    readonly " $data"?: FeatureFeaturedLink_featuredLink$data;
+    readonly " $fragmentRefs": FragmentRefs<"FeatureFeaturedLink_featuredLink">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "FeatureFeaturedLink_featuredLink",
+  "type": "FeaturedLink",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "href",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "subtitle",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": "description",
+      "name": "subtitle",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "cropped",
+          "storageKey": "cropped(height:600,version:[\"wide\"],width:800)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 600
+            },
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": [
+                "wide"
+              ]
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 800
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": "src",
+              "name": "url",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "width",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "height",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = 'b15d1305f0285194e4f05a888f131bcd';
+export default node;

--- a/src/__generated__/FeatureHeader_feature.graphql.ts
+++ b/src/__generated__/FeatureHeader_feature.graphql.ts
@@ -36,8 +36,14 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "alias": "subheadline",
       "name": "description",
-      "args": null,
-      "storageKey": null
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "HTML"
+        }
+      ],
+      "storageKey": "description(format:\"HTML\")"
     },
     {
       "kind": "LinkedField",
@@ -59,5 +65,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '7386675e0f31669178e3e2c164bdf9f1';
+(node as any).hash = '96c7d6fe21ead9f9acd930b2f24bb861';
 export default node;

--- a/src/__generated__/FeatureSet_set.graphql.ts
+++ b/src/__generated__/FeatureSet_set.graphql.ts
@@ -57,12 +57,12 @@ const node: ReaderFragment = {
       "kind": "LinkedField",
       "alias": "orderedItems",
       "name": "orderedItemsConnection",
-      "storageKey": "orderedItemsConnection(first:50)",
+      "storageKey": "orderedItemsConnection(first:20)",
       "args": [
         {
           "kind": "Literal",
           "name": "first",
-          "value": 50
+          "value": 20
         }
       ],
       "concreteType": "OrderedSetItemConnection",
@@ -119,5 +119,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '083aa5a417d2906df27e4cb01b8fb35a';
+(node as any).hash = '6c7b894c485d5ad58abd203535e0b034';
 export default node;

--- a/src/__generated__/FeatureSet_set.graphql.ts
+++ b/src/__generated__/FeatureSet_set.graphql.ts
@@ -1,0 +1,123 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FeatureSet_set = {
+    readonly name: string | null;
+    readonly description: string | null;
+    readonly itemType: string | null;
+    readonly orderedItems: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly __typename: string;
+                readonly id?: string;
+                readonly " $fragmentRefs": FragmentRefs<"FeatureFeaturedLink_featuredLink">;
+            } | null;
+        } | null> | null;
+    };
+    readonly " $refType": "FeatureSet_set";
+};
+export type FeatureSet_set$data = FeatureSet_set;
+export type FeatureSet_set$key = {
+    readonly " $data"?: FeatureSet_set$data;
+    readonly " $fragmentRefs": FragmentRefs<"FeatureSet_set">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "FeatureSet_set",
+  "type": "OrderedSet",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "description",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "itemType",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "orderedItems",
+      "name": "orderedItemsConnection",
+      "storageKey": "orderedItemsConnection(first:50)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "OrderedSetItemConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "OrderedSetItemEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": null,
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "type": "FeaturedLink",
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": "FeatureFeaturedLink_featuredLink",
+                  "args": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '083aa5a417d2906df27e4cb01b8fb35a';
+export default node;

--- a/src/__generated__/routes_FeatureQuery.graphql.ts
+++ b/src/__generated__/routes_FeatureQuery.graphql.ts
@@ -31,7 +31,7 @@ fragment FeatureApp_feature on Feature {
   ...FeatureHeader_feature
   description(format: HTML)
   callOut: description(format: HTML)
-  sets: setsConnection(first: 50) {
+  sets: setsConnection(first: 20) {
     edges {
       node {
         id
@@ -67,7 +67,7 @@ fragment FeatureSet_set on OrderedSet {
   name
   description
   itemType
-  orderedItems: orderedItemsConnection(first: 50) {
+  orderedItems: orderedItemsConnection(first: 20) {
     edges {
       node {
         __typename
@@ -118,7 +118,7 @@ v4 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 50
+    "value": 20
   }
 ],
 v5 = {
@@ -213,7 +213,7 @@ return {
             "kind": "LinkedField",
             "alias": "sets",
             "name": "setsConnection",
-            "storageKey": "setsConnection(first:50)",
+            "storageKey": "setsConnection(first:20)",
             "args": (v4/*: any*/),
             "concreteType": "OrderedSetConnection",
             "plural": false,
@@ -256,7 +256,7 @@ return {
                         "kind": "LinkedField",
                         "alias": "orderedItems",
                         "name": "orderedItemsConnection",
-                        "storageKey": "orderedItemsConnection(first:50)",
+                        "storageKey": "orderedItemsConnection(first:20)",
                         "args": (v4/*: any*/),
                         "concreteType": "OrderedSetItemConnection",
                         "plural": false,
@@ -403,7 +403,7 @@ return {
     "operationKind": "query",
     "name": "routes_FeatureQuery",
     "id": null,
-    "text": "query routes_FeatureQuery(\n  $slug: ID!\n) {\n  feature(id: $slug) {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callOut: description(format: HTML)\n  sets: setsConnection(first: 50) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle\n  description: subtitle\n  image {\n    cropped(width: 800, height: 600, version: [\"wide\"]) {\n      src: url\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  name\n  subheadline: description(format: HTML)\n  image {\n    url\n  }\n}\n\nfragment FeatureSet_set on OrderedSet {\n  name\n  description\n  itemType\n  orderedItems: orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureFeaturedLink_featuredLink\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
+    "text": "query routes_FeatureQuery(\n  $slug: ID!\n) {\n  feature(id: $slug) {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callOut: description(format: HTML)\n  sets: setsConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle\n  description: subtitle\n  image {\n    cropped(width: 800, height: 600, version: [\"wide\"]) {\n      src: url\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  name\n  subheadline: description(format: HTML)\n  image {\n    url\n  }\n}\n\nfragment FeatureSet_set on OrderedSet {\n  name\n  description\n  itemType\n  orderedItems: orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureFeaturedLink_featuredLink\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/__generated__/routes_FeatureQuery.graphql.ts
+++ b/src/__generated__/routes_FeatureQuery.graphql.ts
@@ -29,13 +29,57 @@ query routes_FeatureQuery(
 
 fragment FeatureApp_feature on Feature {
   ...FeatureHeader_feature
+  description(format: HTML)
+  callOut: description(format: HTML)
+  sets: setsConnection(first: 50) {
+    edges {
+      node {
+        id
+        ...FeatureSet_set
+      }
+    }
+  }
+}
+
+fragment FeatureFeaturedLink_featuredLink on FeaturedLink {
+  href
+  title
+  subtitle
+  description: subtitle
+  image {
+    cropped(width: 800, height: 600, version: ["wide"]) {
+      src: url
+      width
+      height
+    }
+  }
 }
 
 fragment FeatureHeader_feature on Feature {
   name
-  subheadline: description
+  subheadline: description(format: HTML)
   image {
     url
+  }
+}
+
+fragment FeatureSet_set on OrderedSet {
+  name
+  description
+  itemType
+  orderedItems: orderedItemsConnection(first: 50) {
+    edges {
+      node {
+        __typename
+        ... on FeaturedLink {
+          id
+        }
+        ...FeatureFeaturedLink_featuredLink
+        ... on Node {
+          id
+        }
+      }
+    }
   }
 }
 */
@@ -55,7 +99,35 @@ v1 = [
     "name": "id",
     "variableName": "slug"
   }
-];
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 50
+  }
+],
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "fragment": {
@@ -97,19 +169,13 @@ return {
         "concreteType": "Feature",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
-            "args": null,
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "kind": "ScalarField",
             "alias": "subheadline",
             "name": "description",
-            "args": null,
-            "storageKey": null
+            "args": (v3/*: any*/),
+            "storageKey": "description(format:\"HTML\")"
           },
           {
             "kind": "LinkedField",
@@ -132,10 +198,203 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "id",
-            "args": null,
-            "storageKey": null
-          }
+            "name": "description",
+            "args": (v3/*: any*/),
+            "storageKey": "description(format:\"HTML\")"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": "callOut",
+            "name": "description",
+            "args": (v3/*: any*/),
+            "storageKey": "description(format:\"HTML\")"
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "sets",
+            "name": "setsConnection",
+            "storageKey": "setsConnection(first:50)",
+            "args": (v4/*: any*/),
+            "concreteType": "OrderedSetConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "OrderedSetEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "OrderedSet",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "itemType",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": "orderedItems",
+                        "name": "orderedItemsConnection",
+                        "storageKey": "orderedItemsConnection(first:50)",
+                        "args": (v4/*: any*/),
+                        "concreteType": "OrderedSetItemConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "OrderedSetItemEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": null,
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "__typename",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/),
+                                  {
+                                    "kind": "InlineFragment",
+                                    "type": "FeaturedLink",
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "href",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "title",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "subtitle",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": "description",
+                                        "name": "subtitle",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "image",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "cropped",
+                                            "storageKey": "cropped(height:600,version:[\"wide\"],width:800)",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 600
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "version",
+                                                "value": [
+                                                  "wide"
+                                                ]
+                                              },
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 800
+                                              }
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": "src",
+                                                "name": "url",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "width",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "height",
+                                                "args": null,
+                                                "storageKey": null
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          (v5/*: any*/)
         ]
       }
     ]
@@ -144,7 +403,7 @@ return {
     "operationKind": "query",
     "name": "routes_FeatureQuery",
     "id": null,
-    "text": "query routes_FeatureQuery(\n  $slug: ID!\n) {\n  feature(id: $slug) {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureHeader_feature\n}\n\nfragment FeatureHeader_feature on Feature {\n  name\n  subheadline: description\n  image {\n    url\n  }\n}\n",
+    "text": "query routes_FeatureQuery(\n  $slug: ID!\n) {\n  feature(id: $slug) {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callOut: description(format: HTML)\n  sets: setsConnection(first: 50) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle\n  description: subtitle\n  image {\n    cropped(width: 800, height: 600, version: [\"wide\"]) {\n      src: url\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  name\n  subheadline: description(format: HTML)\n  image {\n    url\n  }\n}\n\nfragment FeatureSet_set on OrderedSet {\n  name\n  description\n  itemType\n  orderedItems: orderedItemsConnection(first: 50) {\n    edges {\n      node {\n        __typename\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureFeaturedLink_featuredLink\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
![](http://static.damonzucconi.com/_capture/7DxSJxTb8Te1.png)

The duplicated fields are just the placeholder aliases — I'm going to switch to working on Metaphysics next.

### TODO

- [ ] Expose fields for all of those yet-to-exist values
- [ ] Support markdown on FeaturedLink subtitles and OrderedSet descriptions
- [ ] Expose a `srcSet` on Metaphysics image types
- [ ] Featured link images should support different sizes depending on the media width (so using picture/source tags)
- [ ] a11y pass (alt tags, etc)