### PR TITLE
Show prices on default view of artist auction results.

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -26,9 +26,6 @@ import {
   ImageWithFallback,
   renderFallbackImage,
 } from "./Components/ImageWithFallback"
-import { useAuctionResultsFilterContext } from "./AuctionResultsFilterContext"
-import { isEqual } from "lodash"
-import { auctionResultsFilterResetState } from "./AuctionResultsFilterContext"
 
 export interface Props extends SystemContextProps {
   expanded?: boolean
@@ -36,7 +33,7 @@ export interface Props extends SystemContextProps {
   index: number
   mediator?: Mediator
   lastChild: boolean
-  filtersHaveUpdated: boolean
+  filtersAtDefault: boolean
   paginated: boolean
 }
 
@@ -75,13 +72,6 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
     })
   }
 
-  // Is current filter state different from the default (reset) state?
-  const filterContext = useAuctionResultsFilterContext()
-  const filtersHaveUpdated = !isEqual(
-    filterContext.filters,
-    auctionResultsFilterResetState
-  )
-
   return (
     <>
       <Media at="xs">
@@ -92,7 +82,6 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
               expanded={expanded}
               mediator={mediator}
               user={user}
-              filtersHaveUpdated={filtersHaveUpdated}
             />
           </Row>
           <Box>
@@ -100,7 +89,7 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
               { ...props, expanded },
               user,
               mediator,
-              filtersHaveUpdated
+              props.filtersAtDefault
             )}
           </Box>
         </FullWidthBorderBox>
@@ -115,7 +104,6 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
                 expanded={expanded}
                 mediator={mediator}
                 user={user}
-                filtersHaveUpdated={filtersHaveUpdated}
               />
             </Row>
           </Box>
@@ -124,7 +112,7 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
               { ...props, expanded },
               user,
               mediator,
-              filtersHaveUpdated
+              props.filtersAtDefault
             )}
           </Box>
         </FullWidthBorderBox>
@@ -208,7 +196,7 @@ const LargeAuctionItem: SFC<Props> = props => {
               props.user,
               props.mediator,
               "lg",
-              props.filtersHaveUpdated,
+              props.filtersAtDefault,
               props.paginated
             )}
           </Flex>
@@ -253,7 +241,7 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
           props.user,
           props.mediator,
           "xs",
-          props.filtersHaveUpdated,
+          props.filtersAtDefault,
           props.paginated
         )}
         <Sans size="2" weight="medium" color="black60">
