### PR TITLE
Make tracking exclusion more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "klaw-sync": "6.0.0",
     "lint-staged": "10.0.8",
     "patch-package": "6.2.0",
+    "path-to-regexp": "6.1.0",
     "postinstall-prepare": "1.0.1",
     "prettier": "1.19.1",
     "raf": "3.4.0",

--- a/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
+++ b/src/Artsy/Analytics/__tests__/trackingMiddleware.test.ts
@@ -51,16 +51,54 @@ describe("trackingMiddleware", () => {
     expect(global.analytics.page).not.toBeCalled()
   })
 
-  it("excludes paths based on config option", () => {
-    trackingMiddleware({
-      excludePaths: ["/artwork/"],
-    })(store)(noop)({
-      type: ActionTypes.UPDATE_LOCATION,
-      payload: {
-        pathname: "/artwork/some-id",
-      },
+  describe("excluding paths", () => {
+    it("excludes all possible paths for a given route", () => {
+      trackingMiddleware({
+        excludePaths: ["/artwork(.*)"],
+      })(store)(noop)({
+        type: ActionTypes.UPDATE_LOCATION,
+        payload: {
+          pathname: "/artwork/some-id",
+        },
+      })
+      expect(global.analytics.page).not.toBeCalled()
     })
-    expect(global.analytics.page).not.toBeCalled()
+
+    it("excludes dynamic path segments", () => {
+      trackingMiddleware({
+        excludePaths: ["/artwork/:slug"],
+      })(store)(noop)({
+        type: ActionTypes.UPDATE_LOCATION,
+        payload: {
+          pathname: "/artwork/some-id",
+        },
+      })
+      expect(global.analytics.page).not.toBeCalled()
+    })
+
+    it("excludes nested paths", () => {
+      trackingMiddleware({
+        excludePaths: ["/artwork/:slug/:segment*"],
+      })(store)(noop)({
+        type: ActionTypes.UPDATE_LOCATION,
+        payload: {
+          pathname: "/artwork/some-id/foo",
+        },
+      })
+      expect(global.analytics.page).not.toBeCalled()
+    })
+
+    it("excludes paths including regexs", () => {
+      trackingMiddleware({
+        excludePaths: ["/auction/:saleID/bid(2)?/:artworkID"],
+      })(store)(noop)({
+        type: ActionTypes.UPDATE_LOCATION,
+        payload: {
+          pathname: "/auction/some-id/bid2/some-artwork",
+        },
+      })
+      expect(global.analytics.page).not.toBeCalled()
+    })
   })
 
   // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -2,6 +2,7 @@ import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import ActionTypes from "farce/lib/ActionTypes"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
+import { match } from "path-to-regexp"
 
 /**
  * PageView tracking middleware for use in our router apps. Middleware conforms
@@ -39,7 +40,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           // window.sd.routerReferrer = referrer
 
           const foundExcludedPath = excludePaths.some(excludedPath => {
-            return pathname.includes(excludedPath)
+            const matcher = match(excludedPath, { decode: decodeURIComponent })
+            const foundMatch = !!matcher(pathname)
+            return foundMatch
           })
 
           if (!foundExcludedPath) {

--- a/src/Artsy/Router/buildClientApp.tsx
+++ b/src/Artsy/Router/buildClientApp.tsx
@@ -69,9 +69,9 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         }),
         trackingMiddleware({
           excludePaths: [
-            "/artwork/",
+            "/artwork(.*)",
             // FIXME: Remove once old feature pages are migrated
-            "/feature/",
+            "/feature(.*)",
           ],
         }),
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -13995,6 +13995,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
 path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"


### PR DESCRIPTION
Data team noticed that we were doing some double firing on page view tracking. This doesn't fix that, but simply makes path exclusion more robust. The same technique has been copied over to the corresponding Force PR, which does fix the problem. Uses [path-to-regex](https://github.com/pillarjs/path-to-regexp) under the hood.

Going to merge this in order to get a deploy out. 