### PR TITLE
Increases tap area for tabs

### DIFF
--- a/src/Apps/Feature/Components/FeatureHeader.tsx
+++ b/src/Apps/Feature/Components/FeatureHeader.tsx
@@ -56,6 +56,7 @@ export const FeatureHeader: React.FC<FeatureHeaderProps> = ({
             backgroundSize: "cover",
             backgroundPosition: "center center",
           }}
+          height={["50vh", "auto"]}
         />
       )}
 

--- a/src/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
+++ b/src/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
@@ -1,28 +1,22 @@
 import React from "react"
-import { Flex, color, Color, FontWeights, Box, Sans } from "@artsy/palette"
+import {
+  Box,
+  Color,
+  Flex,
+  FlexProps,
+  FontWeights,
+  Sans,
+  color,
+} from "@artsy/palette"
 import { useIsRouteActive, useRouter } from "Artsy/Router/useRouter"
 import { RouterLink } from "Artsy/Router/RouterLink"
 import { LinkProps } from "found"
 import styled from "styled-components"
 
-interface ViewingRoomTabBarProps {}
-
-export const ViewingRoomTabBar: React.FC<ViewingRoomTabBarProps> = props => {
-  const {
-    match: {
-      params: { slug },
-    },
-  } = useRouter()
-
-  return (
-    <Flex width="100%" justifyContent="center" id="viewingRoomTabBarAnchor">
-      <Flex width={["100%", 720]} height={50}>
-        <Tab to={`/viewing-room/${slug}`}>Statement</Tab>
-        <Tab to={`/viewing-room/${slug}/works`}>Works</Tab>
-      </Flex>
-    </Flex>
-  )
-}
+const TabLink = styled(RouterLink)`
+  display: block;
+  text-decoration: none;
+`
 
 const Tab: React.FC<LinkProps> = ({ children, to }) => {
   const active = useIsRouteActive(to)
@@ -35,26 +29,40 @@ const Tab: React.FC<LinkProps> = ({ children, to }) => {
   const weight: FontWeights = active ? "medium" : "regular"
 
   return (
-    <TabContainer
+    <Box
       width={["100%", "50%"]}
       textAlign="center"
-      height={40}
       style={{
         cursor: "pointer",
         borderBottom,
       }}
     >
-      <RouterLink to={to} activeClassName="active">
-        <Sans size="3" color={textColor} weight={weight}>
+      <TabLink to={to}>
+        <Sans pt={[2, 3]} pb={1} size="3" color={textColor} weight={weight}>
           {children}
         </Sans>
-      </RouterLink>
-    </TabContainer>
+      </TabLink>
+    </Box>
   )
 }
+export const ViewingRoomTabBar: React.FC<FlexProps> = props => {
+  const {
+    match: {
+      params: { slug },
+    },
+  } = useRouter()
 
-const TabContainer = styled(Box)`
-  a {
-    text-decoration: none;
-  }
-`
+  return (
+    <Flex
+      width="100%"
+      justifyContent="center"
+      id="viewingRoomTabBarAnchor"
+      {...props}
+    >
+      <Flex width={["100%", 720]}>
+        <Tab to={`/viewing-room/${slug}`}>Statement</Tab>
+        <Tab to={`/viewing-room/${slug}/works`}>Works</Tab>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -21,11 +21,12 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
   return (
     <>
       <ViewingRoomMeta viewingRoom={viewingRoom} />
+
       <AppContainer maxWidth="100%">
         <ViewingRoomHeader viewingRoom={viewingRoom} />
-        <Box my={[2, 3]}>
-          <ViewingRoomTabBar />
-        </Box>
+
+        <ViewingRoomTabBar mb={[2, 3]} />
+
         {children}
 
         <Box mx={2}>


### PR DESCRIPTION
Not a huge patch here just changes the vertical whitespace surrounding the tab to also be hit area

![](http://static.damonzucconi.com/_capture/Pz4bniiuyiQE.png)

Just opening it up as draft and will merge this into force once @damassi merges the reaction migration.