### PR TITLE
[ViewingRoom] Make sure width is auto on carousel

### DIFF
--- a/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomCarousel.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomCarousel.tsx
@@ -51,8 +51,8 @@ const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
           onDragEnd={({ flickity }) => update(flickity.selectedIndex)}
           render={({ resized: { url, width, height }, internalID }) => {
             return (
-              <Box key={internalID} width={width} height={height}>
-                <Image height={CarouselHeight} src={url} width={width} />
+              <Box key={internalID} width="auto" height={CarouselHeight}>
+                <Image src={url} width="auto" height={CarouselHeight} />
               </Box>
             )
           }}


### PR DESCRIPTION
One more -- rather than fixed width, we set to auto and let the height drive the shape. 