### PR TITLE
Show artwork sale message on editorial articles

### DIFF
--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
@@ -1155,6 +1155,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -1593,6 +1594,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -2031,6 +2033,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -2883,6 +2886,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -3735,6 +3739,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -4173,6 +4178,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -4611,6 +4617,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -5877,6 +5884,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -6315,6 +6323,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -7581,6 +7590,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -8433,6 +8443,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -9874,6 +9885,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -10312,6 +10324,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -11578,6 +11591,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -12430,6 +12444,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -13282,6 +13297,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -14134,6 +14150,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -14572,6 +14589,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -15010,6 +15028,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -16865,6 +16884,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -17303,6 +17323,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -19397,6 +19418,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -19835,6 +19857,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -20687,6 +20710,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -21125,6 +21149,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -21563,6 +21588,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>
@@ -22415,6 +22441,7 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                             }
                           />
                         </div>
+                        <div />
                       </div>
                     </div>
                   </div>

--- a/src/Components/Publishing/Sections/ArtworkCaption.tsx
+++ b/src/Components/Publishing/Sections/ArtworkCaption.tsx
@@ -6,6 +6,7 @@ import { Truncator } from "Components/Truncator"
 import _ from "lodash"
 import React from "react"
 import styled from "styled-components"
+import { ArtworkSaleMessageContainer as ArtworkSaleMessage } from "./ArtworkSaleMessage"
 
 interface ArtworkCaptionProps extends BoxProps {
   artwork: any
@@ -221,7 +222,7 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps> {
   }
 
   renderEditorialCaption = () => {
-    const { color, layout, sectionLayout } = this.props
+    const { artwork, color, layout, sectionLayout } = this.props
 
     return (
       <StyledArtworkCaption
@@ -234,6 +235,7 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps> {
           <Truncator>{this.renderTitleDate()}</Truncator>
           <Truncator>{this.renderPartnerCredit()}</Truncator>
         </div>
+        <ArtworkSaleMessage artworkSlug={artwork.slug} />
       </StyledArtworkCaption>
     )
   }

--- a/src/Components/Publishing/Sections/ArtworkCaption.tsx
+++ b/src/Components/Publishing/Sections/ArtworkCaption.tsx
@@ -6,7 +6,7 @@ import { Truncator } from "Components/Truncator"
 import _ from "lodash"
 import React from "react"
 import styled from "styled-components"
-import { ArtworkSaleMessageContainer as ArtworkSaleMessage } from "./ArtworkSaleMessage"
+import { ArtworkSaleMessageContainer as ArtworkSaleMessage } from "Components/Publishing/Sections/ArtworkSaleMessage"
 
 interface ArtworkCaptionProps extends BoxProps {
   artwork: any
@@ -195,6 +195,7 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps> {
   }
 
   renderFullscreenCaption = () => {
+    const { artwork } = this.props
     return (
       <StyledFullscreenCaption variant="mediumText">
         <Line>
@@ -203,6 +204,9 @@ export class ArtworkCaption extends React.Component<ArtworkCaptionProps> {
         <div>
           <Line>{this.renderTitleDate()}</Line>
           <Line>{this.renderPartnerCredit()}</Line>
+          <Line>
+            <ArtworkSaleMessage artworkSlug={artwork.slug} />
+          </Line>
         </div>
       </StyledFullscreenCaption>
     )

--- a/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
+++ b/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import * as Artsy from "Artsy"
+import { Environment, QueryRenderer, graphql } from "react-relay"
+import { ArtworkSaleMessageQuery } from "__generated__/ArtworkSaleMessageQuery.graphql"
+import { get } from "Utils/get"
+
+interface ArtworkSaleMessageProps {
+  relayEnvironment: Environment
+  artworkSlug: string
+}
+
+const ArtworkSaleMessage: React.FC<ArtworkSaleMessageProps> = props => {
+  const saleMessageDisplay = artwork => {
+    const { sale } = artwork
+    const isAuction = sale && sale.isAuction
+
+    if (isAuction) {
+      const showBiddingClosed = sale.isClosed
+      if (showBiddingClosed) {
+        return "Bidding closed"
+      } else {
+        const highestBidDisplay = get(
+          artwork,
+          p => p.saleArtwork.highestBid.display
+        )
+        const openingBidDisplay = get(
+          artwork,
+          p => p.saleArtwork.openingBid.display
+        )
+
+        return highestBidDisplay || openingBidDisplay || ""
+      }
+    }
+
+    return artwork.saleMessage === "Contact For Price"
+      ? "Contact for price"
+      : artwork.saleMessage
+  }
+  const { artworkSlug, relayEnvironment } = props
+  return (
+    <QueryRenderer<ArtworkSaleMessageQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query ArtworkSaleMessageQuery($artworkSlug: String!) {
+          artwork(id: $artworkSlug) {
+            saleMessage
+            sale {
+              isAuction
+              isClosed
+            }
+            saleArtwork: saleArtwork {
+              counts {
+                bidderPositions
+              }
+              highestBid {
+                display
+              }
+              openingBid {
+                display
+              }
+            }
+          }
+        }
+      `}
+      variables={{ artworkSlug }}
+      render={readyState => {
+        const artwork = readyState?.props?.artwork
+        return <div>{artwork ? saleMessageDisplay(artwork) : null}</div>
+      }}
+    />
+  )
+}
+
+export const ArtworkSaleMessageContainer = Artsy.withSystemContext(
+  ArtworkSaleMessage
+)

--- a/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
+++ b/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
@@ -48,7 +48,7 @@ const ArtworkSaleMessage: React.FC<ArtworkSaleMessageProps> = props => {
               isAuction
               isClosed
             }
-            saleArtwork: saleArtwork {
+            saleArtwork {
               counts {
                 bidderPositions
               }

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Caption.test.tsx.snap
@@ -281,6 +281,11 @@ Array [
                     Courtesy of Gary Nader
                   </span>
                 </div>
+                <div
+                  className="c8"
+                >
+                  <div />
+                </div>
               </div>
             </div>
           </div>
@@ -537,6 +542,11 @@ Array [
                   >
                     Courtesy of Gary Nader
                   </span>
+                </div>
+                <div
+                  className="c5"
+                >
+                  <div />
                 </div>
               </div>
             </div>

--- a/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
+++ b/src/Components/Publishing/Sections/FullscreenViewer/__tests__/__snapshots__/Slide.test.tsx.snap
@@ -385,6 +385,11 @@ exports[`renders properly 1`] = `
                       Courtesy of Gary Nader
                     </span>
                   </div>
+                  <div
+                    className="c12"
+                  >
+                    <div />
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkCaption.test.tsx
@@ -9,6 +9,7 @@ import _ from "lodash"
 import React from "react"
 import renderer from "react-test-renderer"
 import { ArtworkCaption } from "../ArtworkCaption"
+import { ArtworkSaleMessageContainer } from "../ArtworkSaleMessage"
 
 describe("ArtworkCaption", () => {
   const getWrapper = (props: any = {}) => {
@@ -112,6 +113,11 @@ describe("ArtworkCaption", () => {
     it("renders partner + credit", () => {
       const component = getWrapper()
       expect(component.text()).toMatch("Gary Nader. Courtesy of Gary Nader")
+    })
+
+    it("renders a sale message", () => {
+      const component = getWrapper()
+      expect(component.find(ArtworkSaleMessageContainer).length).toBe(1)
     })
   })
 })

--- a/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "Components/Publishing/Sections/ArtworkSaleMessage"
 import { ArtworkSaleMessageQueryResponse } from "__generated__/ArtworkSaleMessageQuery.graphql"
 import { mount } from "enzyme"
-import { QueryRenderer, graphql } from "react-relay"
+import { QueryRenderer } from "react-relay"
 
 jest.unmock("react-relay")
 
@@ -41,30 +41,7 @@ describe("ArtworkSaleMessageContainer", () => {
     const wrapper = mount(
       <ArtworkSaleMessageContainer artworkSlug="some-slug" />
     )
-    expect(wrapper.find(QueryRenderer).prop("query")).toBe(
-      graphql`
-        query ArtworkSaleMessageQuery($artworkSlug: String!) {
-          artwork(id: $artworkSlug) {
-            saleMessage
-            sale {
-              isAuction
-              isClosed
-            }
-            saleArtwork {
-              counts {
-                bidderPositions
-              }
-              highestBid {
-                display
-              }
-              openingBid {
-                display
-              }
-            }
-          }
-        }
-      `
-    )
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
   })
 })
 

--- a/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
@@ -1,0 +1,98 @@
+import React from "react"
+import { renderRelayTree } from "DevTools"
+import {
+  ArtworkSaleMessage,
+  ArtworkSaleMessageContainer,
+  ArtworkSaleMessageQueryString,
+} from "Components/Publishing/Sections/ArtworkSaleMessage"
+import { ArtworkSaleMessageQueryResponse } from "__generated__/ArtworkSaleMessageQuery.graphql"
+import { mount } from "enzyme"
+import { QueryRenderer, graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+describe("ArtworkSaleMessage", () => {
+  const getWrapper = async (response: ArtworkSaleMessageQueryResponse) => {
+    return await renderRelayTree({
+      Component: ({ artwork }) => {
+        return <ArtworkSaleMessage artwork={artwork} />
+      },
+      query: ArtworkSaleMessageQueryString,
+      variables: {
+        artworkSlug: "yayoi-kusama-pumpkin-2",
+      },
+      mockData: response,
+    })
+  }
+
+  it("displays the sale message for works not at auction", async () => {
+    const wrapper = await getWrapper(ArtworkSaleMessageForSaleFixture)
+    expect(wrapper.text()).toBe("$20,000")
+  })
+
+  it("displays bidding information for works at auction", async () => {
+    const wrapper = await getWrapper(ArtworkSaleMessageAtAuctionFixture)
+    expect(wrapper.text()).toBe("$6,000 (2 bids)")
+  })
+})
+
+describe("ArtworkSaleMessageContainer", () => {
+  it("fetches the necessary data to display an artwork's sale message", () => {
+    const wrapper = mount(
+      <ArtworkSaleMessageContainer artworkSlug="some-slug" />
+    )
+    expect(wrapper.find(QueryRenderer).prop("query")).toBe(
+      graphql`
+        query ArtworkSaleMessageQuery($artworkSlug: String!) {
+          artwork(id: $artworkSlug) {
+            saleMessage
+            sale {
+              isAuction
+              isClosed
+            }
+            saleArtwork {
+              counts {
+                bidderPositions
+              }
+              highestBid {
+                display
+              }
+              openingBid {
+                display
+              }
+            }
+          }
+        }
+      `
+    )
+  })
+})
+
+const ArtworkSaleMessageForSaleFixture: ArtworkSaleMessageQueryResponse = {
+  artwork: {
+    saleMessage: "$20,000",
+    sale: null,
+    saleArtwork: null,
+  },
+}
+
+const ArtworkSaleMessageAtAuctionFixture: ArtworkSaleMessageQueryResponse = {
+  artwork: {
+    saleMessage: "Contact For Price",
+    sale: {
+      isAuction: true,
+      isClosed: false,
+    },
+    saleArtwork: {
+      counts: {
+        bidderPositions: 2,
+      },
+      highestBid: {
+        display: "$6,000",
+      },
+      openingBid: {
+        display: "$4,000",
+      },
+    },
+  },
+}

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Artwork.test.tsx.snap
@@ -261,6 +261,7 @@ exports[`Artwork snapshots renders properly 1`] = `
           }
         />
       </div>
+      <div />
     </div>
   </div>
 </div>

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ArtworkCaption.test.tsx.snap
@@ -167,6 +167,11 @@ exports[`ArtworkCaption snapshot renders a fullscreen caption properly 1`] = `
           Courtesy of Gary Nader
         </span>
       </div>
+      <div
+        className="c2"
+      >
+        <div />
+      </div>
     </div>
   </div>
 </div>
@@ -263,6 +268,7 @@ exports[`ArtworkCaption snapshot renders a standard caption properly 1`] = `
         }
       />
     </div>
+    <div />
   </div>
 </div>
 `;

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/ImageCollection.test.tsx.snap
@@ -309,6 +309,7 @@ exports[`renders a single image properly 1`] = `
               }
             />
           </div>
+          <div />
         </div>
       </div>
     </div>
@@ -729,6 +730,7 @@ exports[`renders properly 1`] = `
               }
             />
           </div>
+          <div />
         </div>
       </div>
     </div>

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -1394,6 +1394,7 @@ exports[`Sections snapshots tests renders properly 1`] = `
                   }
                 />
               </div>
+              <div />
             </div>
           </div>
         </div>

--- a/src/__generated__/ArtworkSaleMessageQuery.graphql.ts
+++ b/src/__generated__/ArtworkSaleMessageQuery.graphql.ts
@@ -259,5 +259,5 @@ return {
   }
 };
 })();
-(node as any).hash = '46be897dd7a9af62e73a4f1b0ea895a9';
+(node as any).hash = '02a606b1af7ad3c72aa9e7fa4064577b';
 export default node;

--- a/src/__generated__/ArtworkSaleMessageQuery.graphql.ts
+++ b/src/__generated__/ArtworkSaleMessageQuery.graphql.ts
@@ -1,0 +1,263 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type ArtworkSaleMessageQueryVariables = {
+    artworkSlug: string;
+};
+export type ArtworkSaleMessageQueryResponse = {
+    readonly artwork: {
+        readonly saleMessage: string | null;
+        readonly sale: {
+            readonly isAuction: boolean | null;
+            readonly isClosed: boolean | null;
+        } | null;
+        readonly saleArtwork: {
+            readonly counts: {
+                readonly bidderPositions: number | null;
+            } | null;
+            readonly highestBid: {
+                readonly display: string | null;
+            } | null;
+            readonly openingBid: {
+                readonly display: string | null;
+            } | null;
+        } | null;
+    } | null;
+};
+export type ArtworkSaleMessageQuery = {
+    readonly response: ArtworkSaleMessageQueryResponse;
+    readonly variables: ArtworkSaleMessageQueryVariables;
+};
+
+
+
+/*
+query ArtworkSaleMessageQuery(
+  $artworkSlug: String!
+) {
+  artwork(id: $artworkSlug) {
+    saleMessage
+    sale {
+      isAuction
+      isClosed
+      id
+    }
+    saleArtwork {
+      counts {
+        bidderPositions
+      }
+      highestBid {
+        display
+      }
+      openingBid {
+        display
+      }
+      id
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artworkSlug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artworkSlug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "saleMessage",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAuction",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isClosed",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SaleArtworkCounts",
+  "kind": "LinkedField",
+  "name": "counts",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "bidderPositions",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SaleArtworkHighestBid",
+  "kind": "LinkedField",
+  "name": "highestBid",
+  "plural": false,
+  "selections": (v6/*: any*/),
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SaleArtworkOpeningBid",
+  "kind": "LinkedField",
+  "name": "openingBid",
+  "plural": false,
+  "selections": (v6/*: any*/),
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtworkSaleMessageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "kind": "LinkedField",
+            "name": "saleArtwork",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtworkSaleMessageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SaleArtwork",
+            "kind": "LinkedField",
+            "name": "saleArtwork",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v9/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtworkSaleMessageQuery",
+    "operationKind": "query",
+    "text": "query ArtworkSaleMessageQuery(\n  $artworkSlug: String!\n) {\n  artwork(id: $artworkSlug) {\n    saleMessage\n    sale {\n      isAuction\n      isClosed\n      id\n    }\n    saleArtwork {\n      counts {\n        bidderPositions\n      }\n      highestBid {\n        display\n      }\n      openingBid {\n        display\n      }\n      id\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '46be897dd7a9af62e73a4f1b0ea895a9';
+export default node;


### PR DESCRIPTION
## Problem

We currently show artworks on Editorial that are for sale on Artsy. However, users do not see any pricing information which makes their for-sale status unclear.

## Solution

Show an artwork's `saleMessage` in an artwork's image caption on Editorial pages when we show an artwork. 

**Note**: The logic for `bidInfo` and `saleMessageDisplay` was lifted from Force: https://github.com/artsy/force/blob/b607b3b2bd9459981203c879ae3b3a3b04e9e587/src/v2/Components/Artwork/Details.tsx#L156. That code is thoroughly tested in Force and so tests are lighter here in comparison.

![Screen Shot 2020-09-11 at 10 22 23 AM](https://user-images.githubusercontent.com/4432348/92975654-bdfc1300-f456-11ea-9679-23f01ee9dcad.png)

![Screen Shot 2020-09-11 at 10 22 38 AM](https://user-images.githubusercontent.com/4432348/92975655-be94a980-f456-11ea-8595-6fa6ef122f8c.png)
