### PR TITLE
[WIP] Add price sorts to Artist pages' artworks grid

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
@@ -5,7 +5,7 @@ import { ArtworkFilterContextProvider } from "Components/v2/ArtworkFilter/Artwor
 import { updateUrl } from "Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
 import React from "react"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { ZeroState } from "./ZeroState"
 
 interface ArtistArtworkFilterProps {
@@ -30,6 +30,8 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       filters={match && match.location.query}
       sortOptions={[
         { value: "-decayed_merch", text: "Default" },
+        { value: "-has_price,-prices", text: "Price (desc.)" },
+        { value: "-has_price,prices", text: "Price (asc.)" },
         { value: "-partner_updated_at", text: "Recently updated" },
         { value: "-published_at", text: "Recently added" },
         { value: "-year", text: "Artwork year (desc.)" },

--- a/src/Apps/Artist/Routes/Works/__tests__/Works.test.tsx
+++ b/src/Apps/Artist/Routes/Works/__tests__/Works.test.tsx
@@ -60,6 +60,21 @@ describe("Works Route", () => {
       expect(wrapper.html()).toContain("Mock ArtistRecommendations")
       expect(wrapper.html()).toContain("Mock ArtistCollectionRail")
     })
+    it("includes the correct sort options", () => {
+      const sortOptions = wrapper
+        .find("div[title='Sort'] select option")
+        .map(el => el.text())
+
+      expect(sortOptions).toEqual([
+        "Default",
+        "Price (desc.)",
+        "Price (asc.)",
+        "Recently updated",
+        "Recently added",
+        "Artwork year (desc.)",
+        "Artwork year (asc.)",
+      ])
+    })
   })
 
   describe("Artist Recommendations", () => {


### PR DESCRIPTION
_Marked WIP due to the Reaction/Force merge in progress cc @damassi_

https://artsyproduct.atlassian.net/browse/FX-1956

This adds price sorting options (descending and ascending) to the artist page's artwork grid. Note that while this is ticketed as a mWeb improvement, the artist page is a responsive app, so this actually applies to desktop as well. I assume that's a Good Thing 😄 

### Mobile

<img src="https://user-images.githubusercontent.com/140521/82701725-b661f580-9c3e-11ea-952e-45d08ecd5c72.png"  height=600 />


### Desktop 

![sort](https://user-images.githubusercontent.com/140521/82701764-c2e64e00-9c3e-11ea-8f0e-8344e0e8ebe3.gif)
