### PR TITLE
Bugfixes for classic layouts

### DIFF
--- a/src/Components/Publishing/Layouts/ClassicLayout.tsx
+++ b/src/Components/Publishing/Layouts/ClassicLayout.tsx
@@ -26,7 +26,6 @@ export const ClassicLayout: React.SFC<ArticleProps> = props => {
           url={getArticleFullHref(slug)}
           title={social_title || thumbnail_title}
         />
-        hi!
       </Box>
       <CanvasFooter
         article={props.article}

--- a/src/Components/Publishing/Sections/ArtworkCaption.tsx
+++ b/src/Components/Publishing/Sections/ArtworkCaption.tsx
@@ -70,6 +70,12 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps> {
       return joinedNames
 
       // Single artist
+    } else if (artists && artists.length === 1) {
+      const artistName = this.renderArtistName(
+        artists[0],
+        "renderArtists-single"
+      )
+      return artistName
     } else if (artist) {
       const artistName = this.renderArtistName(artist, "renderArtists-single")
       return artistName

--- a/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.tsx
@@ -84,6 +84,15 @@ describe("ArtworkCaption", () => {
       expect(component.html()).toMatch("Fernando Botero")
     })
 
+    it("renders single artist from artist array", () => {
+      const component = getWrapper({
+        artwork: _.extend({}, ArtworkMultipleArtists, {
+          artists: [{ name: "Andy Warhol" }],
+        }),
+      })
+      expect(component.text()).toMatch("Andy Warhol")
+    })
+
     it("renders artists", () => {
       const component = getWrapper({
         artwork: _.extend({}, ArtworkMultipleArtists, {


### PR DESCRIPTION
- Removes errant typo/debugging text
- In article artwork captions, use the `artists` array over to-be-deprecated `artist` to render a single artist's name

Before:
<img width="652" alt="Screen Shot 2020-08-18 at 1 26 19 PM" src="https://user-images.githubusercontent.com/1497424/90550724-50620d00-e15e-11ea-9e7e-05bfdcdac1d4.png">

After:
<img width="568" alt="Screen Shot 2020-08-18 at 2 22 21 PM" src="https://user-images.githubusercontent.com/1497424/90550710-4c35ef80-e15e-11ea-894a-96a933b87f34.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>28.1.1-canary.3624.62831.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/reaction@28.1.1-canary.3624.62831.0
  # or 
  yarn add @artsy/reaction@28.1.1-canary.3624.62831.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
