### PR TITLE
Do not display sale message when sale message is null

### DIFF
--- a/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
+++ b/src/Components/Publishing/Sections/ArtworkSaleMessage.tsx
@@ -36,8 +36,12 @@ export const ArtworkSaleMessage: React.FC<ArtworkSaleMessageQueryResponse> = pro
   }
 
   const saleMessageDisplay = artwork => {
-    const { sale } = artwork
+    const { sale, saleMessage } = artwork
     const isAuction = sale && sale.isAuction
+
+    if (saleMessage === null) {
+      return ""
+    }
 
     if (isAuction) {
       const showBiddingClosed = sale.isClosed
@@ -57,9 +61,9 @@ export const ArtworkSaleMessage: React.FC<ArtworkSaleMessageQueryResponse> = pro
       }
     }
 
-    return artwork.saleMessage === "Contact For Price"
+    return saleMessage === "Contact For Price"
       ? "Contact for price"
-      : artwork.saleMessage
+      : saleMessage
   }
 
   const { artwork } = props

--- a/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/ArtworkSaleMessage.test.tsx
@@ -34,6 +34,11 @@ describe("ArtworkSaleMessage", () => {
     const wrapper = await getWrapper(ArtworkSaleMessageAtAuctionFixture)
     expect(wrapper.text()).toBe("$6,000 (2 bids)")
   })
+
+  it("displays nothing if the work is not for sale", async () => {
+    const wrapper = await getWrapper(ArtworkSaleMessageNotForSale)
+    expect(wrapper.text().length).toBe(0)
+  })
 })
 
 describe("ArtworkSaleMessageContainer", () => {
@@ -71,5 +76,13 @@ const ArtworkSaleMessageAtAuctionFixture: ArtworkSaleMessageQueryResponse = {
         display: "$4,000",
       },
     },
+  },
+}
+
+const ArtworkSaleMessageNotForSale: ArtworkSaleMessageQueryResponse = {
+  artwork: {
+    saleMessage: null,
+    sale: null,
+    saleArtwork: null,
   },
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2283

## Problem

We're currently displaying `null` when the sale message is `null`.

## Solution

Render an empty string instead of `null` when the sale message is `null`.

**Before**

<img width="1089" alt="Screen Shot 2020-09-18 at 12 10 46 PM" src="https://user-images.githubusercontent.com/4432348/93635343-1e8fd080-f9c0-11ea-8dd1-989893c7ff77.png">

**After**

![Screen Shot 2020-09-18 at 2 52 47 PM](https://user-images.githubusercontent.com/4432348/93635297-0c159700-f9c0-11ea-9db2-dc0f53f0abfb.png)
