### PR TITLE
2FA enrollment responsive fix: switch to maxWidth

### DIFF
--- a/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -133,7 +133,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
         justifyContent="space-between"
         width="100%"
       >
-        <Flex flexDirection="column" width="345px">
+        <Flex flexDirection="column" maxWidth="345px">
           <Sans size="4t" color="black100">
             Use text messages
           </Sans>


### PR DESCRIPTION
Missed this in the last go around.

## Screenshots

### Before

![Screenshot from 2020-05-20 09-09-02](https://user-images.githubusercontent.com/123595/82449874-e44a0d00-9a79-11ea-9e97-da9759a6c184.png)
