### PR TITLE
Remove tracking calls for now

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -22,7 +22,6 @@ import { PricingContextFragmentContainer as PricingContext } from "./Components/
 import { SystemContextConsumer } from "Artsy"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
-import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import { useRouteTracking } from "Artsy/Analytics/useRouteTracking"
 import { Footer } from "Components/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "Components/RecentlyViewed"
@@ -92,9 +91,9 @@ export class ArtworkApp extends React.Component<Props> {
       window.analytics.page(properties, { integrations: { Marketo: false } })
 
       // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-      if (sd.CLIENT_NAVIGATION_V5) {
-        trackExperimentViewed("client_navigation_v5", properties)
-      }
+      // if (sd.CLIENT_NAVIGATION_V5) {
+      //   trackExperimentViewed("client_navigation_v5", properties)
+      // }
     }
   }
 

--- a/src/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/Artsy/Analytics/trackingMiddleware.ts
@@ -1,4 +1,3 @@
-import { trackExperimentViewed } from "Artsy/Analytics/trackExperimentViewed"
 import ActionTypes from "farce/lib/ActionTypes"
 import { data as sd } from "sharify"
 import { get } from "Utils/get"
@@ -92,9 +91,9 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             })
 
             // TODO: Remove after EXPERIMENTAL_APP_SHELL AB test ends.
-            if (sd.CLIENT_NAVIGATION_V5) {
-              trackExperimentViewed("client_navigation_v5", trackingData)
-            }
+            // if (sd.CLIENT_NAVIGATION_V5) {
+            //   trackExperimentViewed("client_navigation_v5", trackingData)
+            // }
           }
 
           // Reset timers that track time on page since we're tracking each order

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticleCanvasLink.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticleCanvasLink.tsx
@@ -1,6 +1,5 @@
 import { Serif } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
 import { RelatedArticleCanvasData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -18,18 +17,6 @@ interface RelatedArticleCanvasLinkProps
 export class RelatedArticleCanvasLink extends React.Component<
   RelatedArticleCanvasLinkProps
 > {
-  @track<RelatedArticleCanvasLinkProps>(props => ({
-    action_type: Schema.ActionType.Click,
-    destination_path: getEditorialHref(
-      props.article.layout,
-      props.article.slug
-    ),
-    type: Schema.Type.Thumbnail,
-  }))
-  onClick() {
-    // noop
-  }
-
   render() {
     const { article } = this.props
     const href = getEditorialHref(article.layout, article.slug)
@@ -37,7 +24,7 @@ export class RelatedArticleCanvasLink extends React.Component<
     const bylineArticle = { ...article, id: article.slug }
 
     return (
-      <ArticleFigure href={href} onClick={this.onClick.bind(this)}>
+      <ArticleFigure href={href}>
         <ImageTitle>
           <BlockImage src={imageSrc} alt={article.thumbnail_title} />
           <Serif size="3t">{article.thumbnail_title}</Serif>

--- a/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/RelatedArticlesCanvas.tsx
@@ -2,7 +2,7 @@ import { Flex, Sans } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RelatedArticleCanvasData } from "Components/Publishing/Typings"
-import { map, once } from "lodash"
+import { map } from "lodash"
 import React from "react"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -31,18 +31,13 @@ interface ScrollingContainerProps {
 export class RelatedArticlesCanvas extends React.Component<
   RelatedArticlesCanvasProps
 > {
-  @track(() => ({ action_type: Schema.ActionType.Impression }))
-  trackRelatedImpression() {
-    // noop
-  }
-
   render() {
     const { articles, isMobile, vertical } = this.props
 
     return (
       <Flex flexDirection="column" maxWidth={1250} mx="auto" mt={4} mb={6}>
         {getTitle(vertical)}
-        <Waypoint onEnter={once(this.trackRelatedImpression.bind(this))} />
+        <Waypoint />
         <ArticlesWrapper isMobile={isMobile}>
           {map(articles, (article, i) => {
             return (

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticleCanvasLink.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticleCanvasLink.test.tsx
@@ -27,17 +27,4 @@ describe("RelatedArticleCanvasLink", () => {
     expect(component.text()).toMatch("May 19, 2017")
     expect(component.html()).toMatch("PoetterHall_Exterior%2Bcopy.jpg")
   })
-
-  it("Tracks link clicks", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticleCanvasLink)
-    const component = mount(<Component article={RelatedCanvas[0]} />)
-    component.simulate("click")
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Click",
-      destination_path:
-        "/article/artsy-editorial-15-top-art-schools-united-states",
-      type: "thumbnail",
-    })
-  })
 })

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticleCanvasLink.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticleCanvasLink.test.tsx
@@ -1,4 +1,3 @@
-import { mockTracking } from "Artsy/Analytics"
 import { RelatedCanvas } from "Components/Publishing/Fixtures/Components"
 import { mount } from "enzyme"
 import "jest-styled-components"

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
@@ -1,10 +1,8 @@
-import { mockTracking } from "Artsy/Analytics"
 import { RelatedCanvas } from "Components/Publishing/Fixtures/Components"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
-import Waypoint from "react-waypoint"
 import { RelatedArticleCanvasLink } from "../RelatedArticleCanvasLink"
 import { RelatedArticlesCanvas } from "../RelatedArticlesCanvas"
 

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/RelatedArticlesCanvas.test.tsx
@@ -42,37 +42,4 @@ describe("RelatedArticlesCanvas", () => {
     const component = getWrapper(testProps)
     expect(component.find(RelatedArticleCanvasLink)).toHaveLength(4)
   })
-
-  it("Calls a tracking impression", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticlesCanvas)
-    const component = mount(<Component articles={RelatedCanvas} />)
-    component
-      .find(Waypoint)
-      .getElement()
-      .props.onEnter()
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Impression",
-      context_module: "Further reading",
-      subject: "Further reading",
-    })
-  })
-
-  it("Tracks link clicks", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticlesCanvas)
-    const component = mount(<Component articles={RelatedCanvas} />)
-    component
-      .find(RelatedArticleCanvasLink)
-      .at(0)
-      .simulate("click")
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Click",
-      context_module: "Further reading",
-      subject: "Further reading",
-      destination_path:
-        "/article/artsy-editorial-15-top-art-schools-united-states",
-      type: "thumbnail",
-    })
-  })
 })

