### PR TITLE
Conversation not updated correctly when new messages is entered by collector

### DIFF
--- a/src/Apps/Conversation/Components/Reply.tsx
+++ b/src/Apps/Conversation/Components/Reply.tsx
@@ -49,7 +49,6 @@ interface ReplyProps {
 
 export const Reply: React.FC<ReplyProps> = props => {
   const { environment, conversation } = props
-  // const [bodyText, setBodyText] = useState("")
   const [buttonDisabled, setButtonDisabled] = useState(true)
   const textArea = useRef()
 
@@ -83,12 +82,12 @@ export const Reply: React.FC<ReplyProps> = props => {
               // @ts-ignore
               textArea?.current?.value,
               _response => {
-                // setBodyText(null)
                 // @ts-ignore
                 textArea.current.value = ""
+                setButtonDisabled(true)
               },
               _error => {
-                // setBodyText(null)
+                // TBD
               }
             )
           }}


### PR DESCRIPTION
[PURCHASE-1904]

https://www.notion.so/artsy/Conversation-not-updated-correctly-when-new-messages-is-entered-by-collector-61d0224fe67e4d44bf8c13fe52565a4b

This PR is the result of our mob pairing session on Tuesday. In addition to the message order bug, we fixed an issue where the text area input wasn't clearing properly.

[PURCHASE-1904]: https://artsyproduct.atlassian.net/browse/PURCHASE-1904