### PR TITLE
Fix vertical alignment of CountrySelect ::after element

### DIFF
--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -130,7 +130,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
       })}
     >
       {({ form, wizard }) => (
-        <Box>
+        <>
           <Sans mt={1} color="black60" size="3t">
             Enter your mobile phone number.
           </Sans>
@@ -138,12 +138,12 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
             We’ll send you a security code to this number whenever you log into
             Artsy.
           </Sans>
+          <Spacer mt={3} />
           <CountrySelect
-            mt={3}
-            mb={1}
             selected={form.values.countryCode}
             onSelect={value => form.setFieldValue("countryCode", value)}
           />
+          <Spacer mt={1} />
           <StyledInput
             autoComplete="off"
             name="phoneNumber"
@@ -169,7 +169,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
           >
             Next
           </Button>
-        </Box>
+        </>
       )}
     </Step>,
     <Step
@@ -179,7 +179,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
       })}
     >
       {({ form, wizard }) => (
-        <Box>
+        <>
           <Sans mt={1} color="black60" size="3t">
             We’ve sent the authentication code to{" "}
             {form.values.formattedPhoneNumber}. Please enter the code to verify
@@ -221,7 +221,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
               Turn on
             </Button>
           </Flex>
-        </Box>
+        </>
       )}
     </Step>,
   ]


### PR DESCRIPTION
The position of the ::after element shifts if margin is applied to the `Select` element. Seems strange but using Spacer elements instead fixes the alignment for now.

## Screenshots

### Before

![Screenshot from 2020-05-19 19-51-04](https://user-images.githubusercontent.com/123595/82389491-5a169000-9a0a-11ea-8c27-a045f2da0c54.png)


### After

![Screenshot from 2020-05-19 19-50-06](https://user-images.githubusercontent.com/123595/82389497-5e42ad80-9a0a-11ea-9730-dc03dbf416de.png)
