### PR TITLE
Ensure test checks don't validate actual dates

### DIFF
--- a/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
+++ b/src/Apps/Conversation/__tests__/ConversationApp.test.tsx
@@ -69,7 +69,7 @@ describe("Conversation app", () => {
         }
         const component = await render(mockMe, userType)
         const text = component.text()
-        expect(text).toContain("Ashkan Gallery12 months ago")
+        expect(text).toContain("Conversation with Ashkan Gallery")
       })
     })
     describe("without previous conversations", () => {


### PR DESCRIPTION
This caused a test failure in master due to the number of months changing from 12 to 13. 

You can see the failure here: https://app.circleci.com/jobs/github/artsy/reaction/61094

As a follow up we should figure out how to properly mock up this date data so that it's consistent between runs. Given that we're still really in flux on this work currently though, I'm just narrowing down the check.  