### PR TITLE
Autofocus 2FA authentication code fields

### DIFF
--- a/src/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/Components/Authentication/Desktop/LoginForm.tsx
@@ -49,6 +49,7 @@ const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
         onBlur={handleBlur}
         setTouched={setTouched}
         touchedOnChange={false}
+        autoFocus
       />
     )
   )

--- a/src/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/Components/Authentication/Mobile/LoginForm.tsx
@@ -49,6 +49,7 @@ const OtpInput: React.FC<ConditionalOtpInputProps> = props => {
       onBlur={handleBlur}
       setTouched={setTouched}
       touchedOnChange={false}
+      autoFocus
     />
   )
 }
@@ -160,6 +161,7 @@ class MobileLoginFormWithSystemContext extends Component<
             onBlur={handleBlur}
             setTouched={setTouched}
             touchedOnChange={false}
+            autoFocus
           />
           <Flex alignItems="center" justifyContent="flex-end">
             <ForgotPassword onClick={() => this.getForgotUrl()} />


### PR DESCRIPTION
These inputs conditionally pop into the UI in response to a specific server error code. Autofocus the 2FA authentication code input field when it becomes visible as the user should enter in a valid authentication code at that time.

jira :lock: : https://artsyproduct.atlassian.net/browse/TRUST-235

## Screen Recordings

### Before

![Peek 2020-05-19 22-43-2](https://user-images.githubusercontent.com/123595/82399093-55f66c80-9a22-11ea-8144-d54aa8da905b.gif)
![Peek 2020-05-19 22-44](https://user-images.githubusercontent.com/123595/82399092-55f66c80-9a22-11ea-88f5-f05b65d7b302.gif)


### After

![Peek 2020-05-19 22-42](https://user-images.githubusercontent.com/123595/82399099-5989f380-9a22-11ea-8ca7-0425cee5a58b.gif)
![Peek 2020-05-19 22-43](https://user-images.githubusercontent.com/123595/82399097-58f15d00-9a22-11ea-8102-dd31a647420b.gif)