--- a/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Canvas/__tests__/__snapshots__/RelatedArticlesCanvas.test.tsx.snap
@@ -229,7 +229,6 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
     <a
       className="c5"
       href="/article/artsy-editorial-15-top-art-schools-united-states"
-      onClick={[Function]}
     >
       <div
         className="c6"
@@ -292,7 +291,6 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
     <a
       className="c5"
       href="/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
-      onClick={[Function]}
     >
       <div
         className="c6"
@@ -355,7 +353,6 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
     <a
       className="c5"
       href="/series/artsy-editorial-french-art-history-in-a-nutshell"
-      onClick={[Function]}
     >
       <div
         className="c6"
@@ -418,7 +415,6 @@ exports[`RelatedArticlesCanvas renders the related articles canvas 1`] = `
     <a
       className="c5"
       href="/news/artsy-editorial-miami-artists-museums-brace-hurricane-irma"
-      onClick={[Function]}
     >
       <div
         className="c6"

--- a/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanel.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanel.tsx
@@ -2,7 +2,6 @@ import { Sans } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
 import { RelatedArticlePanelData } from "Components/Publishing/Typings"
-import { once } from "lodash"
 import React from "react"
 import Waypoint from "react-waypoint"
 import styled from "styled-components"
@@ -25,11 +24,6 @@ export class RelatedArticlesPanel extends React.Component<
     label: "Related Stories",
   }
 
-  @track(props => ({ action_type: Schema.ActionType.Impression }))
-  trackRelatedImpression() {
-    // noop
-  }
-
   render() {
     const { articles, label } = this.props
 
@@ -38,7 +32,7 @@ export class RelatedArticlesPanel extends React.Component<
         <Label size="3t" weight="medium">
           {label}
         </Label>
-        <Waypoint onEnter={once(this.trackRelatedImpression.bind(this))} />
+        <Waypoint />
         <Collection>
           {articles.map((article, i) => (
             <RelatedArticlesPanelLink

--- a/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanelLink.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/RelatedArticlesPanelLink.tsx
@@ -1,6 +1,5 @@
-import { color, Serif, space } from "@artsy/palette"
+import { Serif, color, space } from "@artsy/palette"
 import { track } from "Artsy/Analytics"
-import * as Schema from "Artsy/Analytics/Schema"
 import { RelatedArticlePanelData } from "Components/Publishing/Typings"
 import React from "react"
 import styled from "styled-components"
@@ -19,19 +18,6 @@ export class RelatedArticlesPanelLink extends React.Component<
     label: "Related Stories",
   }
 
-  @track<RelatedArticlesPanelProps>(props => ({
-    action_type: Schema.ActionType.Click,
-    destination_path: getEditorialHref(
-      props.article.layout,
-      props.article.slug
-    ),
-    // TODO: add type to schema
-    type: "thumbnail",
-  }))
-  onClick(e) {
-    // noop
-  }
-
   render() {
     const { article } = this.props
     const href = getEditorialHref(article.layout, article.slug)
@@ -41,7 +27,7 @@ export class RelatedArticlesPanelLink extends React.Component<
     })
 
     return (
-      <ArticleLink href={href} onClick={this.onClick.bind(this)}>
+      <ArticleLink href={href}>
         <ArticleImage src={articleImageSrc} />
         <Serif size="4t" color={color("black100")}>
           {article.thumbnail_title}

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanel.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanel.test.tsx
@@ -42,37 +42,4 @@ describe("RelatedArticlesPanel", () => {
     const component = getWrapper(testProps)
     expect(component.find(RelatedArticlesPanelLink)).toHaveLength(3)
   })
-
-  it("tracks link clicks", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticlesPanel)
-    const component = mount(<Component articles={RelatedPanel} />)
-    component
-      .find(RelatedArticlesPanelLink)
-      .at(0)
-      .simulate("click")
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Click",
-      context_module: "Related articles",
-      subject: "Related articles",
-      destination_path:
-        "/article/artsy-editorial-15-top-art-schools-united-states",
-      type: "thumbnail",
-    })
-  })
-
-  it("Calls a tracking impression", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticlesPanel)
-    const component = mount(<Component articles={RelatedPanel} />)
-    component
-      .find(Waypoint)
-      .getElement()
-      .props.onEnter()
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Impression",
-      context_module: "Related articles",
-      subject: "Related articles",
-    })
-  })
 })

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanel.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanel.test.tsx
@@ -1,10 +1,8 @@
-import { mockTracking } from "Artsy/Analytics"
 import { RelatedPanel } from "Components/Publishing/Fixtures/Components"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import renderer from "react-test-renderer"
-import Waypoint from "react-waypoint"
 import { RelatedArticlesPanel } from "../RelatedArticlesPanel"
 import { RelatedArticlesPanelLink } from "../RelatedArticlesPanelLink"
 

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanelLink.test.tsx
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/RelatedArticlesPanelLink.test.tsx
@@ -1,4 +1,3 @@
-import { mockTracking } from "Artsy/Analytics"
 import { RelatedPanel } from "Components/Publishing/Fixtures/Components"
 import { mount } from "enzyme"
 import "jest-styled-components"
@@ -24,18 +23,5 @@ describe("RelatedArticlesPanelLink", () => {
       "The 15 Top Art Schools in the United States"
     )
     expect(component.html()).toMatch("PoetterHall_Exterior%2Bcopy.jpg")
-  })
-
-  it("Tracks link clicks", () => {
-    const { Component, dispatch } = mockTracking(RelatedArticlesPanelLink)
-    const component = mount(<Component article={RelatedPanel[0]} />)
-    component.simulate("click")
-
-    expect(dispatch).toBeCalledWith({
-      action_type: "Click",
-      destination_path:
-        "/article/artsy-editorial-15-top-art-schools-united-states",
-      type: "thumbnail",
-    })
   })
 })

--- a/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
+++ b/src/Components/Publishing/RelatedArticles/Panel/__tests__/__snapshots__/RelatedArticlesPanel.test.tsx.snap
@@ -82,7 +82,6 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     <a
       className="c4"
       href="/article/artsy-editorial-15-top-art-schools-united-states"
-      onClick={[Function]}
     >
       <img
         className="c5"
@@ -101,7 +100,6 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     <a
       className="c4"
       href="/article/artsy-editorial-four-years-walter-de-marias-death-final-work-complete"
-      onClick={[Function]}
     >
       <img
         className="c5"
@@ -120,7 +118,6 @@ exports[`RelatedArticlesPanel renders the related articles panel 1`] = `
     <a
       className="c4"
       href="/news/artsy-editorial-french-art-history-in-a-nutshell"
-      onClick={[Function]}
     >
       <img
         className="c5"


### PR DESCRIPTION
We're hitting our segment quota! This PR:
- Removes publishing events that fire often and are not used.
- Comments out our "Experiment Viewed" event now that we're confident in the result of the test. I didn't remove that code entirely since I figured it would come as part of the A/B test closeout (at which point I think I bunch of code can be cleaned up).