### PR TITLE
[Viewing Room] QA

### DIFF
--- a/src/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -56,7 +56,7 @@ const ViewingRoomHeaderLarge: React.FC<ViewingRoomHeaderProps> = props => {
   return (
     <Flex
       style={{
-        height: `calc(100vh - ${NavBarHeight}px)`,
+        height: `calc(90vh - ${NavBarHeight}px)`,
         borderBottom: `1px solid ${color("black10")}`,
       }}
     >

--- a/src/Apps/ViewingRoom/Routes/Statement/Components/ViewWorksButton.tsx
+++ b/src/Apps/ViewingRoom/Routes/Statement/Components/ViewWorksButton.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { RouterLink } from "Artsy/Router/RouterLink"
+import { scrollToId } from "../Utils/scrollToId"
+import { AnalyticsSchema, useTracking } from "Artsy"
+import { Button } from "@artsy/palette"
+import { useRouter } from "Artsy/Router/useRouter"
+
+export const ViewWorksButton: React.FC = () => {
+  const tracking = useTracking()
+
+  const {
+    match: {
+      params: { slug },
+    },
+  } = useRouter()
+
+  const navigateTo = `/viewing-room/${slug}/works`
+
+  return (
+    <RouterLink
+      to={navigateTo}
+      data-test="viewingRoomWorksButton"
+      onClick={() => {
+        scrollToId("viewingRoomTabBarAnchor")
+        tracking.trackEvent({
+          action_type: AnalyticsSchema.ActionType.ClickedArtworkGroup,
+          context_module: AnalyticsSchema.ContextModule.ViewingRoomArtworkRail,
+          subject: AnalyticsSchema.Subject.ViewWorks,
+          destination_path: navigateTo,
+        })
+      }}
+    >
+      <Button size="large" width="100%">
+        View works
+      </Button>
+    </RouterLink>
+  )
+}

--- a/src/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
+++ b/src/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
@@ -5,8 +5,8 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 import { ViewingRoomWorks_viewingRoom } from "__generated__/ViewingRoomWorks_viewingRoom.graphql"
 import { RouterLink } from "Artsy/Router/RouterLink"
-import { LinkPropsSimple } from "found"
 import { AnalyticsSchema, useTracking } from "Artsy"
+import { scrollToId } from "../Utils/scrollToId"
 
 interface ViewingRoomWorksProps {
   viewingRoom: ViewingRoomWorks_viewingRoom
@@ -17,26 +17,24 @@ const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
     artworksConnection: { edges },
   },
 }) => {
+  const tracking = useTracking()
+
   const {
     match: {
       params: { slug },
     },
   } = useRouter()
 
-  const tracking = useTracking()
-
-  const linkProps: LinkPropsSimple = {
-    to: `/viewing-room/${slug}/works`,
-  }
+  const navigateTo = `/viewing-room/${slug}/works`
 
   return (
     <>
       <Flex>
-        {edges.map(({ node: artwork }) => {
+        {edges.map(({ node: artwork }, index) => {
           return (
             <ArtworkItem
               key={artwork.internalID}
-              linkProps={linkProps}
+              navigateTo={navigateTo}
               {...artwork}
             />
           )
@@ -44,16 +42,16 @@ const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
       </Flex>
       <Spacer my={4} />
       <RouterLink
-        {...linkProps}
+        to={navigateTo}
         data-test="viewingRoomWorksButton"
         onClick={() => {
-          scrollToTabBar()
+          scrollToId("viewingRoomTabBarAnchor")
           tracking.trackEvent({
             action_type: AnalyticsSchema.ActionType.ClickedArtworkGroup,
             context_module:
               AnalyticsSchema.ContextModule.ViewingRoomArtworkRail,
             subject: AnalyticsSchema.Subject.ViewWorks,
-            destination_path: linkProps.to as string,
+            destination_path: navigateTo,
           })
         }}
       >
@@ -87,51 +85,46 @@ export const ViewingRoomWorksFragmentContainer = createFragmentContainer(
 )
 
 type ArtworkNode = ViewingRoomWorksProps["viewingRoom"]["artworksConnection"]["edges"][0]["node"] & {
-  linkProps: LinkPropsSimple
+  navigateTo: string
 }
 
 const ArtworkItem: React.FC<ArtworkNode> = ({
   artistNames,
   date,
   imageUrl,
+  navigateTo,
   title,
-  linkProps,
 }) => {
   const tracking = useTracking()
 
   return (
     <RouterLink
-      {...linkProps}
+      to={navigateTo}
       style={{ textDecoration: "none", width: "50%" }}
       onClick={() => {
-        scrollToTabBar()
+        scrollToId("viewingRoomTabBarAnchor")
+
         tracking.trackEvent({
           action_type: AnalyticsSchema.ActionType.ClickedArtworkGroup,
           context_module: AnalyticsSchema.ContextModule.ViewingRoomArtworkRail,
           subject: AnalyticsSchema.Subject.ArtworkThumbnail,
-          destination_path: linkProps.to as string,
+          destination_path: navigateTo,
         })
       }}
     >
-      <Box pl={1}>
+      <Box width="95%">
         <Box>
           <Image width="100%" src={imageUrl} />
         </Box>
         <Box>
-          <Sans size="3">{artistNames}</Sans>
+          <Sans size="3t">{artistNames}</Sans>
         </Box>
         <Box style={{ textOverflow: "ellipsis" }}>
-          <Sans size="3" color="black60">
+          <Sans size="3t" color="black60">
             {[title, date].filter(s => s).join(", ")}
           </Sans>
         </Box>
       </Box>
     </RouterLink>
   )
-}
-
-const scrollToTabBar = () => {
-  const element = document.getElementById("viewingRoomTabBarAnchor")
-  const top = element.getBoundingClientRect().top + window.pageYOffset - 80
-  window.scrollTo({ top, behavior: "auto" })
 }

--- a/src/Apps/ViewingRoom/Routes/Statement/Utils/scrollToId.tsx
+++ b/src/Apps/ViewingRoom/Routes/Statement/Utils/scrollToId.tsx
@@ -1,0 +1,5 @@
+export function scrollToId(id: string) {
+  const element = document.getElementById(id)
+  const top = element.getBoundingClientRect().top + window.pageYOffset - 80
+  window.scrollTo({ top })
+}

--- a/src/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
+++ b/src/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { Box, Spacer, Join } from "@artsy/palette"
+import { Box, Join, Spacer } from "@artsy/palette"
 import { ViewingRoomWorksFragmentContainer as ViewingRoomWorks } from "./Components/ViewingRoomWorks"
 import { ViewingRoomIntroFragmentContainer as ViewingRoomIntro } from "./Components/ViewingRoomIntro"
 import { ViewingRoomPullQuoteFragmentContainer as ViewingRoomPullQuote } from "./Components/ViewingRoomPullQuote"
 import { ViewingRoomSubsectionsFragmentContainer as ViewingRoomSubsections } from "./Components/ViewingRoomSubsections"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ViewingRoomStatementRoute_viewingRoom } from "__generated__/ViewingRoomStatementRoute_viewingRoom.graphql"
+import { ViewWorksButton } from "./Components/ViewWorksButton"
 
 interface ViewingRoomStatementRouteProps {
   viewingRoom: ViewingRoomStatementRoute_viewingRoom
@@ -22,9 +23,10 @@ const StatementRoute: React.FC<ViewingRoomStatementRouteProps> = ({
           <ViewingRoomWorks viewingRoom={viewingRoom} />
           <ViewingRoomPullQuote viewingRoom={viewingRoom} />
           <ViewingRoomSubsections viewingRoom={viewingRoom} />
+          <ViewWorksButton />
         </Join>
       </Box>
-      <Spacer my={4} />
+      <Spacer mt={4} mb={[4, 9]} />
     </Box>
   )
 }

--- a/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
@@ -24,18 +24,18 @@ export const ViewingRoomArtworkDetails: React.FC<ViewingRoomArtworkDetailsProps>
   return (
     <Box maxWidth={["100%", 470]} m="auto">
       <Box>
-        <Sans size="3">{artistNames}</Sans>
+        <Sans size="3t">{artistNames}</Sans>
       </Box>
 
       <Box style={{ textOverflow: "ellipsis" }}>
-        <Sans size="3" color="black60">
+        <Sans size="3t" color="black60">
           {[title, date].filter(s => s).join(", ")}
         </Sans>
       </Box>
 
       {saleMessage && (
         <Box>
-          <Sans size="3" color="black60">
+          <Sans size="3t" color="black60">
             {saleMessage}
           </Sans>
         </Box>

--- a/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomCarousel.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomCarousel.tsx
@@ -86,7 +86,7 @@ const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
       </Flex>
 
       {showProgressBar && (
-        <Box width="50%" m="auto">
+        <Box maxWidth={["100%", 470]} mx={[2, "auto"]}>
           <ProgressBar
             highlight="black100"
             percentComplete={scrollPercent}

--- a/src/Apps/ViewingRoom/Routes/Works/ViewingRoomWorksRoute.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/ViewingRoomWorksRoute.tsx
@@ -14,7 +14,7 @@ const ViewingRoomWorksRoute: React.FC<WorksRouteProps> = ({ viewingRoom }) => {
     <Join separator={<Spacer my={4} />}>
       {viewingRoom.artworksConnection.edges.map(({ node: artwork }) => {
         return (
-          <Box key={artwork.internalID}>
+          <Box key={artwork.internalID} id={artwork.internalID}>
             <ViewingRoomCarousel artwork={artwork} />
             <Spacer my={2} />
             <Box mb={9} px={[2, 0]}>

--- a/src/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -1,12 +1,13 @@
 import React from "react"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { Box } from "@artsy/palette"
+import { Box, Separator } from "@artsy/palette"
 import { ViewingRoomHeaderFragmentContainer as ViewingRoomHeader } from "./Components/ViewingRoomHeader"
 import { ViewingRoomTabBar } from "./Components/ViewingRoomTabBar"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { ViewingRoomApp_viewingRoom } from "__generated__/ViewingRoomApp_viewingRoom.graphql"
 import { ViewingRoomMetaFragmentContainer as ViewingRoomMeta } from "./Components/ViewingRoomMeta"
+import { Footer } from "Components/Footer"
 
 interface ViewingRoomAppProps {
   children: React.ReactNode
@@ -22,10 +23,15 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
       <ViewingRoomMeta viewingRoom={viewingRoom} />
       <AppContainer maxWidth="100%">
         <ViewingRoomHeader viewingRoom={viewingRoom} />
-        <Box my={3}>
+        <Box my={[2, 3]}>
           <ViewingRoomTabBar />
         </Box>
         {children}
+
+        <Box mx={2}>
+          <Separator mt={6} mb={3} />
+          <Footer />
+        </Box>
       </AppContainer>
     </>
   )

--- a/src/Apps/__stories__/ViewingRoom.story.tsx
+++ b/src/Apps/__stories__/ViewingRoom.story.tsx
@@ -3,11 +3,20 @@ import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { routes as viewingRoomRoutes } from "Apps/ViewingRoom/routes"
 
-storiesOf("Apps/ViewingRoom", module).add("Viewing Room", () => {
-  return (
-    <MockRouter
-      routes={viewingRoomRoutes}
-      initialRoute="/viewing-room/invoicing-demo-partner-christine-sun-kim"
-    />
-  )
-})
+storiesOf("Apps/ViewingRoom", module)
+  .add("Viewing Room (Guy Yanai) ", () => {
+    return (
+      <MockRouter
+        routes={viewingRoomRoutes}
+        initialRoute="/viewing-room/subscription-demo-gg-guy-yanai"
+      />
+    )
+  })
+  .add("Viewing Room (Christine) ", () => {
+    return (
+      <MockRouter
+        routes={viewingRoomRoutes}
+        initialRoute="/viewing-room/invoicing-demo-partner-christine-sun-kim"
+      />
+    )
+  })

--- a/src/Components/Footer.tsx
+++ b/src/Components/Footer.tsx
@@ -1,22 +1,22 @@
-import { Mediator, SystemContext } from "Artsy"
-import React, { useContext } from "react"
+import { Mediator, useSystemContext } from "Artsy"
+import React from "react"
 import styled from "styled-components"
 import { FlexDirectionProps } from "styled-system"
 import { Media } from "Utils/Responsive"
 
 import {
   ArtsyMarkIcon,
-  breakpoints,
   FacebookIcon,
   Flex,
   InstagramIcon,
   Sans,
   Separator,
   Serif,
-  space,
   Spacer,
   TwitterIcon,
   WeChatIcon,
+  breakpoints,
+  space,
 } from "@artsy/palette"
 
 interface Props {
@@ -24,7 +24,7 @@ interface Props {
 }
 
 export const Footer: React.SFC<Props> = props => {
-  const { mediator } = useContext(SystemContext)
+  const { mediator } = useSystemContext()
   return (
     <>
       <Media at="xs">


### PR DESCRIPTION
- [x] (Header) @desktop, reduce header height to 95% viewport (so people know to scroll down)

(Artworks preview on Statement tab)
- [x]  Alignment seems to be a bit off between text, tiles, and button
- [x]  Spacing also looks off in the artwork tile type. 
- [ ]  ~Artworks should preserve their own image ratio.~ we dont adjust these images
- [ ]  [NICE TO HAVE] If possible, if a user taps a work, it should anchor the user to that artwork, in Works tab.

(Statement tab)
- [x]  @xs the spacing above statement text is a bit too tall.

(Carousel)
- [x] Curious how the progress bar width is being determined, would it be possible for the bar to match the width of the text across screen sizes?
- [x] Type needs to be tightened up

(Statement Tab) 
- [x]  Missing “View Works” button at bottom

Footer
- [x] Add responsive footer 
