### PR TITLE
Reenable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "enabled": true,
-  "extends": ["@artsy:lib"],
+  "extends": [
+    "@artsy:lib",
+    "schedule:nonOfficeHours"
+  ],
   "assignees": ["eessex"],
   "reviewers": []
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-  "enabled": false,
+  "enabled": true,
   "extends": ["@artsy:lib"],
-  "assignees": ["zephraph"],
+  "assignees": ["eessex"],
   "reviewers": []
 }


### PR DESCRIPTION
We still need this repo to get updates for publishing code, reenabling renovate to keep @artsy packages up to date.