### PR TITLE
Strip /works-for-sale from urls when attempting to fetch tooltop content

### DIFF
--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -190,7 +190,8 @@ export const getArtsySlugsFromHTML = (
   doc.querySelectorAll("a").forEach(anchor => {
     const href = anchor.getAttribute("href")
     if (href && href.match(`artsy.net/${model}`)) {
-      slugs.push(last(url.parse(href).pathname.split("/")))
+      const path = url.parse(href).pathname.replace("/works-for-sale", "")
+      slugs.push(last(path.split("/")))
     }
   })
 

--- a/src/Components/Publishing/__tests__/Constants.test.ts
+++ b/src/Components/Publishing/__tests__/Constants.test.ts
@@ -158,4 +158,13 @@ describe("getArtsySlugs", () => {
     expect(genes.length).toBe(1)
     expect(genes[0]).toBe("capitalist-realism")
   })
+
+  it("#getArtsySlugsFromHTML can strip '/works-for-sale' from artist links", () => {
+    const html =
+      "<p><a href='artsy.net/artist/andy-warhol/works-for-sale'>Andy Warhol</a></p>"
+    const artists = getArtsySlugsFromHTML(html, "artist")
+
+    expect(artists.length).toBe(1)
+    expect(artists[0]).toBe("andy-warhol")
+  })
 })


### PR DESCRIPTION
Article tooltips fetch content from artsy.net URLs based on simple text parsing. Since we added a redirect on artist pages for to add `/works-for-sale` to the url, the parsing was not finding the slug where it expected it (at the end of the url). This caused fetches to use "works-for-sale" rather than the actual slug, breaking both the artist links & tooltips where the string is present. 

The editorial team has been manually removing these links from articles, that will no longer be necessary with this change. 