### PR TITLE
Update artsy/palette to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/auto-config": "1.0.2",
     "@artsy/cohesion": "1.0.2",
     "@artsy/lint-changed": "3.0.4",
-    "@artsy/palette": "8.2.3",
+    "@artsy/palette": "9.0.0",
     "@babel/cli": "7.0.0",
     "@babel/core": "7.7.2",
     "@babel/plugin-proposal-class-properties": "7.3.4",

--- a/src/Components/CCPARequest.tsx
+++ b/src/Components/CCPARequest.tsx
@@ -307,7 +307,6 @@ export const CCPARequest: React.SFC<Props> = props => {
       </Box>
       <Modal
         title={title}
-        forcedScroll={false}
         show={showModal}
         onClose={onClose}
         FixedButton={modalButton}

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -89,12 +89,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
   }
 
   return (
-    <Modal
-      forcedScroll={false}
-      title="Set up with app"
-      show={props.show}
-      onClose={props.onClose}
-    >
+    <Modal title="Set up with app" show={props.show} onClose={props.onClose}>
       <Formik
         validationSchema={validationSchema}
         initialValues={{ name: secondFactor.name || "", code: "" }}

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactor/index.tsx
@@ -81,7 +81,6 @@ export const BackupSecondFactor: React.FC<BackupSecondFactorProps> = props => {
         </Flex>
       </Flex>
       <Modal
-        forcedScroll={false}
         title="Your backup codes"
         show={showModal}
         onClose={() => setShowModal(false)}

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -228,7 +228,6 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
 
   return (
     <Modal
-      forcedScroll={false}
       title="Set up with text message"
       show={props.show}
       onClose={props.onClose}

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     p-each-series "^2.1.0"
     p-limit "^2.2.2"
 
-"@artsy/palette@8.2.3":
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-8.2.3.tgz#fa038e7118464dc0d506a86de84cf17bea805f35"
-  integrity sha512-NMkYZFW6/Z6IqG139SE+SuSdOqf/aD6oPBMv/TaHBJSZzSocX8kTj542RsroiSM3FZgmensSR1TWygo3ucYFdw==
+"@artsy/palette@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-9.0.0.tgz#ca0183ae41cf73b6113e7f16a6c3aa35736751b4"
+  integrity sha512-ORjqBwZ20TdI/F1KEhMc/ZdAPKzC32Kz2ud5jHvzwvk5S3d6MYC2+a3yrF0tpq73+dfU715Hc3KDuBpXDyqv3A==
   dependencies:
     babel-plugin-styled-components "^1.10.0"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Addresses one breaking change in the Modal component: https://github.com/artsy/palette/pull/680

Removes any use of the `forcedScroll` property. The component now defaults to `overflow: auto`.