### PR TITLE
Redirect to /log_in vs reloading upon initial 2FA setup

### DIFF
--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -52,13 +52,13 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     }
   }
 
-  function onCompleteConfirmed() {
+  async function onCompleteConfirmed() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      request.delete("/users/sign_out", () => {
-        location.reload()
-      })
+      await request.delete("/users/sign_out").accept("application/json")
+
+      location.reload()
     }
   }
 

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -10,6 +10,7 @@ import {
 import { BorderBoxProps } from "@artsy/palette/dist/elements/BorderBox/BorderBoxBase"
 import React, { useState } from "react"
 import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
+import request from "superagent"
 
 import { useSystemContext } from "Artsy"
 import { AppSecondFactorModal } from "./Modal"
@@ -55,9 +56,9 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      location.assign(
-        "/log_in?redirect_uri=" + encodeURIComponent(location.pathname)
-      )
+      request.delete("/users/sign_out", () => {
+        location.reload()
+      })
     }
   }
 

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -55,7 +55,9 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      window.location.reload()
+      location.assign(
+        "/log_in?redirect_uri=" + encodeURIComponent(location.pathname)
+      )
     }
   }
 
@@ -177,11 +179,11 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
       />
       <Modal
         title="Set up with app"
-        onClose={() => onCompleteConfirmed()}
+        onClose={onCompleteConfirmed}
         show={showCompleteModal}
         hideCloseButton={!me.hasSecondFactorEnabled}
         FixedButton={
-          <Button onClick={() => onCompleteConfirmed()} block width="100%">
+          <Button onClick={onCompleteConfirmed} block width="100%">
             {me.hasSecondFactorEnabled ? "OK" : "Log back in"}
           </Button>
         }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -56,7 +56,9 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      await request.delete("/users/sign_out").accept("application/json")
+      await request
+        .delete("/users/sign_out")
+        .set("X-Requested-With", "XMLHttpRequest")
 
       location.reload()
     }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -48,7 +48,9 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      window.location.reload()
+      location.assign(
+        "/log_in?redirect_uri=" + encodeURIComponent(location.pathname)
+      )
     }
   }
 
@@ -167,11 +169,11 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
       />
       <Modal
         title="Set up with text message"
-        onClose={() => onCompleteConfirmed()}
+        onClose={onCompleteConfirmed}
         show={showCompleteModal}
         hideCloseButton={!me.hasSecondFactorEnabled}
         FixedButton={
-          <Button onClick={() => onCompleteConfirmed()} block width="100%">
+          <Button onClick={onCompleteConfirmed} block width="100%">
             {me.hasSecondFactorEnabled ? "OK" : "Log back in"}
           </Button>
         }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -49,7 +49,9 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      await request.delete("/users/sign_out").accept("application/json")
+      await request
+        .delete("/users/sign_out")
+        .set("X-Requested-With", "XMLHttpRequest")
 
       location.reload()
     }

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -2,6 +2,7 @@ import { BorderBox, Button, Flex, Modal, Sans, Serif } from "@artsy/palette"
 import { BorderBoxProps } from "@artsy/palette/dist/elements/BorderBox/BorderBoxBase"
 import React, { useState } from "react"
 import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
+import request from "superagent"
 
 import { useSystemContext } from "Artsy"
 
@@ -48,9 +49,9 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      location.assign(
-        "/log_in?redirect_uri=" + encodeURIComponent(location.pathname)
-      )
+      request.delete("/users/sign_out", () => {
+        location.reload()
+      })
     }
   }
 

--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -45,13 +45,13 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     }
   }
 
-  function onCompleteConfirmed() {
+  async function onCompleteConfirmed() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      request.delete("/users/sign_out", () => {
-        location.reload()
-      })
+      await request.delete("/users/sign_out").accept("application/json")
+
+      location.reload()
     }
   }
 


### PR DESCRIPTION
Log out of the session and reload the page after initial 2FA enrollment.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>26.39.1-canary.3538.60875.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@26.39.1-canary.3538.60875.0
  # or 
  yarn add @artsy/reaction@26.39.1-canary.3538.60875.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


### Screen Recordings

#### Before

![Peek 2020-05-13 23-20](https://user-images.githubusercontent.com/123595/81889031-995b6180-9570-11ea-8ccd-8b297e6a04fb.gif)

#### After

![Peek 2020-05-13 23-21](https://user-images.githubusercontent.com/123595/81889029-98c2cb00-9570-11ea-80e1-7edbb353d70f.gif)