@@ -338,7 +326,7 @@ const renderPricing = (
   user,
   mediator,
   size,
-  filtersHaveUpdated,
+  filtersAtDefault,
   paginated
 ) => {
   const textSize = size === "xs" ? "2" : "3t"
@@ -347,7 +335,7 @@ const renderPricing = (
   // Ideally we get current page number from filter context 'page' property but somehow it is always '1'.
   // So we resort to pagination detection. If user has paginated at all, prices will be hidden. even if user comes back to page 1.
   // TODO: Fix filter context so its 'page' property has the current page number, then change this code.
-  if (user || (!filtersHaveUpdated && !paginated)) {
+  if (user || (filtersAtDefault && !paginated)) {
     const textAlign = size === "xs" ? "left" : "right"
     const dateOfSale = DateTime.fromISO(saleDate)
     const now = DateTime.local()
@@ -448,12 +436,12 @@ const renderRealizedPrice = (
   user,
   mediator,
   size,
-  filtersHaveUpdated,
+  filtersAtDefault,
   paginated
 ) => {
   const justifyContent = size === "xs" ? "flex-start" : "flex-end"
   // Show prices if user is logged in. Otherwise, show prices only on default view - filters at default and no pagination has happened.
-  if (user || (!filtersHaveUpdated && !paginated)) {
+  if (user || (filtersAtDefault && !paginated)) {
     return (
       <Flex justifyContent={justifyContent}>
         {estimatedPrice && (
@@ -487,7 +475,7 @@ const renderRealizedPrice = (
   }
 }
 
-const renderLargeCollapse = (props, user, mediator, filtersHaveUpdated) => {
+const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
   const {
     expanded,
     auctionResult: {
@@ -563,7 +551,7 @@ const renderLargeCollapse = (props, user, mediator, filtersHaveUpdated) => {
               user,
               mediator,
               "lg",
-              filtersHaveUpdated,
+              filtersAtDefault,
               props.paginated
             )}
           </Col>
@@ -588,7 +576,7 @@ const renderLargeCollapse = (props, user, mediator, filtersHaveUpdated) => {
   )
 }
 
-const renderSmallCollapse = (props, user, mediator, filtersHaveUpdated) => {
+const renderSmallCollapse = (props, user, mediator, filtersAtDefault) => {
   const {
     expanded,
     auctionResult: {
@@ -650,7 +638,7 @@ const renderSmallCollapse = (props, user, mediator, filtersHaveUpdated) => {
               user,
               mediator,
               "xs",
-              filtersHaveUpdated,
+              filtersAtDefault,
               props.paginated
             )}
           </Col>

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -36,6 +36,7 @@ export interface Props extends SystemContextProps {
   index: number
   mediator?: Mediator
   lastChild: boolean
+  filtersHaveUpdated: boolean
 }
 
 const FullWidthBorderBox = styled(BorderBox)`
@@ -87,6 +88,7 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
               expanded={expanded}
               mediator={mediator}
               user={user}
+              filtersHaveUpdated={filtersHaveUpdated}
             />
           </Row>
           <Box>
@@ -104,6 +106,7 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
                 expanded={expanded}
                 mediator={mediator}
                 user={user}
+                filtersHaveUpdated={filtersHaveUpdated}
               />
             </Row>
           </Box>
@@ -190,7 +193,8 @@ const LargeAuctionItem: SFC<Props> = props => {
               saleDate,
               props.user,
               props.mediator,
-              "lg"
+              "lg",
+              props.filtersHaveUpdated
             )}
           </Flex>
           <Flex width="10%" justifyContent="flex-end">
@@ -228,7 +232,14 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
         )}
       </Flex>
       <Flex ml={2} flexDirection="column" justifyContent="center" width="100%">
-        {renderPricing(salePrice, saleDate, props.user, props.mediator, "xs")}
+        {renderPricing(
+          salePrice,
+          saleDate,
+          props.user,
+          props.mediator,
+          "xs",
+          props.filtersHaveUpdated
+        )}
         <Sans size="2" weight="medium" color="black60">
           {title}
           {title && date_text && ", "}
@@ -305,10 +316,17 @@ const getProps = (props: Props) => {
   }
 }
 
-const renderPricing = (salePrice, saleDate, user, mediator, size) => {
+const renderPricing = (
+  salePrice,
+  saleDate,
+  user,
+  mediator,
+  size,
+  filtersHaveUpdated
+) => {
   const textSize = size === "xs" ? "2" : "3t"
 
-  if (user) {
+  if (user || !filtersHaveUpdated) {
     const textAlign = size === "xs" ? "left" : "right"
     const dateOfSale = DateTime.fromISO(saleDate)
     const now = DateTime.local()

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -1,4 +1,4 @@
-import { Intent, ContextModule } from "@artsy/cohesion"
+import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   ArrowDownIcon,
   ArrowUpIcon,
@@ -26,6 +26,9 @@ import {
   ImageWithFallback,
   renderFallbackImage,
 } from "./Components/ImageWithFallback"
+import { useAuctionResultsFilterContext } from "./AuctionResultsFilterContext"
+import { isEqual } from "lodash"
+import { usePrevious } from "Utils/Hooks/usePrevious"
 
 export interface Props extends SystemContextProps {
   expanded?: boolean
@@ -69,6 +72,10 @@ export const ArtistAuctionResultItem: SFC<Props> = props => {
       },
     })
   }
+
+  const filterContext = useAuctionResultsFilterContext()
+  const previousFilterContext = usePrevious(filterContext)
+  const filtersHaveUpdated = !isEqual(filterContext, previousFilterContext)
 
   return (
     <>
@@ -300,6 +307,7 @@ const getProps = (props: Props) => {
 
 const renderPricing = (salePrice, saleDate, user, mediator, size) => {
   const textSize = size === "xs" ? "2" : "3t"
+
   if (user) {
     const textAlign = size === "xs" ? "left" : "right"
     const dateOfSale = DateTime.fromISO(saleDate)

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -37,7 +37,7 @@ export interface Props extends SystemContextProps {
   mediator?: Mediator
   lastChild: boolean
   filtersHaveUpdated: boolean
-  paginationCount: number
+  paginated: boolean
 }
 
 const FullWidthBorderBox = styled(BorderBox)`
@@ -209,7 +209,7 @@ const LargeAuctionItem: SFC<Props> = props => {
               props.mediator,
               "lg",
               props.filtersHaveUpdated,
-              props.paginationCount
+              props.paginated
             )}
           </Flex>
           <Flex width="10%" justifyContent="flex-end">
@@ -254,7 +254,7 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
           props.mediator,
           "xs",
           props.filtersHaveUpdated,
-          props.paginationCount
+          props.paginated
         )}
         <Sans size="2" weight="medium" color="black60">
           {title}
@@ -339,15 +339,15 @@ const renderPricing = (
   mediator,
   size,
   filtersHaveUpdated,
-  paginationCount
+  paginated
 ) => {
   const textSize = size === "xs" ? "2" : "3t"
 
   // If user is logged in we show prices. Otherwise we show prices only for the default view - on page 1 and filters not changed.
   // Ideally we get current page number from filter context 'page' property but somehow it is always '1'.
-  // So we resort to pagination count. If user has paginated at all, prices will be hidden. even if user comes back to page 1.
+  // So we resort to pagination detection. If user has paginated at all, prices will be hidden. even if user comes back to page 1.
   // TODO: Fix filter context so its 'page' property has the current page number, then change this code.
-  if (user || (!filtersHaveUpdated && paginationCount == 0)) {
+  if (user || (!filtersHaveUpdated && !paginated)) {
     const textAlign = size === "xs" ? "left" : "right"
     const dateOfSale = DateTime.fromISO(saleDate)
     const now = DateTime.local()
@@ -449,11 +449,11 @@ const renderRealizedPrice = (
   mediator,
   size,
   filtersHaveUpdated,
-  paginationCount
+  paginated
 ) => {
   const justifyContent = size === "xs" ? "flex-start" : "flex-end"
   // Show prices if user is logged in. Otherwise, show prices only on default view - filters at default and no pagination has happened.
-  if (user || (!filtersHaveUpdated && paginationCount == 0)) {
+  if (user || (!filtersHaveUpdated && !paginated)) {
     return (
       <Flex justifyContent={justifyContent}>
         {estimatedPrice && (
@@ -564,7 +564,7 @@ const renderLargeCollapse = (props, user, mediator, filtersHaveUpdated) => {
               mediator,
               "lg",
               filtersHaveUpdated,
-              props.paginationCount
+              props.paginated
             )}
           </Col>
         </Row>
@@ -651,7 +651,7 @@ const renderSmallCollapse = (props, user, mediator, filtersHaveUpdated) => {
               mediator,
               "xs",
               filtersHaveUpdated,
-              props.paginationCount
+              props.paginated
             )}
           </Col>
         </Row>

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -344,7 +344,7 @@ const renderPricing = (
   const textSize = size === "xs" ? "2" : "3t"
 
   // If user is logged in we show prices. Otherwise we show prices only for the default view - on page 1 and filters not changed.
-  // Ideally we get current page number fomr filter context 'page' property but somehow it is always '1'.
+  // Ideally we get current page number from filter context 'page' property but somehow it is always '1'.
   // So we resort to pagination count. If user has paginated at all, prices will be hidden. even if user comes back to page 1.
   // TODO: Fix filter context so its 'page' property has the current page number, then change this code.
   if (user || (!filtersHaveUpdated && paginationCount == 0)) {
@@ -452,7 +452,7 @@ const renderRealizedPrice = (
   paginationCount
 ) => {
   const justifyContent = size === "xs" ? "flex-start" : "flex-end"
-  // Show prices if user is logged in. Also show prices if user is at the first view - filters and pagination at default.
+  // Show prices if user is logged in. Otherwise, show prices only on default view - filters at default and no pagination has happened.
   if (user || (!filtersHaveUpdated && paginationCount == 0)) {
     return (
       <Flex justifyContent={justifyContent}>

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -51,7 +51,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   } = filterContext.filters
 
   // Count number of times user paginated.
-  const [paginationCount, incrementPaginationCount] = useState(0)
+  const [paginated, togglePaginated] = useState(false)
 
   const loadNext = () => {
     const { hasNextPage, endCursor } = pageInfo
@@ -63,7 +63,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   const loadAfter = cursor => {
     setIsLoading(true)
-    incrementPaginationCount(paginationCount + 1)
+    togglePaginated(true)
 
     relay.refetch(
       {
@@ -159,7 +159,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
               auctionResult={node}
               lastChild={index === auctionResultsLength - 1}
               filtersHaveUpdated={false}
-              paginationCount={paginationCount}
+              paginated={paginated}
             />
           </React.Fragment>
         )

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -2,7 +2,7 @@ import { Col, Row } from "@artsy/palette"
 import { ArtistAuctionResults_artist } from "__generated__/ArtistAuctionResults_artist.graphql"
 import { PaginationFragmentContainer as Pagination } from "Components/Pagination"
 import React, { useState } from "react"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { AuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import { TableSidebar } from "./Components/TableSidebar"
@@ -154,6 +154,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
               index={index}
               auctionResult={node}
               lastChild={index === auctionResultsLength - 1}
+              filtersHaveUpdated={false}
             />
           </React.Fragment>
         )

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -24,6 +24,7 @@ import { AuctionFilterMobileActionSheet } from "./Components/AuctionFilterMobile
 import { AuctionFilters } from "./Components/AuctionFilters"
 import { AuctionResultHeaderFragmentContainer as AuctionResultHeader } from "./Components/AuctionResultHeader"
 import { AuctionResultsControls } from "./Components/AuctionResultsControls"
+import { auctionResultsFilterResetState } from "./AuctionResultsFilterContext"
 
 const logger = createLogger("ArtistAuctionResults.tsx")
 
@@ -95,6 +96,12 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const tracking = useTracking()
 
+  // Is current filter state different from the default (reset) state?
+  const filtersAtDefault = isEqual(
+    filterContext.filters,
+    auctionResultsFilterResetState
+  )
+
   const previousFilters = usePrevious(filterContext.filters)
 
   // TODO: move this and artwork copy to util?
@@ -158,7 +165,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
               index={index}
               auctionResult={node}
               lastChild={index === auctionResultsLength - 1}
-              filtersHaveUpdated={false}
+              filtersAtDefault={filtersAtDefault}
               paginated={paginated}
             />
           </React.Fragment>

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -50,6 +50,9 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     allowEmptyCreatedDates,
   } = filterContext.filters
 
+  // Count number of times user paginated.
+  const [paginationCount, incrementPaginationCount] = useState(0)
+
   const loadNext = () => {
     const { hasNextPage, endCursor } = pageInfo
 
@@ -60,6 +63,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   const loadAfter = cursor => {
     setIsLoading(true)
+    incrementPaginationCount(paginationCount + 1)
 
     relay.refetch(
       {
@@ -155,6 +159,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
               auctionResult={node}
               lastChild={index === auctionResultsLength - 1}
               filtersHaveUpdated={false}
+              paginationCount={paginationCount}
             />
           </React.Fragment>
         )

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -51,7 +51,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     allowEmptyCreatedDates,
   } = filterContext.filters
 
-  // Count number of times user paginated.
+  // Detect whether user has paginated at all.
   const [paginated, togglePaginated] = useState(false)
 
   const loadNext = () => {

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -71,7 +71,7 @@ export type SharedAuctionResultsFilterContextProps = Pick<
   onChange?: (filterState) => void
 }
 
-let auctionResultsFilterResetState: AuctionResultsFilters = initialAuctionResultsFilterState
+export let auctionResultsFilterResetState: AuctionResultsFilters = initialAuctionResultsFilterState
 
 export const AuctionResultsFilterContextProvider: React.FC<SharedAuctionResultsFilterContextProps & {
   children: React.ReactNode

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -62,6 +62,12 @@ describe("AuctionResults", () => {
       expect(wrapper.html()).toContain("Showing 830 results")
     })
 
+    it("renders either realized price or price not avail", () => {
+      expect(wrapper.html()).toContain(
+        "Price not available" || "Realized price"
+      )
+    })
+
     it("renders proper select options", () => {
       const html = wrapper.find("SelectSmall").html()
       expect(html).toContain("Most recent")
@@ -116,6 +122,17 @@ describe("AuctionResults", () => {
               after: "YXJyYXljb25uZWN0aW9uOjk=",
             })
           )
+        })
+
+        it("re-shows sign up to see price", () => {
+          const pagination = wrapper.find("Pagination")
+          pagination
+            .find("button")
+            .at(2)
+            .simulate("click")
+          wrapper.update()
+          const html = wrapper.html()
+          expect(html).toContain("Sign up to see price")
         })
       })
       describe("filters", () => {

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.test.tsx
@@ -137,7 +137,7 @@ describe("AuctionResults", () => {
       })
       describe("filters", () => {
         describe("medium filter", () => {
-          it("triggers relay refetch with medium list", done => {
+          it("triggers relay refetch with medium list, and re-shows sign up to see price", done => {
             const filter = wrapper.find("MediumFilter")
 
             const checkboxes = filter.find("Checkbox")
@@ -188,13 +188,17 @@ describe("AuctionResults", () => {
                   allowEmptyCreatedDates: true,
                 },
               })
+
+              wrapper.update()
+              const html = wrapper.html()
+              expect(html).toContain("Sign up to see price")
+
               done()
             })
           })
         })
         describe("auction house filter", () => {
-          // TODO: Re-enable once we uncollapse auction house filters
-          it.skip("triggers relay refetch with organization list", done => {
+          it("triggers relay refetch with organization list, and re-shows sign up to see price", done => {
             const filter = wrapper.find("AuctionHouseFilter")
 
             const checkboxes = filter.find("Checkbox")
@@ -226,12 +230,17 @@ describe("AuctionResults", () => {
                   organizations: ["Phillips"],
                 })
               )
+
+              wrapper.update()
+              const html = wrapper.html()
+              expect(html).toContain("Sign up to see price")
+
               done()
             })
           })
         })
         describe("size filter", () => {
-          it("triggers relay refetch with size list and tracks events", done => {
+          it("triggers relay refetch with size list and tracks events, and re-shows sign up to see price", done => {
             const filter = wrapper.find("SizeFilter")
 
             const checkboxes = filter.find("Checkbox")
@@ -283,13 +292,17 @@ describe("AuctionResults", () => {
                 },
               })
 
+              wrapper.update()
+              const html = wrapper.html()
+              expect(html).toContain("Sign up to see price")
+
               done()
             })
           })
         })
         describe("year created filter", () => {
           const value = v => ({ target: { value: `${v}` } })
-          it("triggers relay refetch with created years and tracks events", () => {
+          it("triggers relay refetch with created years and tracks events, and re-shows sign up to see price", () => {
             const filter = wrapper.find("YearCreated")
             const selects = filter.find("select")
 
@@ -309,12 +322,16 @@ describe("AuctionResults", () => {
                 latestCreatedYear: 1973,
               })
             )
+
+            wrapper.update()
+            const html = wrapper.html()
+            expect(html).toContain("Sign up to see price")
           })
         })
       })
 
       describe("sort", () => {
-        it("triggers relay refetch with correct params", done => {
+        it("triggers relay refetch with correct params, and re-shows sign up to see price", done => {
           const sort = wrapper.find("SortSelect SelectSmall")
 
           sort
@@ -330,6 +347,11 @@ describe("AuctionResults", () => {
                 sort: "ESTIMATE_AND_DATE_DESC",
               })
             )
+
+            wrapper.update()
+            const html = wrapper.html()
+            expect(html).toContain("Sign up to see price")
+
             done()
           })
         })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1925

Currently on Artist Auction Results, user must be logged-in to see prices. This change is to relax that restriction but only for the default view which is the view on page 1 when filters are at default. We will show prices in the default view even when no user is logged-in.

Please note, due to filter context being incorrect about the page# of the page being viewed (it always says 1), I cannot track the page# the user is on. I resort to tracking whether pagination has occurred. If pagination has occurred, prices are hidden. So if user clicks page 1 while on page 1, the page hasn't changed, but pagination has occurred, prices will be hidden again.

--
Screenshots showing effects of the change:

Not logged-in. Page 1. Default filters. Price shown.
![Screenshot from 2020-05-20 16-49-44](https://user-images.githubusercontent.com/63004951/82496285-7b36b980-9aba-11ea-989a-d204319814b3.png)

Not logged-in. Page 1. Medium `Painting` checked. Prices hidden.
![Screenshot from 2020-05-20 16-50-33](https://user-images.githubusercontent.com/63004951/82496361-97d2f180-9aba-11ea-93d7-ea7bd8ab64e2.png)

Not logged-in. Page 2. Default filters. Prices hidden.
![Screenshot from 2020-05-20 16-50-57](https://user-images.githubusercontent.com/63004951/82496450-be912800-9aba-11ea-865c-606f44295e6c.png)

