### PR TITLE
GRO-1: Render react artist follow buttons in mobile contexts

### DIFF
--- a/src/Components/FollowButton/MobileFollowArtistButton.tsx
+++ b/src/Components/FollowButton/MobileFollowArtistButton.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { QueryRenderer, graphql } from "react-relay"
+import { SystemContextProps, withSystemContext } from "Artsy/SystemContext"
+import { Flex, Spinner } from "@artsy/palette"
+import {
+  MobileFollowArtistButtonQuery,
+  MobileFollowArtistButtonQueryResponse,
+  MobileFollowArtistButtonQueryVariables,
+} from "__generated__/MobileFollowArtistButtonQuery.graphql"
+import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "./FollowArtistButton"
+import { ContextModule } from "@artsy/cohesion"
+
+export const MobileFollowArtistButton: React.FC<MobileFollowArtistButtonQueryResponse> = props => {
+  return (
+    <FollowArtistButton
+      contextModule={ContextModule.intextTooltip}
+      artist={props.artist}
+    />
+  )
+}
+
+export const MobileFollowArtistButtonQueryRenderer = withSystemContext(
+  ({
+    artistId,
+    relayEnvironment,
+  }: SystemContextProps & MobileFollowArtistButtonQueryVariables) => {
+    return (
+      <QueryRenderer<MobileFollowArtistButtonQuery>
+        // @ts-ignore
+        environment={relayEnvironment}
+        query={graphql`
+          query MobileFollowArtistButtonQuery($artistId: String!) {
+            artist(id: $artistId) {
+              ...FollowArtistButton_artist
+            }
+          }
+        `}
+        variables={{ artistId }}
+        render={({ props }) => {
+          if (props) {
+            return <MobileFollowArtistButton {...props} />
+          } else {
+            return (
+              <Flex position="relative" height="178px">
+                <Spinner />
+              </Flex>
+            )
+          }
+        }}
+      />
+    )
+  }
+)

--- a/src/Components/FollowButton/MobileFollowArtistButton.tsx
+++ b/src/Components/FollowButton/MobileFollowArtistButton.tsx
@@ -13,7 +13,7 @@ import { ContextModule } from "@artsy/cohesion"
 export const MobileFollowArtistButton: React.FC<MobileFollowArtistButtonQueryResponse> = props => {
   return (
     <FollowArtistButton
-      contextModule={ContextModule.intextTooltip}
+      contextModule={ContextModule.articleArtist}
       artist={props.artist}
     />
   )

--- a/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists/index.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists/index.tsx
@@ -90,7 +90,6 @@ export class Eoy2018Artists extends React.Component<EditorialFeaturesProps> {
     const {
       article: { sections, layout },
       showTooltips,
-      isMobile,
     } = this.props
     const isChapterStart =
       sections[i - 1] && sections[i - 1].type === "image_collection"
@@ -101,7 +100,6 @@ export class Eoy2018Artists extends React.Component<EditorialFeaturesProps> {
           <Text
             html={section.body}
             layout={layout}
-            isMobile={isMobile}
             showTooltips={showTooltips}
           />
         </TextSection>

--- a/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists/index.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Eoy2018Artists/index.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, media, Sans, Serif, space } from "@artsy/palette"
+import { Box, Flex, Sans, Serif, color, media, space } from "@artsy/palette"
 import { compact, find, map } from "lodash"
 import React from "react"
 import styled from "styled-components"
@@ -90,6 +90,7 @@ export class Eoy2018Artists extends React.Component<EditorialFeaturesProps> {
     const {
       article: { sections, layout },
       showTooltips,
+      isMobile,
     } = this.props
     const isChapterStart =
       sections[i - 1] && sections[i - 1].type === "image_collection"
@@ -100,6 +101,7 @@ export class Eoy2018Artists extends React.Component<EditorialFeaturesProps> {
           <Text
             html={section.body}
             layout={layout}
+            isMobile={isMobile}
             showTooltips={showTooltips}
           />
         </TextSection>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
@@ -60,12 +60,7 @@ export const VanguardIntroduction: React.SFC<{
           </Flex>
 
           <Box pb={12}>
-            <Text
-              layout="standard"
-              html={description}
-              width="800px"
-              isMobile={isMobile}
-            />
+            <Text layout="standard" html={description} width="800px" />
           </Box>
         </Box>
       </Box>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/Introduction.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, media, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, Sans, Serif, color, media } from "@artsy/palette"
 import { Byline, BylineContainer } from "Components/Publishing/Byline/Byline"
 import { VanguardCredits } from "Components/Publishing/EditorialFeature/Components/Vanguard2019/Components/VanguardCredits"
 import { Text } from "Components/Publishing/Sections/Text"
@@ -60,7 +60,12 @@ export const VanguardIntroduction: React.SFC<{
           </Flex>
 
           <Box pb={12}>
-            <Text layout="standard" html={description} width="800px" />
+            <Text
+              layout="standard"
+              html={description}
+              width="800px"
+              isMobile={isMobile}
+            />
           </Box>
         </Box>
       </Box>

--- a/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/Components/Vanguard2019/__tests__/__snapshots__/index.test.tsx.snap
@@ -397,13 +397,30 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
             className="article__text-section StyledText-sc-1ysl1h-0 bBVXyI"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>The landscape of contemporary art is ever-changing. It shifts according to countless factors, from artists’ principles and the political climate to auction records and collectors’ tastes. Nevertheless, each year, a new crop of ambitious artists stands out. They catapult from obscurity to ubiquity, earn representation from top galleries, garner interest from prominent collectors, and pack their schedules with exhibitions. Most importantly, they make work that expands our understanding of what art can be. </p><p>The Artsy Vanguard 2019 features 50 artists, hailing from 27 countries and working in 27 cities around the world. Ranging in age from 28 to 93, they pursue painting, sculpture, photography, filmmaking, and performance, as well as investigative research and virtual reality. They delve into topics from human rights violations to youth culture, and capture the attention of powerhouse collectors and celebrity royalty, like Beyoncé. </p><p><i>Artsy </i>editors developed this list from a pool of 600 artists who were nominated by more than 100 curators, collectors, and art-world professionals. These artists represent three distinct career stages, which we’ve arranged into the following categories: Emerging, which introduces artists who recently started showing at leading institutions and galleries; Newly Established, which presents the artists making noise at major art events and gaining representation with influential galleries; and Getting Their Due, which recognizes artists who have worked persistently for decades, yet have only recently received the spotlight they deserve. The Artsy Vanguard highlights the artists paving the future of art <i>right now</i>.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                The landscape of contemporary art is ever-changing. It shifts according to countless factors, from artists’ principles and the political climate to auction records and collectors’ tastes. Nevertheless, each year, a new crop of ambitious artists stands out. They catapult from obscurity to ubiquity, earn representation from top galleries, garner interest from prominent collectors, and pack their schedules with exhibitions. Most importantly, they make work that expands our understanding of what art can be. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The Artsy Vanguard 2019 features 50 artists, hailing from 27 countries and working in 27 cities around the world. Ranging in age from 28 to 93, they pursue painting, sculpture, photography, filmmaking, and performance, as well as investigative research and virtual reality. They delve into topics from human rights violations to youth culture, and capture the attention of powerhouse collectors and celebrity royalty, like Beyoncé. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                <i>
+                  Artsy 
+                </i>
+                editors developed this list from a pool of 600 artists who were nominated by more than 100 curators, collectors, and art-world professionals. These artists represent three distinct career stages, which we’ve arranged into the following categories: Emerging, which introduces artists who recently started showing at leading institutions and galleries; Newly Established, which presents the artists making noise at major art events and gaining representation with influential galleries; and Getting Their Due, which recognizes artists who have worked persistently for decades, yet have only recently received the spotlight they deserve. The Artsy Vanguard highlights the artists paving the future of art 
+                <i>
+                  right now
+                </i>
+                .
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -1169,13 +1186,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/victoria-sin\\">Victoria Sin</a> develops performances, films, texts, and installations that delve into gender, harnessing science-fiction themes to imagine alternate societal norms. Sin began performing at the London nightclub Vogue Fabrics in Dalston in 2013. Since then, they’ve captured the attention of the art world. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/victoria-sin"
+                    >
+                      Victoria Sin
+                    </a>
+                     develops performances, films, texts, and installations that delve into gender, harnessing science-fiction themes to imagine alternate societal norms. Sin began performing at the London nightclub Vogue Fabrics in Dalston in 2013. Since then, they’ve captured the attention of the art world. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1608,13 +1630,29 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Through videos and installations, artist <a href=\\"https://www.artsy.net/artist/monira-al-qadiri\\">Monira Al Qadiri</a> creates unsettling, supernatural, or kitschy atmospheres. Drawing on history, ritual, culture, and power, she shifts viewers into a new headspace. For her 2017 video installation <em>The Craft</em>—commissioned by Gasworks in London and <a href=\\"https://www.artsy.net/sursock\\">The Sursock Museum</a> in Beirut—Al Qadiri turned her childhood memories in Kuwait into a paranoid narrative in which aliens invade from the brightly lit interior of an American diner. Her distrust increasingly blossoms, addressing first her familial relationships, and then society itself.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Through videos and installations, artist 
+                    <a
+                      href="https://www.artsy.net/artist/monira-al-qadiri"
+                    >
+                      Monira Al Qadiri
+                    </a>
+                     creates unsettling, supernatural, or kitschy atmospheres. Drawing on history, ritual, culture, and power, she shifts viewers into a new headspace. For her 2017 video installation 
+                    <em>
+                      The Craft
+                    </em>
+                    —commissioned by Gasworks in London and 
+                    <a
+                      href="https://www.artsy.net/sursock"
+                    >
+                      The Sursock Museum
+                    </a>
+                     in Beirut—Al Qadiri turned her childhood memories in Kuwait into a paranoid narrative in which aliens invade from the brightly lit interior of an American diner. Her distrust increasingly blossoms, addressing first her familial relationships, and then society itself.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -2047,13 +2085,66 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/diedrick-brackens\\">Diedrick Brackens</a>’s woven textiles feature depictions of people and animals, embedded with expressions of black and queer identity. Last summer, he was featured in the <a href=\\"https://www.artsy.net/hammer-museum\\">Hammer Museum</a>’s “<a href=\\"https://www.artsy.net/show/hammer-museum-made-in-la-2018\\">Made in L.A.</a>” biennial, and then won the <a href=\\"https://www.artsy.net/studio-museum\\">Studio Museum in Harlem</a>’s $50,000 Joyce Alexander Wein Artist Prize in the fall. This past spring, his work filled both a gallery show and a Frieze New York booth with L.A.’s <a href=\\"https://www.artsy.net/various-small-fires\\">Various Small Fires</a>; his work entered the collection of the <a href=\\"https://www.artsy.net/brooklyn-museum\\">Brooklyn Museum</a>; he joined the roster of New York’s <a href=\\"https://www.artsy.net/jack-shainman-gallery\\">Jack Shainman Gallery</a>; and he opened a <a href=\\"https://www.artsy.net/show/new-museum-1-diedrick-brackens-darling-divined\\">solo show</a> at the <a href=\\"https://www.artsy.net/newmuseum\\">New Museum</a>. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/diedrick-brackens"
+                    >
+                      Diedrick Brackens
+                    </a>
+                    ’s woven textiles feature depictions of people and animals, embedded with expressions of black and queer identity. Last summer, he was featured in the 
+                    <a
+                      href="https://www.artsy.net/hammer-museum"
+                    >
+                      Hammer Museum
+                    </a>
+                    ’s “
+                    <a
+                      href="https://www.artsy.net/show/hammer-museum-made-in-la-2018"
+                    >
+                      Made in L.A.
+                    </a>
+                    ” biennial, and then won the 
+                    <a
+                      href="https://www.artsy.net/studio-museum"
+                    >
+                      Studio Museum in Harlem
+                    </a>
+                    ’s $50,000 Joyce Alexander Wein Artist Prize in the fall. This past spring, his work filled both a gallery show and a Frieze New York booth with L.A.’s 
+                    <a
+                      href="https://www.artsy.net/various-small-fires"
+                    >
+                      Various Small Fires
+                    </a>
+                    ; his work entered the collection of the 
+                    <a
+                      href="https://www.artsy.net/brooklyn-museum"
+                    >
+                      Brooklyn Museum
+                    </a>
+                    ; he joined the roster of New York’s 
+                    <a
+                      href="https://www.artsy.net/jack-shainman-gallery"
+                    >
+                      Jack Shainman Gallery
+                    </a>
+                    ; and he opened a 
+                    <a
+                      href="https://www.artsy.net/show/new-museum-1-diedrick-brackens-darling-divined"
+                    >
+                      solo show
+                    </a>
+                     at the 
+                    <a
+                      href="https://www.artsy.net/newmuseum"
+                    >
+                      New Museum
+                    </a>
+                    . 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -2461,13 +2552,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>As South African installation artist <a href=\\"https://www.artsy.net/artist/dineo-seshee-bopape\\">Dineo Seshee Bopape</a>’s career has taken off, her work has remained truly grounded. Her most distinctive work of the last four years has involved large-scale interventions consisting of dirt, clay, and earthen bricks. Bopape, who is represented by Sfeir-Semler Gallery, punctuates such works with videos, sculptures, and enigmatic materials and artifacts. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    As South African installation artist 
+                    <a
+                      href="https://www.artsy.net/artist/dineo-seshee-bopape"
+                    >
+                      Dineo Seshee Bopape
+                    </a>
+                    ’s career has taken off, her work has remained truly grounded. Her most distinctive work of the last four years has involved large-scale interventions consisting of dirt, clay, and earthen bricks. Bopape, who is represented by Sfeir-Semler Gallery, punctuates such works with videos, sculptures, and enigmatic materials and artifacts. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -2900,13 +2997,25 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>At the <a href=\\"https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times\\">58th Venice Biennale</a>, one can’t help but stop in their tracks before the work of <a href=\\"https://www.artsy.net/artist/martine-gutierrez\\">Martine Gutierrez</a>. The transgender Latinx photographer’s self-portraits challenge gender stereotypes, offer up new visions of pop-cultural icons, and commingle tropes of high fashion and indigenous cultures. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    At the 
+                    <a
+                      href="https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times"
+                    >
+                      58th Venice Biennale
+                    </a>
+                    , one can’t help but stop in their tracks before the work of 
+                    <a
+                      href="https://www.artsy.net/artist/martine-gutierrez"
+                    >
+                      Martine Gutierrez
+                    </a>
+                    . The transgender Latinx photographer’s self-portraits challenge gender stereotypes, offer up new visions of pop-cultural icons, and commingle tropes of high fashion and indigenous cultures. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -3314,13 +3423,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/genesis-belanger\\">Genesis Belanger</a> charmed the New York art world in the fall of 2017 with her small-but-mighty show of otherworldly ceramic foodstuffs, cigarettes, and fingers at Mrs. Gallery. Her ceramics—with lush pastel hues, matte surfaces, trompe l’oeil aesthetics, and finely hewn details—transcend the typical clay-and-glaze constructions we expect from the medium.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/genesis-belanger"
+                    >
+                      Genesis Belanger
+                    </a>
+                     charmed the New York art world in the fall of 2017 with her small-but-mighty show of otherworldly ceramic foodstuffs, cigarettes, and fingers at Mrs. Gallery. Her ceramics—with lush pastel hues, matte surfaces, trompe l’oeil aesthetics, and finely hewn details—transcend the typical clay-and-glaze constructions we expect from the medium.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -3753,13 +3867,26 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/tao-hui-tao-hui\\">Tao Hui</a> remembers a childhood when he experienced much of the world through a television set. It’s a perspective that underlies his video work, where realities and fictions commingle, and identities and interactions are performed. In stilted, melodramatic scenes brought to life by actors, Tao creates fragments of narratives that hold a flame to our media-saturated world. In <em>Joint Images</em> (2016), a man and woman engage in hammy dialogue while a soap opera on the television behind them mirrors their scripted conversation. In <em>Double Talk </em>(2018), the ghost of a K-pop star reflects upon his life and legacy while a classroom of children watch through a screen.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/tao-hui-tao-hui"
+                    >
+                      Tao Hui
+                    </a>
+                     remembers a childhood when he experienced much of the world through a television set. It’s a perspective that underlies his video work, where realities and fictions commingle, and identities and interactions are performed. In stilted, melodramatic scenes brought to life by actors, Tao creates fragments of narratives that hold a flame to our media-saturated world. In 
+                    <em>
+                      Joint Images
+                    </em>
+                     (2016), a man and woman engage in hammy dialogue while a soap opera on the television behind them mirrors their scripted conversation. In 
+                    <em>
+                      Double Talk 
+                    </em>
+                    (2018), the ghost of a K-pop star reflects upon his life and legacy while a classroom of children watch through a screen.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -4192,13 +4319,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/jordan-nassar\\">Jordan Nassar</a> harnesses the disarming charm of embroidery to devastating effect. His handmade works meld dramatic mountainscapes of cascading slopes saturated with color, which are overlaid with abstract patterns sourced from traditional Palestinian embroidery. Initially, Nassar generated the patterns for his work via computer and hand-stitched them himself, but he has since collaborated with female artisans in the West Bank who stitch the patterns; he then overlays the colorful landscapes.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/jordan-nassar"
+                    >
+                      Jordan Nassar
+                    </a>
+                     harnesses the disarming charm of embroidery to devastating effect. His handmade works meld dramatic mountainscapes of cascading slopes saturated with color, which are overlaid with abstract patterns sourced from traditional Palestinian embroidery. Initially, Nassar generated the patterns for his work via computer and hand-stitched them himself, but he has since collaborated with female artisans in the West Bank who stitch the patterns; he then overlays the colorful landscapes.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -4631,13 +4763,22 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/geng-xue\\">Geng Xue</a>’s best-known work is a stop-motion film featuring porcelain marionette figures, titled <em>Mr. Sea </em>(2014). The piece conjures a sensual, mystical world in which a man falls in love with a woman who turns into a monster. Though static, Geng’s sculptural figures appear to exist in states of perpetual transformation: heads that are seemingly submerged in water grow branches and bones emerge from severed legs.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/geng-xue"
+                    >
+                      Geng Xue
+                    </a>
+                    ’s best-known work is a stop-motion film featuring porcelain marionette figures, titled 
+                    <em>
+                      Mr. Sea 
+                    </em>
+                    (2014). The piece conjures a sensual, mystical world in which a man falls in love with a woman who turns into a monster. Though static, Geng’s sculptural figures appear to exist in states of perpetual transformation: heads that are seemingly submerged in water grow branches and bones emerge from severed legs.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -5045,13 +5186,23 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>In 2015, the world was introduced to <em>Fardaous Funjab </em>(2015–17), a documentary about an avant-garde hijab designer who makes outlandish versions of the Muslim headgear: a Metallica hijab; a birthday hijab with a cake on the top. Alas, no such designer exists—she is a character concocted by <a href=\\"https://www.artsy.net/artist/meriem-bennani\\">Meriem Bennani</a>. The artist was drawing upon her upbringing in Rabat, Morocco, and playing on the contemporary obsession with reality television and Instagram. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    In 2015, the world was introduced to 
+                    <em>
+                      Fardaous Funjab 
+                    </em>
+                    (2015–17), a documentary about an avant-garde hijab designer who makes outlandish versions of the Muslim headgear: a Metallica hijab; a birthday hijab with a cake on the top. Alas, no such designer exists—she is a character concocted by 
+                    <a
+                      href="https://www.artsy.net/artist/meriem-bennani"
+                    >
+                      Meriem Bennani
+                    </a>
+                    . The artist was drawing upon her upbringing in Rabat, Morocco, and playing on the contemporary obsession with reality television and Instagram. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -5459,13 +5610,53 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/manuel-solano\\">Manuel Solano</a>’s paintings are pulsating figurative scenes that picture slices of pop culture, vivid portraits, and homey environments where the artist grew up. Looking at them, you wouldn’t know that Solano went blind at age 26. Losing their sight didn’t stop the artist from continuing to paint. Now, some five years later, their work has earned them institutional shows and gallery representation: in 2018 Solano was included in the <a href=\\"https://www.artsy.net/newmuseum\\">New Museum </a><a href=\\"https://www.artsy.net/show/new-museum-1-2018-triennial-songs-for-sabotage\\">Triennial</a> and had a <a href=\\"https://www.artsy.net/show/ica-miami-manuel-solano-i-dont-wanna-wait-for-our-lives-to-be-over-1\\">solo show</a> at the <a href=\\"https://www.artsy.net/icamiami\\">Institute of Contemporary Art, Miami</a>; they are represented by tastemaking Berlin gallery <a href=\\"https://www.artsy.net/peres-projects\\">Peres Projects</a>. The artist is currently included in a show at the <a href=\\"https://www.artsy.net/palaisdetokyo\\">Palais de Tokyo</a>, and will soon open a solo exhibition at the esteemed São Paulo nonprofit, Pivô.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/manuel-solano"
+                    >
+                      Manuel Solano
+                    </a>
+                    ’s paintings are pulsating figurative scenes that picture slices of pop culture, vivid portraits, and homey environments where the artist grew up. Looking at them, you wouldn’t know that Solano went blind at age 26. Losing their sight didn’t stop the artist from continuing to paint. Now, some five years later, their work has earned them institutional shows and gallery representation: in 2018 Solano was included in the 
+                    <a
+                      href="https://www.artsy.net/newmuseum"
+                    >
+                      New Museum 
+                    </a>
+                    <a
+                      href="https://www.artsy.net/show/new-museum-1-2018-triennial-songs-for-sabotage"
+                    >
+                      Triennial
+                    </a>
+                     and had a 
+                    <a
+                      href="https://www.artsy.net/show/ica-miami-manuel-solano-i-dont-wanna-wait-for-our-lives-to-be-over-1"
+                    >
+                      solo show
+                    </a>
+                     at the 
+                    <a
+                      href="https://www.artsy.net/icamiami"
+                    >
+                      Institute of Contemporary Art, Miami
+                    </a>
+                    ; they are represented by tastemaking Berlin gallery 
+                    <a
+                      href="https://www.artsy.net/peres-projects"
+                    >
+                      Peres Projects
+                    </a>
+                    . The artist is currently included in a show at the 
+                    <a
+                      href="https://www.artsy.net/palaisdetokyo"
+                    >
+                      Palais de Tokyo
+                    </a>
+                    , and will soon open a solo exhibition at the esteemed São Paulo nonprofit, Pivô.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -5898,13 +6089,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/lauren-halsey\\">Lauren Halsey</a>, winner of the 2019 Frieze Artist Award, created arguably the most timely artwork at the fair’s recent New York edition. At the entrance to the white tent on Randall’s Island, she erected two giant white columns to commemorate the recent death of rapper Nipsey Hussle. In such sculptures, and in the immersive installations for which she’s become known, the native Angeleno considers the black experience in her hometown. Halsey’s site-specific works are always in dialogue with their structures—she adorns columns, walls, and entire rooms with images and artifacts that infuse staid, institutional structures with new, youthful energy.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/lauren-halsey"
+                    >
+                      Lauren Halsey
+                    </a>
+                    , winner of the 2019 Frieze Artist Award, created arguably the most timely artwork at the fair’s recent New York edition. At the entrance to the white tent on Randall’s Island, she erected two giant white columns to commemorate the recent death of rapper Nipsey Hussle. In such sculptures, and in the immersive installations for which she’s become known, the native Angeleno considers the black experience in her hometown. Halsey’s site-specific works are always in dialogue with their structures—she adorns columns, walls, and entire rooms with images and artifacts that infuse staid, institutional structures with new, youthful energy.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -6337,13 +6533,24 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/derek-fordjour\\">Derek Fordjour</a>’s vibrant paintings entice the viewer with colorful surfaces, frequently built up with skillfully applied cardboard and newspaper. They often feature athletes, cheerleaders, and marching bands. Fittingly, last December, the artist’s sold-out presentation (with <a href=\\"https://www.artsy.net/josh-lilley\\">Josh Lilley</a>) at Art Basel in Miami Beach was a gravel-covered arena with enamored fairgoers becoming his cheering crowd. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/derek-fordjour"
+                    >
+                      Derek Fordjour
+                    </a>
+                    ’s vibrant paintings entice the viewer with colorful surfaces, frequently built up with skillfully applied cardboard and newspaper. They often feature athletes, cheerleaders, and marching bands. Fittingly, last December, the artist’s sold-out presentation (with 
+                    <a
+                      href="https://www.artsy.net/josh-lilley"
+                    >
+                      Josh Lilley
+                    </a>
+                    ) at Art Basel in Miami Beach was a gravel-covered arena with enamored fairgoers becoming his cheering crowd. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -6751,13 +6958,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/alia-farid\\">Alia Farid</a>’s art concerns many-faceted themes firmly enmeshed in the fabric of contemporary life. Her projects have a way of taking on lives of their own. She was tapped to curate the pavilion of her native Kuwait at the 2014 Venice Biennale of Architecture, where she presented a century of Kuwaiti modernity as it came to be shaped by the discovery of oil. But the presentation also spawned an informal school that outlived the pavilion, becoming a venue for discussing the social dimensions of architectural spaces and environments.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/alia-farid"
+                    >
+                      Alia Farid
+                    </a>
+                    ’s art concerns many-faceted themes firmly enmeshed in the fabric of contemporary life. Her projects have a way of taking on lives of their own. She was tapped to curate the pavilion of her native Kuwait at the 2014 Venice Biennale of Architecture, where she presented a century of Kuwaiti modernity as it came to be shaped by the discovery of oil. But the presentation also spawned an informal school that outlived the pavilion, becoming a venue for discussing the social dimensions of architectural spaces and environments.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -7165,13 +7377,24 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/gala-porras-kim\\">Gala Porras-Kim</a> delves into the conceptual underpinnings of art, often investigating how artifacts and cultural heritage come to be considered artworks. Her work has taken her deep into the <a href=\\"https://www.artsy.net/lacma\\">Los Angeles County Museum of Art</a>’s collection of ancient Mexican ceramics, analyzing how the meaning of such objects changed upon entering the context of an art museum. She’s also researched Zapotec, an ancient Mexican language, to consider the boundaries between visual language and drawing. These inquiries, informed by a master’s degree in Latin American studies, culminate in paintings and sculpture. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/gala-porras-kim"
+                    >
+                      Gala Porras-Kim
+                    </a>
+                     delves into the conceptual underpinnings of art, often investigating how artifacts and cultural heritage come to be considered artworks. Her work has taken her deep into the 
+                    <a
+                      href="https://www.artsy.net/lacma"
+                    >
+                      Los Angeles County Museum of Art
+                    </a>
+                    ’s collection of ancient Mexican ceramics, analyzing how the meaning of such objects changed upon entering the context of an art museum. She’s also researched Zapotec, an ancient Mexican language, to consider the boundaries between visual language and drawing. These inquiries, informed by a master’s degree in Latin American studies, culminate in paintings and sculpture. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -7604,13 +7827,23 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Often more than 10 feet tall and featuring glitter, bright hues, and larger-than-life subjects, <a href=\\"https://www.artsy.net/artist/jonathan-lyndon-chase\\">Jonathan Lyndon Chase</a>’s canvases are understandably difficult to ignore. Beyond their materiality and formal qualities, they demand attention—and visibility—for the queer black bodies they depict. For instance, the painting <em>Butt naked dressed in nothing but pearls</em> (2018) relishes gender nonconformity: The subject wears a beard, close-cropped hair, bright red lips, and the titular gems. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Often more than 10 feet tall and featuring glitter, bright hues, and larger-than-life subjects, 
+                    <a
+                      href="https://www.artsy.net/artist/jonathan-lyndon-chase"
+                    >
+                      Jonathan Lyndon Chase
+                    </a>
+                    ’s canvases are understandably difficult to ignore. Beyond their materiality and formal qualities, they demand attention—and visibility—for the queer black bodies they depict. For instance, the painting 
+                    <em>
+                      Butt naked dressed in nothing but pearls
+                    </em>
+                     (2018) relishes gender nonconformity: The subject wears a beard, close-cropped hair, bright red lips, and the titular gems. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -8018,13 +8251,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>In March 2018, <a href=\\"https://www.artsy.net/artist/elle-perez/shows\\">Elle Pérez</a>’s first show at 47 Canal, titled “In Bloom,” immediately announced the artist as a new voice in photography, one that could explore the contemporary body with raw intimacy. One of the photos showed a bloody scab- and scar-lined hand resting with popping veins between two legs.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    In March 2018, 
+                    <a
+                      href="https://www.artsy.net/artist/elle-perez/shows"
+                    >
+                      Elle Pérez
+                    </a>
+                    ’s first show at 47 Canal, titled “In Bloom,” immediately announced the artist as a new voice in photography, one that could explore the contemporary body with raw intimacy. One of the photos showed a bloody scab- and scar-lined hand resting with popping veins between two legs.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -8457,13 +8696,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>There’s a reason why many of <a href=\\"https://www.artsy.net/artist/suki-seokyeong-kang\\">Suki Seokyeong Kang</a>’s abstract, found-object structures feel strangely familial, even human. Her subtly anthropomorphized “Grandmother Towers” are sculptural portraits of her late grandmother. One of the Korean artist’s sculptures—an arched construction resembling coffee tables or musical drums stacked into a craning formation—is a tender representation of her relative’s hunched-over spinal column. Imbued in these personal forms is the artist’s exploration of the relationship between individual and society; she sees her grandmother as an embodiment of Korea’s tumultuous recent history.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    There’s a reason why many of 
+                    <a
+                      href="https://www.artsy.net/artist/suki-seokyeong-kang"
+                    >
+                      Suki Seokyeong Kang
+                    </a>
+                    ’s abstract, found-object structures feel strangely familial, even human. Her subtly anthropomorphized “Grandmother Towers” are sculptural portraits of her late grandmother. One of the Korean artist’s sculptures—an arched construction resembling coffee tables or musical drums stacked into a craning formation—is a tender representation of her relative’s hunched-over spinal column. Imbued in these personal forms is the artist’s exploration of the relationship between individual and society; she sees her grandmother as an embodiment of Korea’s tumultuous recent history.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -8871,13 +9116,23 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>In 2017, multidisciplinary artist <a href=\\"https://www.artsy.net/artist/evelyn-taocheng-wang\\">Evelyn Taocheng Wang</a> released a catalog of diary entries and watercolors to coincide with her first institutional solo show, held at De Hallen Haarlem in the Netherlands. Titled <em>Unintended Experience (A job in Amsterdam)</em>, the volume recounted the five months she spent working as a trans woman in a red-light district massage parlor. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    In 2017, multidisciplinary artist 
+                    <a
+                      href="https://www.artsy.net/artist/evelyn-taocheng-wang"
+                    >
+                      Evelyn Taocheng Wang
+                    </a>
+                     released a catalog of diary entries and watercolors to coincide with her first institutional solo show, held at De Hallen Haarlem in the Netherlands. Titled 
+                    <em>
+                      Unintended Experience (A job in Amsterdam)
+                    </em>
+                    , the volume recounted the five months she spent working as a trans woman in a red-light district massage parlor. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -9285,13 +9540,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>There is something particularly current about <a href=\\"https://www.artsy.net/artist/jill-mulleady\\">Jill Mulleady’</a>s paintings. Her vaguely surrealistic scenes entail figures who get lost in private moments on cell phones, or in substance-induced oblivion while objects take on a sinister quality. An atmospheric tension pervades the scenes, curdling the air. Valérie Knoll, who curated Mulleady’s 2017 show at Kunsthalle Bern, noted that the artist’s paintings lure us “into worlds infiltrated by an air of violence and uncanniness.” She added, “They are intense, sexual, cold, and often nightmarish.”</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    There is something particularly current about 
+                    <a
+                      href="https://www.artsy.net/artist/jill-mulleady"
+                    >
+                      Jill Mulleady’
+                    </a>
+                    s paintings. Her vaguely surrealistic scenes entail figures who get lost in private moments on cell phones, or in substance-induced oblivion while objects take on a sinister quality. An atmospheric tension pervades the scenes, curdling the air. Valérie Knoll, who curated Mulleady’s 2017 show at Kunsthalle Bern, noted that the artist’s paintings lure us “into worlds infiltrated by an air of violence and uncanniness.” She added, “They are intense, sexual, cold, and often nightmarish.”
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -9899,13 +10160,47 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Thin seams rise up from beneath <a href=\\"https://www.artsy.net/artist/michael-armitage\\">Michael Armitage</a>’s lush, oil-painted scenes, like memories that lie just beneath consciousness. The artist paints on a traditional Ugandan bark cloth, called <em>lugobo</em>, which gives his surfaces intriguing inconsistencies. He draws his imagery from popular culture and his own past in Kenya, which makes for dreamlike, psychologically rich presentations. Though the artist has shown with mega-gallery <a href=\\"https://www.artsy.net/white-cube\\">White Cube</a> since 2015, he’s currently in the spotlight as his paintings earn much-deserved acclaim at the <a href=\\"https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times\\">Venice Biennale</a>. Additionally, his first solo museum show in New York will open this October at the freshly expanded <a href=\\"https://www.artsy.net/museum-of-modern-art\\">Museum of Modern Art</a>, in partnership with the <a href=\\"https://www.artsy.net/studio-museum\\">Studio Museum in Harlem</a>. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Thin seams rise up from beneath 
+                    <a
+                      href="https://www.artsy.net/artist/michael-armitage"
+                    >
+                      Michael Armitage
+                    </a>
+                    ’s lush, oil-painted scenes, like memories that lie just beneath consciousness. The artist paints on a traditional Ugandan bark cloth, called 
+                    <em>
+                      lugobo
+                    </em>
+                    , which gives his surfaces intriguing inconsistencies. He draws his imagery from popular culture and his own past in Kenya, which makes for dreamlike, psychologically rich presentations. Though the artist has shown with mega-gallery 
+                    <a
+                      href="https://www.artsy.net/white-cube"
+                    >
+                      White Cube
+                    </a>
+                     since 2015, he’s currently in the spotlight as his paintings earn much-deserved acclaim at the 
+                    <a
+                      href="https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times"
+                    >
+                      Venice Biennale
+                    </a>
+                    . Additionally, his first solo museum show in New York will open this October at the freshly expanded 
+                    <a
+                      href="https://www.artsy.net/museum-of-modern-art"
+                    >
+                      Museum of Modern Art
+                    </a>
+                    , in partnership with the 
+                    <a
+                      href="https://www.artsy.net/studio-museum"
+                    >
+                      Studio Museum in Harlem
+                    </a>
+                    . 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -10338,13 +10633,31 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>For the first iteration of her touring solo exhibition “<a href=\\"https://www.artsy.net/show/perez-art-museum-miami-pamm-ebony-g-patterson-while-the-dew-is-still-on-the-roses\\">. . . while the dew is still on the roses . . .</a>” in 2018, <a href=\\"https://www.artsy.net/artist/ebony-g-patterson\\">Ebony G. Patterson</a> transformed the <a href=\\"https://www.artsy.net/pamm\\">Pérez Art Museum Miami</a> (PAMM) into what she called a “night garden.” Purple-and-blue floral wallpaper underpinned tapestries layered with glitter, lace, beads, drawings, and found objects like brooches and shoes. Blossoming faux-flowers and vines of ivy hung from the ceiling and clung to the walls.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    For the first iteration of her touring solo exhibition “
+                    <a
+                      href="https://www.artsy.net/show/perez-art-museum-miami-pamm-ebony-g-patterson-while-the-dew-is-still-on-the-roses"
+                    >
+                      . . . while the dew is still on the roses . . .
+                    </a>
+                    ” in 2018, 
+                    <a
+                      href="https://www.artsy.net/artist/ebony-g-patterson"
+                    >
+                      Ebony G. Patterson
+                    </a>
+                     transformed the 
+                    <a
+                      href="https://www.artsy.net/pamm"
+                    >
+                      Pérez Art Museum Miami
+                    </a>
+                     (PAMM) into what she called a “night garden.” Purple-and-blue floral wallpaper underpinned tapestries layered with glitter, lace, beads, drawings, and found objects like brooches and shoes. Blossoming faux-flowers and vines of ivy hung from the ceiling and clung to the walls.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -10752,13 +11065,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>For <a href=\\"https://www.artsy.net/artist/lawrence-abu-hamdan\\">Lawrence Abu Hamdan</a>, sound is more than an art form, or even a fact of life. The self-described “private ear” uses various kinds of audio in installations, performances, and graphic works that interrogate the effects of sound on human rights—how voices are silenced, and how they can be heard and answered. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    For 
+                    <a
+                      href="https://www.artsy.net/artist/lawrence-abu-hamdan"
+                    >
+                      Lawrence Abu Hamdan
+                    </a>
+                    , sound is more than an art form, or even a fact of life. The self-described “private ear” uses various kinds of audio in installations, performances, and graphic works that interrogate the effects of sound on human rights—how voices are silenced, and how they can be heard and answered. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -11166,13 +11485,30 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/korakrit-arunanondchai\\">Korakrit Arunanondchai</a>’s work has always been pretty unmissable in person. He makes brashly ambitious sculptures, where twisty coils rise up from matte-black bases and loom above the heads of gallery-goers; canvases licked with images of flames; and video works that evoke the calming presence of a Thai jungle or the feverish world of a rave. In 2019, he became globally visible: His work is currently on view at the <a href=\\"https://www.artsy.net/show/whitney-museum-of-american-art-1-whitney-biennial-2019-1\\">Whitney Biennial</a> and is featured in the <a href=\\"https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times\\">Venice Biennale</a>, making Arunanondchai one of the few artists included in both shows at the same time. The artist shows with London gallery Carlos/Ishikawa, as well as Bangkok CityCity Gallery and the Brussels- and Brooklyn-based Clearing.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/korakrit-arunanondchai"
+                    >
+                      Korakrit Arunanondchai
+                    </a>
+                    ’s work has always been pretty unmissable in person. He makes brashly ambitious sculptures, where twisty coils rise up from matte-black bases and loom above the heads of gallery-goers; canvases licked with images of flames; and video works that evoke the calming presence of a Thai jungle or the feverish world of a rave. In 2019, he became globally visible: His work is currently on view at the 
+                    <a
+                      href="https://www.artsy.net/show/whitney-museum-of-american-art-1-whitney-biennial-2019-1"
+                    >
+                      Whitney Biennial
+                    </a>
+                     and is featured in the 
+                    <a
+                      href="https://www.artsy.net/show/58th-venice-biennale-may-you-live-in-interesting-times"
+                    >
+                      Venice Biennale
+                    </a>
+                    , making Arunanondchai one of the few artists included in both shows at the same time. The artist shows with London gallery Carlos/Ishikawa, as well as Bangkok CityCity Gallery and the Brussels- and Brooklyn-based Clearing.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -11605,13 +11941,23 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>The creative duo that is <a href=\\"https://www.artsy.net/artist/barbara-wagner-and-benjamin-de-burca/shows\\">Bárbara Wagner &amp; Benjamin de Burca</a> got their start only six years ago, when the two collaborated on a photographic series exploring the new middle class in Brazil. They have since developed some 10 comprehensive projects for biennials, exhibitions, and festivals around the world. Their signature works investigate youth culture and marginalized communities through a multidisciplinary practice that integrates filmmaking, anthropology, performance, music, and dance. The artists meld documentary and fiction by working in collaboration with their protagonists: rappers in Toronto; Swingueira dancers in Brazil; <em>schlager</em> singers in Germany.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    The creative duo that is 
+                    <a
+                      href="https://www.artsy.net/artist/barbara-wagner-and-benjamin-de-burca/shows"
+                    >
+                      Bárbara Wagner & Benjamin de Burca
+                    </a>
+                     got their start only six years ago, when the two collaborated on a photographic series exploring the new middle class in Brazil. They have since developed some 10 comprehensive projects for biennials, exhibitions, and festivals around the world. Their signature works investigate youth culture and marginalized communities through a multidisciplinary practice that integrates filmmaking, anthropology, performance, music, and dance. The artists meld documentary and fiction by working in collaboration with their protagonists: rappers in Toronto; Swingueira dancers in Brazil; 
+                    <em>
+                      schlager
+                    </em>
+                     singers in Germany.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -12019,13 +12365,37 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Winner of the <a href=\\"https://www.artsy.net/show/tate-britain-turner-prize-2018\\">2018 Turner Prize</a>, <a href=\\"https://www.artsy.net/artist/charlotte-prodger\\">Charlotte Prodger</a> debuted an intimate film at this year’s Venice Biennale representing Scotland at its satellite pavillion. In this newest work, the British artist juxtaposes breathtaking shots of nature with spoken anecdotes that sound like diary entries about queer relationships and sexual encounters. The viewer must work out the connections between the disembodied voice, personal stories, and the landscape on screen. Brief pauses in the dialogue offer time for additional contemplation and looking. Titled <em>SaF05</em> (2019), the work completes a trilogy that began with <em>Stoneymollan Trail</em> (2015) and <em>BRIDGIT</em> (2016).</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Winner of the 
+                    <a
+                      href="https://www.artsy.net/show/tate-britain-turner-prize-2018"
+                    >
+                      2018 Turner Prize
+                    </a>
+                    , 
+                    <a
+                      href="https://www.artsy.net/artist/charlotte-prodger"
+                    >
+                      Charlotte Prodger
+                    </a>
+                     debuted an intimate film at this year’s Venice Biennale representing Scotland at its satellite pavillion. In this newest work, the British artist juxtaposes breathtaking shots of nature with spoken anecdotes that sound like diary entries about queer relationships and sexual encounters. The viewer must work out the connections between the disembodied voice, personal stories, and the landscape on screen. Brief pauses in the dialogue offer time for additional contemplation and looking. Titled 
+                    <em>
+                      SaF05
+                    </em>
+                     (2019), the work completes a trilogy that began with 
+                    <em>
+                      Stoneymollan Trail
+                    </em>
+                     (2015) and 
+                    <em>
+                      BRIDGIT
+                    </em>
+                     (2016).
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -12458,13 +12828,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/jeffrey-gibson\\">Jeffrey Gibson</a>’s punching-bag sculptures, kaleidoscopic paintings, and mixed-media works incorporate elements of traditional Native American dress and modern Western fashion. The Choctaw and Cherokee artist has become a contemporary art heavyweight over the last three years. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/jeffrey-gibson"
+                    >
+                      Jeffrey Gibson
+                    </a>
+                    ’s punching-bag sculptures, kaleidoscopic paintings, and mixed-media works incorporate elements of traditional Native American dress and modern Western fashion. The Choctaw and Cherokee artist has become a contemporary art heavyweight over the last three years. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -12872,13 +13247,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/hao-liang\\">Hao Liang</a>’s epic contemporary take on ancient Chinese ink-wash painting has made him an art-world fixture in his home country. Hao’s work pays homage to the history of Chinese literati tradition—the scholar-painters of old who expressed their philosophies through handscrolls, portraits, and majestic landscape paintings where subtle qualities of light and shadow play out over mountain peaks and carefully cultivated gardens. In the young artist’s work, the twist is the way in which the silk paintings’ ancient origins morph into the contemporary. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/hao-liang"
+                    >
+                      Hao Liang
+                    </a>
+                    ’s epic contemporary take on ancient Chinese ink-wash painting has made him an art-world fixture in his home country. Hao’s work pays homage to the history of Chinese literati tradition—the scholar-painters of old who expressed their philosophies through handscrolls, portraits, and majestic landscape paintings where subtle qualities of light and shadow play out over mountain peaks and carefully cultivated gardens. In the young artist’s work, the twist is the way in which the silk paintings’ ancient origins morph into the contemporary. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -13311,13 +13691,35 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Strap on a headset and enter a VR realm of voguing ball dancers, figures in gimp masks, and leather daddies on spaceships. This is the world dreamt up by the artist <a href=\\"https://www.artsy.net/artist/jacolby-satterwhite\\">Jacolby Satterwhite</a>, who has been on a roll since emerging as one of the stars of the 2014 Whitney Biennial. In 2018, he brought an extension of <em>Blessed Avenue </em>(2018)—an installation with a VR component first shown at <a href=\\"https://www.artsy.net/gavin-browns-enterprise\\">Gavin Brown’s Enterprise</a> in New York—to Art Basel in Basel, Switzerland, for a booth with <a href=\\"https://www.artsy.net/ohwow/overview\\">Morán Morán</a>. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Strap on a headset and enter a VR realm of voguing ball dancers, figures in gimp masks, and leather daddies on spaceships. This is the world dreamt up by the artist 
+                    <a
+                      href="https://www.artsy.net/artist/jacolby-satterwhite"
+                    >
+                      Jacolby Satterwhite
+                    </a>
+                    , who has been on a roll since emerging as one of the stars of the 2014 Whitney Biennial. In 2018, he brought an extension of 
+                    <em>
+                      Blessed Avenue 
+                    </em>
+                    (2018)—an installation with a VR component first shown at 
+                    <a
+                      href="https://www.artsy.net/gavin-browns-enterprise"
+                    >
+                      Gavin Brown’s Enterprise
+                    </a>
+                     in New York—to Art Basel in Basel, Switzerland, for a booth with 
+                    <a
+                      href="https://www.artsy.net/ohwow/overview"
+                    >
+                      Morán Morán
+                    </a>
+                    . 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -13725,13 +14127,42 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/melike-kara\\">Melike Kara</a>’s graphic, stylized painted figures—part–futuristic frontiers-people, part–tribal civilization—have earned her a steady progression of interest from curators, dealers, and collectors alike over the past few years. In 2018, the Kurdish-German artist received her first <a href=\\"https://www.artsy.net/show/yuz-museum-melike-kara-a-taste-of-parsley\\">solo show</a> at an institution, the <a href=\\"https://www.artsy.net/yuz-museum\\">Yuz Museum</a> in Shanghai. This year, she’s had solo shows at Rotterdam’s <a href=\\"https://www.artsy.net/witte-de-with-center-for-contemporary-art\\">Witte de With Center for Contemporary Art</a> and London gallery Arcadia Missa. This September she made her solo debut in New York, at <a href=\\"https://www.artsy.net/salon-94\\">Salon 94</a>, firmly establishing her presence across the international art world. The artist also shows with Berlin’s Peres Projects.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/melike-kara"
+                    >
+                      Melike Kara
+                    </a>
+                    ’s graphic, stylized painted figures—part–futuristic frontiers-people, part–tribal civilization—have earned her a steady progression of interest from curators, dealers, and collectors alike over the past few years. In 2018, the Kurdish-German artist received her first 
+                    <a
+                      href="https://www.artsy.net/show/yuz-museum-melike-kara-a-taste-of-parsley"
+                    >
+                      solo show
+                    </a>
+                     at an institution, the 
+                    <a
+                      href="https://www.artsy.net/yuz-museum"
+                    >
+                      Yuz Museum
+                    </a>
+                     in Shanghai. This year, she’s had solo shows at Rotterdam’s 
+                    <a
+                      href="https://www.artsy.net/witte-de-with-center-for-contemporary-art"
+                    >
+                      Witte de With Center for Contemporary Art
+                    </a>
+                     and London gallery Arcadia Missa. This September she made her solo debut in New York, at 
+                    <a
+                      href="https://www.artsy.net/salon-94"
+                    >
+                      Salon 94
+                    </a>
+                    , firmly establishing her presence across the international art world. The artist also shows with Berlin’s Peres Projects.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -14164,13 +14595,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>To walk into a <a href=\\"https://www.artsy.net/artist/cui-jie\\">Cui Jie</a> exhibition is to enter a fantastical, futuristic city. Her paintings are imaginative, science fiction–tinged depictions of metropolises that merge Eastern and Western aesthetics. Taking architecture and furniture as source material, the artist abstracts the structures to develop novel compositions. Paintings feature chair spindles broken apart into spirals, and tubes that float against a brushy background. Aidan Li, head of the K11 Art Foundation, noted that Cui “is one of the most talented painters of her generation.” </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    To walk into a 
+                    <a
+                      href="https://www.artsy.net/artist/cui-jie"
+                    >
+                      Cui Jie
+                    </a>
+                     exhibition is to enter a fantastical, futuristic city. Her paintings are imaginative, science fiction–tinged depictions of metropolises that merge Eastern and Western aesthetics. Taking architecture and furniture as source material, the artist abstracts the structures to develop novel compositions. Paintings feature chair spindles broken apart into spirals, and tubes that float against a brushy background. Aidan Li, head of the K11 Art Foundation, noted that Cui “is one of the most talented painters of her generation.” 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -14603,13 +15040,25 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>The <a href=\\"https://www.artsy.net/article/artsy-editorial-firelei-baezs-intoxicating-installation-feminist-ode-african-diaspora\\">narrative complexities</a> of history, folklore, and personal experience collide in Dominican-American artist <a href=\\"https://www.artsy.net/artist/firelei-baez-1\\">Firelei Báez</a>’s energetically saturated paintings, sculptures, and installations. Afro-Caribbean women of the diaspora are the heroes of her intoxicating, symbol-laden works. The artist draws upon fiction and historical record in equal measure to reimagine the migration of these women across the globe, as well as the resilient and distinct communities that they helped build.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    The 
+                    <a
+                      href="https://www.artsy.net/article/artsy-editorial-firelei-baezs-intoxicating-installation-feminist-ode-african-diaspora"
+                    >
+                      narrative complexities
+                    </a>
+                     of history, folklore, and personal experience collide in Dominican-American artist 
+                    <a
+                      href="https://www.artsy.net/artist/firelei-baez-1"
+                    >
+                      Firelei Báez
+                    </a>
+                    ’s energetically saturated paintings, sculptures, and installations. Afro-Caribbean women of the diaspora are the heroes of her intoxicating, symbol-laden works. The artist draws upon fiction and historical record in equal measure to reimagine the migration of these women across the globe, as well as the resilient and distinct communities that they helped build.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -15042,13 +15491,25 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>The individuals who make up <a href=\\"https://www.artsy.net/artist/forensic-architecture\\">Forensic Architecture</a> have exposed the lies of the Israeli Defense Forces, Russia’s foreign ministry, and Syrian president Bashar al-Assad, along with many other powerful people and organizations. The collective, founded by Israeli-British architect <a href=\\"https://www.artsy.net/artist/eyal-weizman\\">Eyal Weizman</a>, is a multidisciplinary team of architects, designers, developers, archaeologists, filmmakers, and more. Nominated for the Turner Prize in 2018, the group has been known to investigate human rights violations, launch legal battles, and reveal truths through exhibitions, journalism, and the internet.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    The individuals who make up 
+                    <a
+                      href="https://www.artsy.net/artist/forensic-architecture"
+                    >
+                      Forensic Architecture
+                    </a>
+                     have exposed the lies of the Israeli Defense Forces, Russia’s foreign ministry, and Syrian president Bashar al-Assad, along with many other powerful people and organizations. The collective, founded by Israeli-British architect 
+                    <a
+                      href="https://www.artsy.net/artist/eyal-weizman"
+                    >
+                      Eyal Weizman
+                    </a>
+                    , is a multidisciplinary team of architects, designers, developers, archaeologists, filmmakers, and more. Nominated for the Turner Prize in 2018, the group has been known to investigate human rights violations, launch legal battles, and reveal truths through exhibitions, journalism, and the internet.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -15456,13 +15917,25 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>What makes <a href=\\"https://www.artsy.net/artist/tschabalala-self\\">Tschabalala Self</a> such a rising star is her visionary approach to textile-based canvases, where the fabrics act as backgrounds to the painted figures. “Tschabalala brings the cutting edge of visual culture today into dialogue with a Western art-historical canon that has held as a tradition the exclusion and marginalization of the black figure,” said Legacy Russell, associate curator at the <a href=\\"https://www.artsy.net/studio-museum\\">Studio Museum in Harlem</a>, where Self has been an artist-in-residence from 2018–19. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    What makes 
+                    <a
+                      href="https://www.artsy.net/artist/tschabalala-self"
+                    >
+                      Tschabalala Self
+                    </a>
+                     such a rising star is her visionary approach to textile-based canvases, where the fabrics act as backgrounds to the painted figures. “Tschabalala brings the cutting edge of visual culture today into dialogue with a Western art-historical canon that has held as a tradition the exclusion and marginalization of the black figure,” said Legacy Russell, associate curator at the 
+                    <a
+                      href="https://www.artsy.net/studio-museum"
+                    >
+                      Studio Museum in Harlem
+                    </a>
+                    , where Self has been an artist-in-residence from 2018–19. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -15870,13 +16343,30 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/harold-ancart\\">Harold Ancart</a> has a feverish approach to putting out work. He’s produced enough of his large-scale paintings—of matches, icebergs, and other abstracted forms—to be in 14 shows in 8 years with his New York gallery, the influential Bushwick- and Brussels-based hub <a href=\\"https://www.artsy.net/c-l-e-a-r-i-n-g\\">Clearing</a>. He got so restless to paint on a road trip across the United States that he built a makeshift studio in his trunk. And since signing on with mega-gallery <a href=\\"https://www.artsy.net/david-zwirner\\">David Zwirner</a> in 2018, Ancart has made enough work to fill walls at fairs such as Frieze New York and Los Angeles, Art Basel in Hong Kong, ART021 in Shanghai, and FIAC in Paris. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/harold-ancart"
+                    >
+                      Harold Ancart
+                    </a>
+                     has a feverish approach to putting out work. He’s produced enough of his large-scale paintings—of matches, icebergs, and other abstracted forms—to be in 14 shows in 8 years with his New York gallery, the influential Bushwick- and Brussels-based hub 
+                    <a
+                      href="https://www.artsy.net/c-l-e-a-r-i-n-g"
+                    >
+                      Clearing
+                    </a>
+                    . He got so restless to paint on a road trip across the United States that he built a makeshift studio in his trunk. And since signing on with mega-gallery 
+                    <a
+                      href="https://www.artsy.net/david-zwirner"
+                    >
+                      David Zwirner
+                    </a>
+                     in 2018, Ancart has made enough work to fill walls at fairs such as Frieze New York and Los Angeles, Art Basel in Hong Kong, ART021 in Shanghai, and FIAC in Paris. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -16459,13 +16949,36 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/frank-bowling\\">Frank Bowling</a> is a master colorist known for his large-scale abstract compositions with evocative details layered between oozing, glowing hues. The artist, now in his mid-eighties, has been long overdue for the type of recognition he’s finally getting. After solo shows at Haus der Kunst (curated by the late Okwui Enwezor) and the <a href=\\"https://www.artsy.net/dallasmuseumart\\">Dallas Museum of Art</a>, Bowling’s <a href=\\"https://www.artsy.net/show/tate-britain-frank-bowling-1\\">first major retrospective</a> opened at <a href=\\"https://www.artsy.net/tate-britain\\">Tate Britain</a> in May.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/frank-bowling"
+                    >
+                      Frank Bowling
+                    </a>
+                     is a master colorist known for his large-scale abstract compositions with evocative details layered between oozing, glowing hues. The artist, now in his mid-eighties, has been long overdue for the type of recognition he’s finally getting. After solo shows at Haus der Kunst (curated by the late Okwui Enwezor) and the 
+                    <a
+                      href="https://www.artsy.net/dallasmuseumart"
+                    >
+                      Dallas Museum of Art
+                    </a>
+                    , Bowling’s 
+                    <a
+                      href="https://www.artsy.net/show/tate-britain-frank-bowling-1"
+                    >
+                      first major retrospective
+                    </a>
+                     opened at 
+                    <a
+                      href="https://www.artsy.net/tate-britain"
+                    >
+                      Tate Britain
+                    </a>
+                     in May.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -16898,13 +17411,27 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>With titles like <em>Amazon </em>(1993) and <em>Antigone </em>(1970), <a href=\\"https://www.artsy.net/artist/zilia-sanchez\\">Zilia Sánchez</a>’s three-dimensional paintings evoke woman warriors and ancient mythologies. Her works are minimal and metaphoric, but leave lasting impressions. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    With titles like 
+                    <em>
+                      Amazon 
+                    </em>
+                    (1993) and 
+                    <em>
+                      Antigone 
+                    </em>
+                    (1970), 
+                    <a
+                      href="https://www.artsy.net/artist/zilia-sanchez"
+                    >
+                      Zilia Sánchez
+                    </a>
+                    ’s three-dimensional paintings evoke woman warriors and ancient mythologies. Her works are minimal and metaphoric, but leave lasting impressions. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -17337,13 +17864,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/fred-eversley\\">Fred Eversley</a>’s parabolic lens sculptures remind us of the wonder of being human in the vastness of the universe. His optically enticing works encourage self-reflection and shifts in perception. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/fred-eversley"
+                    >
+                      Fred Eversley
+                    </a>
+                    ’s parabolic lens sculptures remind us of the wonder of being human in the vastness of the universe. His optically enticing works encourage self-reflection and shifts in perception. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -17751,13 +18283,24 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/tishan-hsu\\">Tishan Hsu</a>’s multimedia work from the 1980s and ’90s radiates a dingy, lo-fi buzz. His muted paintings feature bumps, orifices, and ridges that suggest bodies in fragments or seen through an X-ray. Some paintings protrude from the wall, given dynamic heft with layered styrofoam; a number of sculptures integrate similar corporeal motifs with bathroom tiles, carts, and cages. Looking at Hsu’s work, one might think of hospitals, basements, and old-timey computer parts. The artist has “anticipated so many concerns that younger artists are dealing with in their work today,” said <a href=\\"https://www.artsy.net/whitneymuseum\\">Whitney Museum of American Art</a> curator Christopher Y. Lew, “especially in relation to technology and the body.” Lew added that he believes Hsu is a role model for Asian-Americans in the art world.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/tishan-hsu"
+                    >
+                      Tishan Hsu
+                    </a>
+                    ’s multimedia work from the 1980s and ’90s radiates a dingy, lo-fi buzz. His muted paintings feature bumps, orifices, and ridges that suggest bodies in fragments or seen through an X-ray. Some paintings protrude from the wall, given dynamic heft with layered styrofoam; a number of sculptures integrate similar corporeal motifs with bathroom tiles, carts, and cages. Looking at Hsu’s work, one might think of hospitals, basements, and old-timey computer parts. The artist has “anticipated so many concerns that younger artists are dealing with in their work today,” said 
+                    <a
+                      href="https://www.artsy.net/whitneymuseum"
+                    >
+                      Whitney Museum of American Art
+                    </a>
+                     curator Christopher Y. Lew, “especially in relation to technology and the body.” Lew added that he believes Hsu is a role model for Asian-Americans in the art world.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -18165,13 +18708,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Since the 1960s, <a href=\\"https://www.artsy.net/artist/howardena-pindell\\">Howardena Pindell</a> has forced a “seat at the table” by exploding the traditions of painting. Working with unconventional materials like glitter, talcum powder, and perfume, the African-American artist affixes her unstretched canvases to the wall with nails in a relaxed and sumptuous pose. These tactile paintings underlie the labor-intensive practices that the artist employs to make them: Whole canvases are composed of obsessively hole-punched paper dots, or violently cut and sewn back together. However abstract or conceptual, Pindell’s work addresses personal, political, and social issues. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Since the 1960s, 
+                    <a
+                      href="https://www.artsy.net/artist/howardena-pindell"
+                    >
+                      Howardena Pindell
+                    </a>
+                     has forced a “seat at the table” by exploding the traditions of painting. Working with unconventional materials like glitter, talcum powder, and perfume, the African-American artist affixes her unstretched canvases to the wall with nails in a relaxed and sumptuous pose. These tactile paintings underlie the labor-intensive practices that the artist employs to make them: Whole canvases are composed of obsessively hole-punched paper dots, or violently cut and sewn back together. However abstract or conceptual, Pindell’s work addresses personal, political, and social issues. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -18579,13 +19128,24 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/diane-simpson\\">Diane Simpson</a>’s abstract constructions—made with industrial materials like fiberboard, steel, linoleum, and rivets—allude to the labor of women and to traditional forms of femininity. At the same time, Simpson challenges functionality and our ideas of domestic and industrial work. As an artist, she reveres axonometric projection, depicting three-dimensional objects on flat surfaces. In these handmade structures, Simpson has also drawn upon references including <a href=\\"https://www.artsy.net/gene/art-deco\\">Art Deco</a> architecture and Japanese samurai armor.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/diane-simpson"
+                    >
+                      Diane Simpson
+                    </a>
+                    ’s abstract constructions—made with industrial materials like fiberboard, steel, linoleum, and rivets—allude to the labor of women and to traditional forms of femininity. At the same time, Simpson challenges functionality and our ideas of domestic and industrial work. As an artist, she reveres axonometric projection, depicting three-dimensional objects on flat surfaces. In these handmade structures, Simpson has also drawn upon references including 
+                    <a
+                      href="https://www.artsy.net/gene/art-deco"
+                    >
+                      Art Deco
+                    </a>
+                     architecture and Japanese samurai armor.
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -18993,13 +19553,26 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/lorraine-ogrady\\">Lorraine O’Grady</a>’s fearless determination to make the mainstream art world more accessible to black individuals can be witnessed in two particular works: <em>Mlle Bourgeoise Noire </em>(1980–83/2009), a guerilla performance of the artist dressed as “Miss Black Middle Class” while shouting protest poems at art happenings; and <em>Art Is…</em>(1983), a participatory performance during the African-American Day Parade in Harlem. In the latter piece, volunteers held up empty picture frames for the people of color watching the parade to consider themselves as art. O’Grady is best known for her performance, film, and photography exploring diaspora, hybridity, and black female subjectivity. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/lorraine-ogrady"
+                    >
+                      Lorraine O’Grady
+                    </a>
+                    ’s fearless determination to make the mainstream art world more accessible to black individuals can be witnessed in two particular works: 
+                    <em>
+                      Mlle Bourgeoise Noire 
+                    </em>
+                    (1980–83/2009), a guerilla performance of the artist dressed as “Miss Black Middle Class” while shouting protest poems at art happenings; and 
+                    <em>
+                      Art Is…
+                    </em>
+                    (1983), a participatory performance during the African-American Day Parade in Harlem. In the latter piece, volunteers held up empty picture frames for the people of color watching the parade to consider themselves as art. O’Grady is best known for her performance, film, and photography exploring diaspora, hybridity, and black female subjectivity. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -19432,13 +20005,44 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/teresa-burga\\">Teresa Burga</a>’s most iconic project, <em>Profile of the Peruvian Woman</em> (1980–81), was an investigation into the lives of middle-class Peruvian women through meticulous surveys. The artist went on to display the results through a series of objects, including a colorful indigenous yarn grid (or <em>quipu</em>). Her brightly painted, two-dimensional female bodies from 1967 appear playful, but are meant to parody ideals of femininity. Most impressive of Burga’s practice is that she has been questioning technology and information in her art since the 1970s. A pioneer of installation, media, and technology-driven art, Burga was also a founding member of the 1960s avant-garde group Arte Nuevo, known for producing <a href=\\"https://www.artsy.net/gene/happenings\\">Happenings</a>, <a href=\\"https://www.artsy.net/gene/op-art\\">Op art</a>, and <a href=\\"https://www.artsy.net/gene/pop-art\\">Pop art</a>. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/teresa-burga"
+                    >
+                      Teresa Burga
+                    </a>
+                    ’s most iconic project, 
+                    <em>
+                      Profile of the Peruvian Woman
+                    </em>
+                     (1980–81), was an investigation into the lives of middle-class Peruvian women through meticulous surveys. The artist went on to display the results through a series of objects, including a colorful indigenous yarn grid (or 
+                    <em>
+                      quipu
+                    </em>
+                    ). Her brightly painted, two-dimensional female bodies from 1967 appear playful, but are meant to parody ideals of femininity. Most impressive of Burga’s practice is that she has been questioning technology and information in her art since the 1970s. A pioneer of installation, media, and technology-driven art, Burga was also a founding member of the 1960s avant-garde group Arte Nuevo, known for producing 
+                    <a
+                      href="https://www.artsy.net/gene/happenings"
+                    >
+                      Happenings
+                    </a>
+                    , 
+                    <a
+                      href="https://www.artsy.net/gene/op-art"
+                    >
+                      Op art
+                    </a>
+                    , and 
+                    <a
+                      href="https://www.artsy.net/gene/pop-art"
+                    >
+                      Pop art
+                    </a>
+                    . 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -19871,13 +20475,47 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Inspired by vernacular American architecture, <a href=\\"https://www.artsy.net/artist/siah-armajani\\">Siah Armajani</a> designs large-scale, interactive sculptures with political resonances. After creating art for six decades, Armajani received <a href=\\"https://www.artsy.net/show/walker-art-center-siah-armajani-follow-this-line\\">his first American retrospective</a> at the <a href=\\"https://www.artsy.net/walker-art-center\\">Walker Art Center</a> in Minneapolis last year, which then traveled to the <a href=\\"https://www.artsy.net/metmuseum\\">Met Breuer</a> this past February. That same month, his seminal installation <em>Bridge Over Tree</em> (1970) was re-staged in Brooklyn by the <a href=\\"https://www.artsy.net/publicartfund\\">Public Art Fund</a> (PAF). Using basic construction and materials, Armajani’s bridge challenges our notions of nature and will. PAF director and chief curator Nicholas Baume noted that the artist “transfigures everyday, utilitarian architectural forms into a poetic language, imbuing them with meaning beyond their conventional function.” </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Inspired by vernacular American architecture, 
+                    <a
+                      href="https://www.artsy.net/artist/siah-armajani"
+                    >
+                      Siah Armajani
+                    </a>
+                     designs large-scale, interactive sculptures with political resonances. After creating art for six decades, Armajani received 
+                    <a
+                      href="https://www.artsy.net/show/walker-art-center-siah-armajani-follow-this-line"
+                    >
+                      his first American retrospective
+                    </a>
+                     at the 
+                    <a
+                      href="https://www.artsy.net/walker-art-center"
+                    >
+                      Walker Art Center
+                    </a>
+                     in Minneapolis last year, which then traveled to the 
+                    <a
+                      href="https://www.artsy.net/metmuseum"
+                    >
+                      Met Breuer
+                    </a>
+                     this past February. That same month, his seminal installation 
+                    <em>
+                      Bridge Over Tree
+                    </em>
+                     (1970) was re-staged in Brooklyn by the 
+                    <a
+                      href="https://www.artsy.net/publicartfund"
+                    >
+                      Public Art Fund
+                    </a>
+                     (PAF). Using basic construction and materials, Armajani’s bridge challenges our notions of nature and will. PAF director and chief curator Nicholas Baume noted that the artist “transfigures everyday, utilitarian architectural forms into a poetic language, imbuing them with meaning beyond their conventional function.” 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -20285,13 +20923,18 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p><a href=\\"https://www.artsy.net/artist/mcarthur-binion\\">McArthur Binion</a>’s work beckons you to get closer. From afar, his canvases look like painted, gridded abstractions, while suggesting hanging, knitted tapestries. Walk towards one, though, and each individual cell takes on a distinct texture, with subtle color variations throughout the composition. Binion’s works are made of paper, crayon, laser-printed images, and oil paint sticks; he builds them from personal documents, including copies of his birth certificate and pages from his address book. His oeuvre might be seen as a body of abstracted self-portraits, rendered with data. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    <a
+                      href="https://www.artsy.net/artist/mcarthur-binion"
+                    >
+                      McArthur Binion
+                    </a>
+                    ’s work beckons you to get closer. From afar, his canvases look like painted, gridded abstractions, while suggesting hanging, knitted tapestries. Walk towards one, though, and each individual cell takes on a distinct texture, with subtle color variations throughout the composition. Binion’s works are made of paper, crayon, laser-printed images, and oil paint sticks; he builds them from personal documents, including copies of his birth certificate and pages from his address book. His oeuvre might be seen as a body of abstracted self-portraits, rendered with data. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -20724,13 +21367,27 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>At 80 years old, painter and sculptor <a href=\\"https://www.artsy.net/artist/beatriz-gonzalez\\">Beatriz González</a> has been called one of the founders of modern Colombian art, but her international profile has grown in the past few years. Originally a figurative painter, González changed styles in the 1960s, creating vivid, colorblocked compositions based on mass media. In 1965, her painting <em>The Suicides of the Sisga I, II and III </em>was refused by the jury of the Salon of Colombian Artists. The artist has often dealt with violent unrest in her work, having come of age during a bloody era of Colombian history known as <em>La Violencia</em>.</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    At 80 years old, painter and sculptor 
+                    <a
+                      href="https://www.artsy.net/artist/beatriz-gonzalez"
+                    >
+                      Beatriz González
+                    </a>
+                     has been called one of the founders of modern Colombian art, but her international profile has grown in the past few years. Originally a figurative painter, González changed styles in the 1960s, creating vivid, colorblocked compositions based on mass media. In 1965, her painting 
+                    <em>
+                      The Suicides of the Sisga I, II and III 
+                    </em>
+                    was refused by the jury of the Salon of Colombian Artists. The artist has often dealt with violent unrest in her work, having come of age during a bloody era of Colombian history known as 
+                    <em>
+                      La Violencia
+                    </em>
+                    .
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -21163,13 +21820,31 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>In exile from her home in war-torn Lebanon, <a href=\\"https://www.artsy.net/artist/simone-fattal\\">Simone Fattal</a> found grace in literature and visual art. She settled in California in 1980, started The Post-Apollo Press, and wrote and distributed experimental poetry and fiction. When not writing or publishing, Fattal has pursued an expansive art practice that includes painting, collage, and sculpture. She may be best known for her ceramics, which suggest truncated human figures and archeological ruins—forms that seem to echo the destruction and violence of her past. A love for narrative is evident in Fattal’s visual work. Ruba Katrib, curator of “<a href=\\"https://www.artsy.net/show/moma-ps1-simone-fattal-works-and-days\\">Works and Days</a>,” the recently closed retrospective of Fattal’s work at <a href=\\"https://www.artsy.net/moma-ps1\\">MoMA PS1</a>, remarked that the artist “reconsiders how stories are told.”</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    In exile from her home in war-torn Lebanon, 
+                    <a
+                      href="https://www.artsy.net/artist/simone-fattal"
+                    >
+                      Simone Fattal
+                    </a>
+                     found grace in literature and visual art. She settled in California in 1980, started The Post-Apollo Press, and wrote and distributed experimental poetry and fiction. When not writing or publishing, Fattal has pursued an expansive art practice that includes painting, collage, and sculpture. She may be best known for her ceramics, which suggest truncated human figures and archeological ruins—forms that seem to echo the destruction and violence of her past. A love for narrative is evident in Fattal’s visual work. Ruba Katrib, curator of “
+                    <a
+                      href="https://www.artsy.net/show/moma-ps1-simone-fattal-works-and-days"
+                    >
+                      Works and Days
+                    </a>
+                    ,” the recently closed retrospective of Fattal’s work at 
+                    <a
+                      href="https://www.artsy.net/moma-ps1"
+                    >
+                      MoMA PS1
+                    </a>
+                    , remarked that the artist “reconsiders how stories are told.”
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -21602,13 +22277,19 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>In the early 1980s, painter <a href=\\"https://www.artsy.net/artist/vivian-suter\\">Vivian Suter</a> renounced the art world. Instead of hustling in major metropolises and fraternizing with dealers, she opted for a peaceful existence on the edge of a Guatemalan lake and focused on her practice. Suter arrived at a signature style: free-hanging canvases tacked to the wall or dangling from the ceiling, featuring brushy, bright, abstract designs. They suggest islands, trees, leaves, and large topographies. Her indoor and outdoor presentations envelop the viewer in soothing forms. And she’s made something of a triumphant return to the art world in recent years. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    In the early 1980s, painter 
+                    <a
+                      href="https://www.artsy.net/artist/vivian-suter"
+                    >
+                      Vivian Suter
+                    </a>
+                     renounced the art world. Instead of hustling in major metropolises and fraternizing with dealers, she opted for a peaceful existence on the edge of a Guatemalan lake and focused on her practice. Suter arrived at a signature style: free-hanging canvases tacked to the wall or dangling from the ceiling, featuring brushy, bright, abstract designs. They suggest islands, trees, leaves, and large topographies. Her indoor and outdoor presentations envelop the viewer in soothing forms. And she’s made something of a triumphant return to the art world in recent years. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -22016,13 +22697,25 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Nearly 20 years after he emerged on the Los Angeles art scene by making paintings on empty cigarette boxes and selling them for $80, <a href=\\"https://www.artsy.net/artist/henry-taylor\\">Henry Taylor</a> is making the best work of his life. In 2017, his large, ravishing portraits—of a black man grilling meat on his lawn; of the 32-year-old Philando Castile being shot by a Minnesota police officer—were a highlight of the Whitney Biennial in New York. Months later, his dealer <a href=\\"https://www.artsy.net/galerie-eva-presenhuber\\">Eva Presenhuber</a> unveiled a raucous show of his portraits at her Zurich gallery, with paintings of the artist’s friends and neighbors, and of Andrea Motley Crabtree, the first female deep sea diver in the U.S. Army. (Blum &amp; Poe has been Taylor’s primary dealer for the past decade.)</p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Nearly 20 years after he emerged on the Los Angeles art scene by making paintings on empty cigarette boxes and selling them for $80, 
+                    <a
+                      href="https://www.artsy.net/artist/henry-taylor"
+                    >
+                      Henry Taylor
+                    </a>
+                     is making the best work of his life. In 2017, his large, ravishing portraits—of a black man grilling meat on his lawn; of the 32-year-old Philando Castile being shot by a Minnesota police officer—were a highlight of the Whitney Biennial in New York. Months later, his dealer 
+                    <a
+                      href="https://www.artsy.net/galerie-eva-presenhuber"
+                    >
+                      Eva Presenhuber
+                    </a>
+                     unveiled a raucous show of his portraits at her Zurich gallery, with paintings of the artist’s friends and neighbors, and of Andrea Motley Crabtree, the first female deep sea diver in the U.S. Army. (Blum & Poe has been Taylor’s primary dealer for the past decade.)
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -22455,13 +23148,55 @@ exports[`Vanguard2019 Snapshots renders article series snapshot properly 1`] = `
                 className="article__text-section StyledText-sc-1ysl1h-0 higeIF"
                 color="black"
               >
-                <div
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Migrant, mother, global citizen—the Italian-born, Brazil-based artist <a href=\\"https://www.artsy.net/artist/anna-maria-maiolino\\">Anna Maria Maiolino</a> has explored these identities in intimate, autobiographical works that reflect her own displacement at the hand of authoritarian regimes. Maiolino’s first retrospective, at the <a href=\\"https://www.artsy.net/pinacoteca\\">Pinacoteca do Estado de São Paulo</a>, premiered in 2005. In 2017, she had a <a href=\\"https://www.artsy.net/show/moca-los-angeles-anna-maria-maiolino\\">major retrospective</a> at the <a href=\\"https://www.artsy.net/moca\\">Museum of Contemporary Art, Los Angeles</a>. This year, the artist—who shows with <a href=\\"https://www.artsy.net/hauser-and-wirth\\">Hauser &amp; Wirth</a>, Galeria Luisa Strina, and Galleria Raffaella Cortese—had a solo show at <a href=\\"https://www.artsy.net/pac-milano\\">Padiglione d’Arte Contemporanea</a> in Milan; a new survey of her work will debut at London’s <a href=\\"https://www.artsy.net/whitechapel-gallery\\">Whitechapel Gallery</a> in late September. </p>",
-                    }
-                  }
-                />
+                <div>
+                  <div
+                    className="paragraph"
+                  >
+                    Migrant, mother, global citizen—the Italian-born, Brazil-based artist 
+                    <a
+                      href="https://www.artsy.net/artist/anna-maria-maiolino"
+                    >
+                      Anna Maria Maiolino
+                    </a>
+                     has explored these identities in intimate, autobiographical works that reflect her own displacement at the hand of authoritarian regimes. Maiolino’s first retrospective, at the 
+                    <a
+                      href="https://www.artsy.net/pinacoteca"
+                    >
+                      Pinacoteca do Estado de São Paulo
+                    </a>
+                    , premiered in 2005. In 2017, she had a 
+                    <a
+                      href="https://www.artsy.net/show/moca-los-angeles-anna-maria-maiolino"
+                    >
+                      major retrospective
+                    </a>
+                     at the 
+                    <a
+                      href="https://www.artsy.net/moca"
+                    >
+                      Museum of Contemporary Art, Los Angeles
+                    </a>
+                    . This year, the artist—who shows with 
+                    <a
+                      href="https://www.artsy.net/hauser-and-wirth"
+                    >
+                      Hauser & Wirth
+                    </a>
+                    , Galeria Luisa Strina, and Galleria Raffaella Cortese—had a solo show at 
+                    <a
+                      href="https://www.artsy.net/pac-milano"
+                    >
+                      Padiglione d’Arte Contemporanea
+                    </a>
+                     in Milan; a new survey of her work will debut at London’s 
+                    <a
+                      href="https://www.artsy.net/whitechapel-gallery"
+                    >
+                      Whitechapel Gallery
+                    </a>
+                     in late September. 
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
+++ b/src/Components/Publishing/EditorialFeature/__tests__/__snapshots__/EditorialFeature.test.tsx.snap
@@ -2280,13 +2280,11 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
               className="article__text-section c27 c28"
               color="black"
             >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<blockquote>Whether they were experimenting with floating sculptures, investigating war zones, or pushing painting forward in bold new directions, artists in 2018 made exciting and eclectic contributions to the world. There are so many creative accomplishments to celebrate this year that narrowing our focus to the year’s 20 most influential artists was no easy task. The talents you’ll find here have undeniably changed our culture and have touched and inspired countless others who have followed their examples. In many cases, they’ve caused us to reconsider the very definitions of what art can look like, and what it can achieve. </blockquote>",
-                  }
-                }
-              />
+              <div>
+                <blockquote>
+                  Whether they were experimenting with floating sculptures, investigating war zones, or pushing painting forward in bold new directions, artists in 2018 made exciting and eclectic contributions to the world. There are so many creative accomplishments to celebrate this year that narrowing our focus to the year’s 20 most influential artists was no easy task. The talents you’ll find here have undeniably changed our culture and have touched and inspired countless others who have followed their examples. In many cases, they’ve caused us to reconsider the very definitions of what art can look like, and what it can achieve. 
+                </blockquote>
+              </div>
             </div>
           </div>
         </div>
@@ -2338,13 +2336,47 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Since <a href=\\"https://www.artsy.net/artist/kerry-james-marshall\\">Kerry James Marshall</a>’s stellar retrospective at <a href=\\"https://www.artsy.net/mcachicago\\">MCA Chicago</a>, the <a href=\\"https://www.artsy.net/metmuseum\\">Met Breuer</a>, and <a href=\\"https://www.artsy.net/mocala\\">MOCA Los Angeles</a> in 2016–17—an epic tour through some 35 years of his oeuvre, which places black Americans on the scale of history painting, conjuring transcendent scenes in barber shops and housing projects that vibrate with poetry, nuance, and magic—the artist has continued his ascension to become one of the most admired and influential artists living today. This year, Marshall became the <a href=\\"https://www.artsy.net/news/artsy-editorial-kerry-james-marshall-painting-sold-211-million-sothebys-making-expensive-african-american-artist-auction-alive-today\\">most expensive living African-American artist</a> at auction; in early 2018, his painting <em>Past Times</em> (1997) sold at Sotheby’s for $21.1 million, smashing his previous record of $5 million. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Since 
+                <a
+                  href="https://www.artsy.net/artist/kerry-james-marshall"
+                >
+                  Kerry James Marshall
+                </a>
+                ’s stellar retrospective at 
+                <a
+                  href="https://www.artsy.net/mcachicago"
+                >
+                  MCA Chicago
+                </a>
+                , the 
+                <a
+                  href="https://www.artsy.net/metmuseum"
+                >
+                  Met Breuer
+                </a>
+                , and 
+                <a
+                  href="https://www.artsy.net/mocala"
+                >
+                  MOCA Los Angeles
+                </a>
+                 in 2016–17—an epic tour through some 35 years of his oeuvre, which places black Americans on the scale of history painting, conjuring transcendent scenes in barber shops and housing projects that vibrate with poetry, nuance, and magic—the artist has continued his ascension to become one of the most admired and influential artists living today. This year, Marshall became the 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-kerry-james-marshall-painting-sold-211-million-sothebys-making-expensive-african-american-artist-auction-alive-today"
+                >
+                  most expensive living African-American artist
+                </a>
+                 at auction; in early 2018, his painting 
+                <em>
+                  Past Times
+                </em>
+                 (1997) sold at Sotheby’s for $21.1 million, smashing his previous record of $5 million. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2495,13 +2527,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Marshall’s latest work shows he’s in his prime and not afraid to move in new directions; he debuted new paintings at <a href=\\"https://www.artsy.net/david-zwirner\\">David Zwirner</a>’s London gallery, for a buzzy show that opened during the week of Frieze. The works summoned the whole of art history, alluding to the deep structural biases against black artists and the nature of the art market, while also experimenting with pure abstraction and paintings of quietly otherworldly scenes of everyday people doing everyday things, like a woman walking a dog. </p><p>Additional accolades this year came with presentations at Cleveland’s FRONT Triennial and the Carnegie International. Marshall also mounted his first public sculpture: a pair of stacked brick cylinders installed in Des Moines, Iowa, that pay tribute to the 12 African-American lawyers who founded the National Bar Association in Des Moines in 1925 after they were denied membership to the American Bar Association. Though he’s already cemented his place in the contemporary art canon, Marshall continues to experiment, take risks, and push his painting forward. “The structure of my practice as an artist makes me feel like I’m completely free,” he <a href=\\"https://www.artsy.net/article/artsy-editorial-kerry-james-marshall-proves-greatest-living-artists\\">said</a> during the opening of his London exhibition with David Zwirner. “I’m totally free. I’m not restrained by anything or anybody—I don’t have a lack of knowledge, a lack of ability, to do any of the things that I want to do.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Marshall’s latest work shows he’s in his prime and not afraid to move in new directions; he debuted new paintings at 
+                <a
+                  href="https://www.artsy.net/david-zwirner"
+                >
+                  David Zwirner
+                </a>
+                ’s London gallery, for a buzzy show that opened during the week of Frieze. The works summoned the whole of art history, alluding to the deep structural biases against black artists and the nature of the art market, while also experimenting with pure abstraction and paintings of quietly otherworldly scenes of everyday people doing everyday things, like a woman walking a dog. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Additional accolades this year came with presentations at Cleveland’s FRONT Triennial and the Carnegie International. Marshall also mounted his first public sculpture: a pair of stacked brick cylinders installed in Des Moines, Iowa, that pay tribute to the 12 African-American lawyers who founded the National Bar Association in Des Moines in 1925 after they were denied membership to the American Bar Association. Though he’s already cemented his place in the contemporary art canon, Marshall continues to experiment, take risks, and push his painting forward. “The structure of my practice as an artist makes me feel like I’m completely free,” he 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-kerry-james-marshall-proves-greatest-living-artists"
+                >
+                  said
+                </a>
+                 during the opening of his London exhibition with David Zwirner. “I’m totally free. I’m not restrained by anything or anybody—I don’t have a lack of knowledge, a lack of ability, to do any of the things that I want to do.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2552,13 +2601,33 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><a href=\\"https://www.artsy.net/artist/adrian-piper\\">Adrian Piper</a>’s art can be a profoundly uncomfortable experience—perhaps intentionally so. Over the course of several decades, Piper has needled, prodded at, and brought definition to the essence of American racism, class divisions, and misogyny through provocative performances, installations, and two-dimensional works, as well as with her writings and teachings. She is also a highly accomplished philosopher, with Eastern philosophies and the work of Kant looming large across her practice. </p><p>This year, Piper was the first living artist in the <a href=\\"https://www.artsy.net/museum-of-modern-art\\">Museum of Modern Art</a>’s history to receive the institution’s entire sixth floor for a sprawling retrospective. The show included her best-known works, like performance documentation of <em>The Mythic Being: I Embody Everything You Most Hate and Fear</em> (1975), in which she assumed the stereotype of an angry black man, donning an afro and fake mustache and engaging people in the street in aggressive, confrontational behavior, and even staging a mugging. But it also highlighted her lesser-known abstract compositions and recordings of her guerilla dance performances in public spaces, which underline the received notions of propriety and order inscribed into the built environment. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.artsy.net/artist/adrian-piper"
+                >
+                  Adrian Piper
+                </a>
+                ’s art can be a profoundly uncomfortable experience—perhaps intentionally so. Over the course of several decades, Piper has needled, prodded at, and brought definition to the essence of American racism, class divisions, and misogyny through provocative performances, installations, and two-dimensional works, as well as with her writings and teachings. She is also a highly accomplished philosopher, with Eastern philosophies and the work of Kant looming large across her practice. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                This year, Piper was the first living artist in the 
+                <a
+                  href="https://www.artsy.net/museum-of-modern-art"
+                >
+                  Museum of Modern Art
+                </a>
+                ’s history to receive the institution’s entire sixth floor for a sprawling retrospective. The show included her best-known works, like performance documentation of 
+                <em>
+                  The Mythic Being: I Embody Everything You Most Hate and Fear
+                </em>
+                 (1975), in which she assumed the stereotype of an angry black man, donning an afro and fake mustache and engaging people in the street in aggressive, confrontational behavior, and even staging a mugging. But it also highlighted her lesser-known abstract compositions and recordings of her guerilla dance performances in public spaces, which underline the received notions of propriety and order inscribed into the built environment. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2709,13 +2778,19 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Piper was given the prestigious Golden Lion award at the 2015 Venice Biennale. Her retrospective has since left MoMA, and a version of it is on view at the <a href=\\"https://www.artsy.net/hammer-museum\\">Hammer Museum</a> in L.A.; it will travel to the Haus der Kunst in Munich in 2019. “I was told by a friend during the opening that after this exhibition, it will no longer be possible to tell the story of the art of our times without Piper,” asserted Christophe Cherix, Robert Lehman Foundation Chief Curator of Drawings and Prints at MoMA. “I can only hope that’s true.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Piper was given the prestigious Golden Lion award at the 2015 Venice Biennale. Her retrospective has since left MoMA, and a version of it is on view at the 
+                <a
+                  href="https://www.artsy.net/hammer-museum"
+                >
+                  Hammer Museum
+                </a>
+                 in L.A.; it will travel to the Haus der Kunst in Munich in 2019. “I was told by a friend during the opening that after this exhibition, it will no longer be possible to tell the story of the art of our times without Piper,” asserted Christophe Cherix, Robert Lehman Foundation Chief Curator of Drawings and Prints at MoMA. “I can only hope that’s true.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2766,13 +2841,41 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Since “retiring” from the art world in 2011, following his retrospective-cum-spectacle at the <a href=\\"https://www.artsy.net/guggenheim\\">Guggenheim</a> that year, <a href=\\"https://www.artsy.net/artist/maurizio-cattelan\\">Maurizio Cattelan</a> has been busy dissolving the boundaries between art and commerce, fusing his high-concept chicanery with fashion and photography. <em>Toiletpaper</em>, the magazine he founded in 2010 with photographer <a href=\\"https://www.artsy.net/artist/pierpaolo-ferrari\\">Pierpaolo Ferrari</a>, has <a href=\\"https://www.artsy.net/article/artsy-editorial-seductive-surreal-photography-toiletpaper\\">garnered a cult following</a>—and has also attracted commissions from companies, like OKCupid and Kenzo, seeking to give their brands a facelift with the Italian duo’s saturated, surrealistic aesthetic.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Since “retiring” from the art world in 2011, following his retrospective-cum-spectacle at the 
+                <a
+                  href="https://www.artsy.net/guggenheim"
+                >
+                  Guggenheim
+                </a>
+                 that year, 
+                <a
+                  href="https://www.artsy.net/artist/maurizio-cattelan"
+                >
+                  Maurizio Cattelan
+                </a>
+                 has been busy dissolving the boundaries between art and commerce, fusing his high-concept chicanery with fashion and photography. 
+                <em>
+                  Toiletpaper
+                </em>
+                , the magazine he founded in 2010 with photographer 
+                <a
+                  href="https://www.artsy.net/artist/pierpaolo-ferrari"
+                >
+                  Pierpaolo Ferrari
+                </a>
+                , has 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-seductive-surreal-photography-toiletpaper"
+                >
+                  garnered a cult following
+                </a>
+                —and has also attracted commissions from companies, like OKCupid and Kenzo, seeking to give their brands a facelift with the Italian duo’s saturated, surrealistic aesthetic.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2923,13 +3026,86 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In the past couple of years, <em>Toiletpaper</em> has moved into selling collectable objects and environments—but Cattelan has still kept a foot in the world of galleries and museums. In 2018, he and Gucci creative director and fashion icon Alessandro Michele opened “The Artist Is Present,” an immersive blockbuster exhibition at the <a href=\\"https://www.artsy.net/yuz-museum\\">Yuz Museum</a> in Shanghai. The extravaganza features work by more than 30 high-profile artists, including <a href=\\"https://www.artsy.net/artist/kapwani-kiwanga\\">Kapwani Kiwanga</a>, <a href=\\"https://www.artsy.net/artist/superflex\\">Superflex</a>, <a href=\\"https://www.artsy.net/artist/xu-zhen-xu-zhen\\">Xu Zhen</a>, <a href=\\"https://www.artsy.net/artist/sturtevant-1\\">Sturtevant</a>, <a href=\\"https://www.artsy.net/artist/lawrence-weiner\\">Lawrence Weiner</a>, <a href=\\"https://www.artsy.net/artist/josh-kline\\">Josh Kline</a>, and <a href=\\"https://www.artsy.net/artist/reena-spaulings\\">Reena Spaulings</a>—each of whom tests the limits of artistic authorship. And despite technically being out of the game, Cattelan has still been making work. For Art Basel Cities in Buenos Aires, Argentina, this year, he conceived <em>Eternity</em>. Enlisting <a href=\\"https://www.artbasel.com/cities/catalog/Maurizio-Cattelan\\">help from locals</a>, he built a graveyard full of memorials in honor of people who are not yet dead.</p><p>“As an Italian, I am used to seeing plenty of ‘fake retirees,’” said Massimiliano Gioni, artistic director of the <a href=\\"https://www.artsy.net/newmuseum\\">New Museum</a> and a longtime friend of the artist. “It’s a national sport and a serious financial plague: people feigning disabilities in order to collect pensions or retiring for the sole purpose of getting paid while still working illegally. As always, Maurizio plays with Italian stereotypes and exacerbates them. I have always thought he is a very rare example of a lazy overachiever, so he has managed to be somewhat busier since he has gone into retirement.…To borrow the title of a recent study by Elena Filipovic on Duchamp, ‘the apparently marginal activities’ of Maurizio Cattelan will turn out to be as important a part of his career as all the work he had done before his retirement.” </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In the past couple of years, 
+                <em>
+                  Toiletpaper
+                </em>
+                 has moved into selling collectable objects and environments—but Cattelan has still kept a foot in the world of galleries and museums. In 2018, he and Gucci creative director and fashion icon Alessandro Michele opened “The Artist Is Present,” an immersive blockbuster exhibition at the 
+                <a
+                  href="https://www.artsy.net/yuz-museum"
+                >
+                  Yuz Museum
+                </a>
+                 in Shanghai. The extravaganza features work by more than 30 high-profile artists, including 
+                <a
+                  href="https://www.artsy.net/artist/kapwani-kiwanga"
+                >
+                  Kapwani Kiwanga
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/superflex"
+                >
+                  Superflex
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/xu-zhen-xu-zhen"
+                >
+                  Xu Zhen
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/sturtevant-1"
+                >
+                  Sturtevant
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/lawrence-weiner"
+                >
+                  Lawrence Weiner
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/josh-kline"
+                >
+                  Josh Kline
+                </a>
+                , and 
+                <a
+                  href="https://www.artsy.net/artist/reena-spaulings"
+                >
+                  Reena Spaulings
+                </a>
+                —each of whom tests the limits of artistic authorship. And despite technically being out of the game, Cattelan has still been making work. For Art Basel Cities in Buenos Aires, Argentina, this year, he conceived 
+                <em>
+                  Eternity
+                </em>
+                . Enlisting 
+                <a
+                  href="https://www.artbasel.com/cities/catalog/Maurizio-Cattelan"
+                >
+                  help from locals
+                </a>
+                , he built a graveyard full of memorials in honor of people who are not yet dead.
+              </div>
+              <div
+                className="paragraph"
+              >
+                “As an Italian, I am used to seeing plenty of ‘fake retirees,’” said Massimiliano Gioni, artistic director of the 
+                <a
+                  href="https://www.artsy.net/newmuseum"
+                >
+                  New Museum
+                </a>
+                 and a longtime friend of the artist. “It’s a national sport and a serious financial plague: people feigning disabilities in order to collect pensions or retiring for the sole purpose of getting paid while still working illegally. As always, Maurizio plays with Italian stereotypes and exacerbates them. I have always thought he is a very rare example of a lazy overachiever, so he has managed to be somewhat busier since he has gone into retirement.…To borrow the title of a recent study by Elena Filipovic on Duchamp, ‘the apparently marginal activities’ of Maurizio Cattelan will turn out to be as important a part of his career as all the work he had done before his retirement.” 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2980,13 +3156,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Over her nearly 60-year career, <a href=\\"https://www.artsy.net/artist/judy-chicago\\">Judy Chicago</a> has contended with women’s disenfranchisement, both in the art world and beyond it. Her major projects—ambitious series gathered for the first time in the survey “Judy Chicago: A Reckoning,” now at the <a href=\\"https://www.artsy.net/icamiami\\">Institute of Contemporary Art, Miami</a>—anticipate questions of power and erasure that are now central to the #MeToo movement. </p><p>As a young artist in the 1960s, Chicago struggled to squeeze herself—and her work—into the narrow confines of the male-dominated art scene centered around Los Angeles’s Ferus Gallery. Chicago’s experiences of misogynistic exclusion from this circle incentivized her to create a new art world that reflected women’s struggles and contributions.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Over her nearly 60-year career, 
+                <a
+                  href="https://www.artsy.net/artist/judy-chicago"
+                >
+                  Judy Chicago
+                </a>
+                 has contended with women’s disenfranchisement, both in the art world and beyond it. Her major projects—ambitious series gathered for the first time in the survey “Judy Chicago: A Reckoning,” now at the 
+                <a
+                  href="https://www.artsy.net/icamiami"
+                >
+                  Institute of Contemporary Art, Miami
+                </a>
+                —anticipate questions of power and erasure that are now central to the #MeToo movement. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                As a young artist in the 1960s, Chicago struggled to squeeze herself—and her work—into the narrow confines of the male-dominated art scene centered around Los Angeles’s Ferus Gallery. Chicago’s experiences of misogynistic exclusion from this circle incentivized her to create a new art world that reflected women’s struggles and contributions.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3137,13 +3330,73 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In 1970, she divested herself of her married name, choosing Chicago—her hometown—as a representation of that newfound emancipation. Soon after, she co-founded, with <a href=\\"https://www.artsy.net/artist/miriam-schapiro\\">Miriam Schapiro</a>, the pioneering Feminist Art Program at the <a href=\\"https://www.artsy.net/gene/calarts\\">California Institute of the Arts</a>, encouraging her students through consciousness-raising sessions to create works inspired by their gendered experiences. This helped lead, in 1972, to the groundbreaking Womanhouse project, in which Chicago and Schapiro, along with their students and local artists, overtook a dilapidated house with site-specific installations that probed the often-confining combination of artmaking and domestic labor present in so many female artists’ practices.</p><p>Women’s exclusion from public discourse features in Chicago’s best-known work, <em>The Dinner Party</em> (1974–79), a triangular banquet table set to honor centuries of important women, from Sappho to <a href=\\"https://www.artsy.net/artist/georgia-okeeffe\\">Georgia O’Keeffe</a>. Although it now enjoys a permanent home in a temple-like gallery at the <a href=\\"https://www.artsy.net/brooklyn-museum\\">Brooklyn Museum</a>, it was, for many years, regarded as little more than kitsch. </p><p>At her core, Chicago has endeavored to understand if the female experience can “be a pathway to the universal in the way male experience has been,” as she said <a href=\\"https://www.nytimes.com/2018/11/30/arts/judy-chicago-miami.html\\">in a recent interview</a>. Though she long struggled for her own recognition and critical acceptance, the fruits of Chicago’s feminist labor can be clearly seen throughout our current culture, from <a href=\\"https://www.artsy.net/artist/petra-collins\\">Petra Collins</a>’s menstruating vagina shirts to <a href=\\"https://www.artsy.net/artist/carmen-winant\\">Carmen Winant</a>’s sensational <em>My Birth</em> (2018)—a clear homage to Chicago’s “The Birth Project” (1980–85)—and even the pink “pussy hats” worn at recent women’s marches. There’s a new world coming, indeed, and Chicago helped make it possible.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In 1970, she divested herself of her married name, choosing Chicago—her hometown—as a representation of that newfound emancipation. Soon after, she co-founded, with 
+                <a
+                  href="https://www.artsy.net/artist/miriam-schapiro"
+                >
+                  Miriam Schapiro
+                </a>
+                , the pioneering Feminist Art Program at the 
+                <a
+                  href="https://www.artsy.net/gene/calarts"
+                >
+                  California Institute of the Arts
+                </a>
+                , encouraging her students through consciousness-raising sessions to create works inspired by their gendered experiences. This helped lead, in 1972, to the groundbreaking Womanhouse project, in which Chicago and Schapiro, along with their students and local artists, overtook a dilapidated house with site-specific installations that probed the often-confining combination of artmaking and domestic labor present in so many female artists’ practices.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Women’s exclusion from public discourse features in Chicago’s best-known work, 
+                <em>
+                  The Dinner Party
+                </em>
+                 (1974–79), a triangular banquet table set to honor centuries of important women, from Sappho to 
+                <a
+                  href="https://www.artsy.net/artist/georgia-okeeffe"
+                >
+                  Georgia O’Keeffe
+                </a>
+                . Although it now enjoys a permanent home in a temple-like gallery at the 
+                <a
+                  href="https://www.artsy.net/brooklyn-museum"
+                >
+                  Brooklyn Museum
+                </a>
+                , it was, for many years, regarded as little more than kitsch. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                At her core, Chicago has endeavored to understand if the female experience can “be a pathway to the universal in the way male experience has been,” as she said 
+                <a
+                  href="https://www.nytimes.com/2018/11/30/arts/judy-chicago-miami.html"
+                >
+                  in a recent interview
+                </a>
+                . Though she long struggled for her own recognition and critical acceptance, the fruits of Chicago’s feminist labor can be clearly seen throughout our current culture, from 
+                <a
+                  href="https://www.artsy.net/artist/petra-collins"
+                >
+                  Petra Collins
+                </a>
+                ’s menstruating vagina shirts to 
+                <a
+                  href="https://www.artsy.net/artist/carmen-winant"
+                >
+                  Carmen Winant
+                </a>
+                ’s sensational 
+                <em>
+                  My Birth
+                </em>
+                 (2018)—a clear homage to Chicago’s “The Birth Project” (1980–85)—and even the pink “pussy hats” worn at recent women’s marches. There’s a new world coming, indeed, and Chicago helped make it possible.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3194,13 +3447,28 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><a href=\\"https://www.artsy.net/artist/alex-da-corte\\">Alex Da Corte</a>’s stunning installations incorporate elements of design, architecture, film, and sculpture to create Day-Glo fantasylands. The Philadelphia-based artist started 2018 off strong with a winter show at New York’s Karma gallery. Even the exhibition title, “C-A-T Spells Murder,” promised plenty of irreverent fun. The exhibition was something of an oxymoron: thoughtful Instagram bait. In the middle of a room drenched in pink light, Da Corte turned a massive, orange foam-and-velvet cat on its head. This feline centerpiece was offset by a series of sculptures in neon and vinyl siding that turned simple motifs—a pie on a window sill, a spider’s web—into seductive signage. Across town, the artist’s film <em>Slow Graffiti </em>(2017) got its New York City debut in a summer group show at <a href=\\"https://www.artsy.net/david-zwirner\\">David Zwirner</a>, “This Is Not a Prop.” And at Art Basel Cities in Buenos Aires, Argentina, this past September, Da Corte mounted a giant, inflatable Kermit the Frog in the middle of an old studio. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.artsy.net/artist/alex-da-corte"
+                >
+                  Alex Da Corte
+                </a>
+                ’s stunning installations incorporate elements of design, architecture, film, and sculpture to create Day-Glo fantasylands. The Philadelphia-based artist started 2018 off strong with a winter show at New York’s Karma gallery. Even the exhibition title, “C-A-T Spells Murder,” promised plenty of irreverent fun. The exhibition was something of an oxymoron: thoughtful Instagram bait. In the middle of a room drenched in pink light, Da Corte turned a massive, orange foam-and-velvet cat on its head. This feline centerpiece was offset by a series of sculptures in neon and vinyl siding that turned simple motifs—a pie on a window sill, a spider’s web—into seductive signage. Across town, the artist’s film 
+                <em>
+                  Slow Graffiti 
+                </em>
+                (2017) got its New York City debut in a summer group show at 
+                <a
+                  href="https://www.artsy.net/david-zwirner"
+                >
+                  David Zwirner
+                </a>
+                , “This Is Not a Prop.” And at Art Basel Cities in Buenos Aires, Argentina, this past September, Da Corte mounted a giant, inflatable Kermit the Frog in the middle of an old studio. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3351,13 +3619,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Da Corte also produced one of the most-loved artworks at this year’s Carnegie International in Pittsburgh, where curator Ingrid Schaffner devoted an entire gallery to his exuberant work. At the center of the gallery, he erected a neon structure that resembled a cottage. Window boxes filled with neon flowers and jack-o-lanterns added sweet, illuminated touches. Inside, 57 of Da Corte’s films played on loop. It was surreal cinema: In one video, a platinum blonde played with knives as she chatted on the phone. In others, Da Corte dressed up in costumes that made him look like Mr. Rogers or the apple from Fruit of the Loom commercials. “His neon house positively glows with a love of music, movies, Mr. Rogers, muppets, Saturday morning cartoons, holiday schmalz, and works of contemporary art. At the same time it stands skeletal and alone,” Schaffner said, calling the work an “emotional and intense experience of American culture.”</p><p>It’s no surprise that Da Corte’s playful, campy style has captivated an audience that extends well beyond the art world (the musician St. Vincent is a fan, as well, tapping him to direct a <a href=\\"https://www.youtube.com/watch?v=4TPqUvy1vYU\\">vibrant music video</a> last year). Though the artist makes immersive, alluring eye candy, its strangeness saves it from becoming twee. His weird riffs on pop culture (he once <a href=\\"https://www.artsy.net/article/artsy-editorial-alex-da-corte-slim-shady-art-world-comeback\\">dressed up as Eminem</a> for a video) and old fables (he’s also impersonated Frankenstein) ask viewers to reconsider the media they consume daily and the characters who are part of the cultural lexicon.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Da Corte also produced one of the most-loved artworks at this year’s Carnegie International in Pittsburgh, where curator Ingrid Schaffner devoted an entire gallery to his exuberant work. At the center of the gallery, he erected a neon structure that resembled a cottage. Window boxes filled with neon flowers and jack-o-lanterns added sweet, illuminated touches. Inside, 57 of Da Corte’s films played on loop. It was surreal cinema: In one video, a platinum blonde played with knives as she chatted on the phone. In others, Da Corte dressed up in costumes that made him look like Mr. Rogers or the apple from Fruit of the Loom commercials. “His neon house positively glows with a love of music, movies, Mr. Rogers, muppets, Saturday morning cartoons, holiday schmalz, and works of contemporary art. At the same time it stands skeletal and alone,” Schaffner said, calling the work an “emotional and intense experience of American culture.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                It’s no surprise that Da Corte’s playful, campy style has captivated an audience that extends well beyond the art world (the musician St. Vincent is a fan, as well, tapping him to direct a 
+                <a
+                  href="https://www.youtube.com/watch?v=4TPqUvy1vYU"
+                >
+                  vibrant music video
+                </a>
+                 last year). Though the artist makes immersive, alluring eye candy, its strangeness saves it from becoming twee. His weird riffs on pop culture (he once 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-alex-da-corte-slim-shady-art-world-comeback"
+                >
+                  dressed up as Eminem
+                </a>
+                 for a video) and old fables (he’s also impersonated Frankenstein) ask viewers to reconsider the media they consume daily and the characters who are part of the cultural lexicon.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3408,13 +3693,36 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>How can an artist reshape our perceptions of the world and fundamentally reimagine the limits of art at the same time? <a href=\\"https://www.artsy.net/artist/bruce-nauman\\">Bruce Nauman</a>’s extraordinarily restless and wide-ranging 50-year practice offers some clues. From the beginning of his career, Nauman has grounded his artistic inquiries in the big questions: What does it mean to be a human being? Where is truth? Who holds power? </p><p>With the smallest of gestures—painting a picture of his spilled morning coffee, leaving a camera running in his studio for 24 hours, or forging a flashing neon sign that rotates between commonplace words—the artist has captured the ecstasy, pain, and deep existential dread of being alive. The artist’s two-part, widely-raved-about retrospective that opened at the Schaulager in Basel, Switzerland, earlier this year, and then traveled to the <a href=\\"https://www.artsy.net/museum-of-modern-art\\">Museum of Modern Art</a> and <a href=\\"https://www.artsy.net/moma-ps1\\">MoMA PS1</a> in New York, has further canonized Nauman’s reputation as one of the most influential contemporary artists of all time. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                How can an artist reshape our perceptions of the world and fundamentally reimagine the limits of art at the same time? 
+                <a
+                  href="https://www.artsy.net/artist/bruce-nauman"
+                >
+                  Bruce Nauman
+                </a>
+                ’s extraordinarily restless and wide-ranging 50-year practice offers some clues. From the beginning of his career, Nauman has grounded his artistic inquiries in the big questions: What does it mean to be a human being? Where is truth? Who holds power? 
+              </div>
+              <div
+                className="paragraph"
+              >
+                With the smallest of gestures—painting a picture of his spilled morning coffee, leaving a camera running in his studio for 24 hours, or forging a flashing neon sign that rotates between commonplace words—the artist has captured the ecstasy, pain, and deep existential dread of being alive. The artist’s two-part, widely-raved-about retrospective that opened at the Schaulager in Basel, Switzerland, earlier this year, and then traveled to the 
+                <a
+                  href="https://www.artsy.net/museum-of-modern-art"
+                >
+                  Museum of Modern Art
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/moma-ps1"
+                >
+                  MoMA PS1
+                </a>
+                 in New York, has further canonized Nauman’s reputation as one of the most influential contemporary artists of all time. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3565,13 +3873,35 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>As the exhibition’s lead curator, Kathy Halbreich, <a href=\\"https://www.artsy.net/article/artsy-editorial-bruce-naumans-seismic-impact-contemporary-art\\">told</a> <em>Artsy</em>, “If you’re interested in language, you can’t avoid Bruce; if you’re interested in video—and he was one of the first to use a Portapak—you can’t avoid Bruce. Bruce knew about performance before we even had a word for it. If you’re interested in any new technology, he was there early, if not first.” Indeed, Nauman’s explorations into and reinventions of performance, sculpture, new media, and everything in between have opened up so many new avenues for contemporary art that any one moment in his oeuvre could lead to a lifetime of experimentation for another artist. (Nauman <a href=\\"https://krollermuller.nl/en/bruce-nauman-a-cast-of-the-space-under-my-chair\\">cast the negative space under his seat</a> in the mid-1960s, for example, and today, <a href=\\"https://www.artsy.net/artist/rachel-whiteread\\">Rachel Whiteread</a> has made a career out of casting the negative spaces of houses, staircases, and smaller objects.) His influence is myriad, and it continues to ripple.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                As the exhibition’s lead curator, Kathy Halbreich, 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-bruce-naumans-seismic-impact-contemporary-art"
+                >
+                  told
+                </a>
+                 
+                <em>
+                  Artsy
+                </em>
+                , “If you’re interested in language, you can’t avoid Bruce; if you’re interested in video—and he was one of the first to use a Portapak—you can’t avoid Bruce. Bruce knew about performance before we even had a word for it. If you’re interested in any new technology, he was there early, if not first.” Indeed, Nauman’s explorations into and reinventions of performance, sculpture, new media, and everything in between have opened up so many new avenues for contemporary art that any one moment in his oeuvre could lead to a lifetime of experimentation for another artist. (Nauman 
+                <a
+                  href="https://krollermuller.nl/en/bruce-nauman-a-cast-of-the-space-under-my-chair"
+                >
+                  cast the negative space under his seat
+                </a>
+                 in the mid-1960s, for example, and today, 
+                <a
+                  href="https://www.artsy.net/artist/rachel-whiteread"
+                >
+                  Rachel Whiteread
+                </a>
+                 has made a career out of casting the negative spaces of houses, staircases, and smaller objects.) His influence is myriad, and it continues to ripple.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3622,13 +3952,37 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>For at least a decade, <a href=\\"https://www.artsy.net/artist/cao-fei\\">Cao Fei</a> has been considered one of the most important young voices to come out of China—an artist able to combine a macro view of the seismic shifts in the country since the Cultural Revolution with her personal experiences growing up in the city of Guangzhou, northwest of Hong Kong. Across appearances at the <a href=\\"https://www.artsy.net/serpentineuk\\">Serpentine Galleries</a> in London, the Venice Biennale, <a href=\\"https://www.artsy.net/moma-ps1\\">MoMA PS1</a> in New York, the <a href=\\"https://www.artsy.net/center-for-contemporary-art-tel-aviv\\">Center for Contemporary Art</a> in Tel Aviv, K21 in Dusseldorf, and numerous other international venues over the years, Cao has received acclaim for her videos and multimedia installations that feature surreal, absurdist, or grotesque narratives set in post-industrial China. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                For at least a decade, 
+                <a
+                  href="https://www.artsy.net/artist/cao-fei"
+                >
+                  Cao Fei
+                </a>
+                 has been considered one of the most important young voices to come out of China—an artist able to combine a macro view of the seismic shifts in the country since the Cultural Revolution with her personal experiences growing up in the city of Guangzhou, northwest of Hong Kong. Across appearances at the 
+                <a
+                  href="https://www.artsy.net/serpentineuk"
+                >
+                  Serpentine Galleries
+                </a>
+                 in London, the Venice Biennale, 
+                <a
+                  href="https://www.artsy.net/moma-ps1"
+                >
+                  MoMA PS1
+                </a>
+                 in New York, the 
+                <a
+                  href="https://www.artsy.net/center-for-contemporary-art-tel-aviv"
+                >
+                  Center for Contemporary Art
+                </a>
+                 in Tel Aviv, K21 in Dusseldorf, and numerous other international venues over the years, Cao has received acclaim for her videos and multimedia installations that feature surreal, absurdist, or grotesque narratives set in post-industrial China. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3779,13 +4133,38 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In her work, we see factory workers acting out their fantasies in the corridors and workstations at a warehouse; cosplayers assuming the roles of digital avatars amid gray, apocalyptic landscapes; or a relationship that plays out between the only two humans in the world’s first automated sorting plant (in Kunshan, Jiangsu Province)—as in her video <em>Asia One </em>(2018), which was on view in a group exhibition this year at the <a href=\\"https://www.artsy.net/guggenheim\\">Guggenheim</a>, and was acquired by the museum. </p><p>Another recent film, <em>Prison Architect</em> (2018), tells the fictional story of an architect charged with turning an arts center into a prison. It is the centerpiece of Cao’s first major retrospective in greater China, which opened earlier this year at Hong Kong’s Tai Kwun art center, cementing her wide-ranging influence in her home country, as well as abroad. It’s an ambitious, cinematic meditation on creative freedom and incarceration; it reverses the narrative behind Tai Kwun itself, which is an arts center renovated from a former police station. In 2020, Cao will enjoy a larger retrospective—her first in her current home of Beijing—at the <a href=\\"https://www.artsy.net/ucca\\">Ullens Center for Contemporary Art</a>. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In her work, we see factory workers acting out their fantasies in the corridors and workstations at a warehouse; cosplayers assuming the roles of digital avatars amid gray, apocalyptic landscapes; or a relationship that plays out between the only two humans in the world’s first automated sorting plant (in Kunshan, Jiangsu Province)—as in her video 
+                <em>
+                  Asia One 
+                </em>
+                (2018), which was on view in a group exhibition this year at the 
+                <a
+                  href="https://www.artsy.net/guggenheim"
+                >
+                  Guggenheim
+                </a>
+                , and was acquired by the museum. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Another recent film, 
+                <em>
+                  Prison Architect
+                </em>
+                 (2018), tells the fictional story of an architect charged with turning an arts center into a prison. It is the centerpiece of Cao’s first major retrospective in greater China, which opened earlier this year at Hong Kong’s Tai Kwun art center, cementing her wide-ranging influence in her home country, as well as abroad. It’s an ambitious, cinematic meditation on creative freedom and incarceration; it reverses the narrative behind Tai Kwun itself, which is an arts center renovated from a former police station. In 2020, Cao will enjoy a larger retrospective—her first in her current home of Beijing—at the 
+                <a
+                  href="https://www.artsy.net/ucca"
+                >
+                  Ullens Center for Contemporary Art
+                </a>
+                . 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3836,13 +4215,31 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Plenty of art purports to change your perspective on the world, but <a href=\\"https://www.artsy.net/artist/simone-leigh\\">Simone Leigh</a> actually hopes to heal. The multidisciplinary artist—who may be best known for her innovative ceramics and sculptures—once created a free clinic for Brooklyn residents (with yoga, pilates, and HIV screenings) and offered acupuncture and a guided meditation for Black Lives Matter at the <a href=\\"https://www.artsy.net/newmuseum\\">New Museum</a>. Leigh’s work, by design, is not for everyone: She <a href=\\"https://www.artinamericamagazine.com/news-features/interviews/going-underground-an-interview-with-simone-leigh/\\">consciously</a> makes art with a black, female viewer in mind. American institutions have catered their language and displays to white men for most of history; Leigh’s work bravely undermines the status quo.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Plenty of art purports to change your perspective on the world, but 
+                <a
+                  href="https://www.artsy.net/artist/simone-leigh"
+                >
+                  Simone Leigh
+                </a>
+                 actually hopes to heal. The multidisciplinary artist—who may be best known for her innovative ceramics and sculptures—once created a free clinic for Brooklyn residents (with yoga, pilates, and HIV screenings) and offered acupuncture and a guided meditation for Black Lives Matter at the 
+                <a
+                  href="https://www.artsy.net/newmuseum"
+                >
+                  New Museum
+                </a>
+                . Leigh’s work, by design, is not for everyone: She 
+                <a
+                  href="https://www.artinamericamagazine.com/news-features/interviews/going-underground-an-interview-with-simone-leigh/"
+                >
+                  consciously
+                </a>
+                 makes art with a black, female viewer in mind. American institutions have catered their language and displays to white men for most of history; Leigh’s work bravely undermines the status quo.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3993,13 +4390,50 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Ironically, the spaces she critiques throughout her practice are gradually enhancing her mainstream popularity. This past October, the <a href=\\"https://www.artsy.net/guggenheim\\">Guggenheim</a> awarded Leigh its prestigious Hugo Boss Prize. The month before, she opened her first solo exhibition at <a href=\\"https://www.artsy.net/luhring-augustine\\">Luhring Augustine</a>, a blue-chip New York gallery. <em>Cupboard VIII </em>(2018), one of the show’s most impressive sculptures, stands over 10 feet tall. The piece resembles a monumental woman, comprising a brown stoneware torso, hands, and neck; a head that resembles an open pot; and a layered raffia skirt that fans out 10 feet in diameter. In the show, the figure demanded her own private space—viewers could walk around the massive, hooping form, but never peer inside. Leigh often incorporates disconcerting female heads into her work: Faces are missing eyes or replaced entirely with gaping holes. As a result, the pieces sacrifice specificity as they address larger ideas about identity; if her figures are more mythological than real, they <em>are</em> clearly black women. </p><p>Next year, Leigh’s work will get a further spotlight in the public sphere when she mounts a massive, 16-foot-tall bronze bust on the <a href=\\"https://www.artsy.net/highlineart\\">High Line</a> park in New York. Leigh is an increasingly formidable presence in contemporary art, making the large-scale work apt for her outsize, revolutionary ambitions. “I’ve come to see her mute ceramic female figures as sentinels holding space for a culture that is very much in the making,” curator Helen Molesworth recently <a href=\\"https://www.artforum.com/print/201803/helen-molesworth-on-the-work-of-simone-leigh-74304\\">wrote</a>, “a culture in which whiteness is neither the center nor the frame.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Ironically, the spaces she critiques throughout her practice are gradually enhancing her mainstream popularity. This past October, the 
+                <a
+                  href="https://www.artsy.net/guggenheim"
+                >
+                  Guggenheim
+                </a>
+                 awarded Leigh its prestigious Hugo Boss Prize. The month before, she opened her first solo exhibition at 
+                <a
+                  href="https://www.artsy.net/luhring-augustine"
+                >
+                  Luhring Augustine
+                </a>
+                , a blue-chip New York gallery. 
+                <em>
+                  Cupboard VIII 
+                </em>
+                (2018), one of the show’s most impressive sculptures, stands over 10 feet tall. The piece resembles a monumental woman, comprising a brown stoneware torso, hands, and neck; a head that resembles an open pot; and a layered raffia skirt that fans out 10 feet in diameter. In the show, the figure demanded her own private space—viewers could walk around the massive, hooping form, but never peer inside. Leigh often incorporates disconcerting female heads into her work: Faces are missing eyes or replaced entirely with gaping holes. As a result, the pieces sacrifice specificity as they address larger ideas about identity; if her figures are more mythological than real, they 
+                <em>
+                  are
+                </em>
+                 clearly black women. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Next year, Leigh’s work will get a further spotlight in the public sphere when she mounts a massive, 16-foot-tall bronze bust on the 
+                <a
+                  href="https://www.artsy.net/highlineart"
+                >
+                  High Line
+                </a>
+                 park in New York. Leigh is an increasingly formidable presence in contemporary art, making the large-scale work apt for her outsize, revolutionary ambitions. “I’ve come to see her mute ceramic female figures as sentinels holding space for a culture that is very much in the making,” curator Helen Molesworth recently 
+                <a
+                  href="https://www.artforum.com/print/201803/helen-molesworth-on-the-work-of-simone-leigh-74304"
+                >
+                  wrote
+                </a>
+                , “a culture in which whiteness is neither the center nor the frame.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4050,13 +4484,35 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>It’s official: <a href=\\"https://www.artsy.net/artist/david-hockney\\">David Hockney</a> has surpassed <a href=\\"https://www.artsy.net/artist/jeff-koons\\">Jeff Koons</a> to become the <a href=\\"https://www.artsy.net/article/artsy-editorial-david-hockney-worlds-expensive-living-artist\\">most expensive living artist</a> in the world, after his iconic <em>Portrait of an Artist (Pool with Two Figures) </em>(1972) sold at Christie’s this past November for $90.3 million, with fees. Hockney created the painting after the end of a relationship, and there are competing interpretations about who the two figures in the painting are—whether the jacketed figure is Hockney looking down through the ripples of a swimming pool at his former lover swimming below, or his former lover gazing down at a new romantic partner, or nothing to do with their breakup at all (as his former lover has posited). Regardless of what it depicts, the painting represents two of Hockney’s most celebrated genres: his crystalline swimming pools and his double portraits, the latter capturing casual yet bold representations of individuals that vibrate with psychological connection. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                It’s official: 
+                <a
+                  href="https://www.artsy.net/artist/david-hockney"
+                >
+                  David Hockney
+                </a>
+                 has surpassed 
+                <a
+                  href="https://www.artsy.net/artist/jeff-koons"
+                >
+                  Jeff Koons
+                </a>
+                 to become the 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-david-hockney-worlds-expensive-living-artist"
+                >
+                  most expensive living artist
+                </a>
+                 in the world, after his iconic 
+                <em>
+                  Portrait of an Artist (Pool with Two Figures) 
+                </em>
+                (1972) sold at Christie’s this past November for $90.3 million, with fees. Hockney created the painting after the end of a relationship, and there are competing interpretations about who the two figures in the painting are—whether the jacketed figure is Hockney looking down through the ripples of a swimming pool at his former lover swimming below, or his former lover gazing down at a new romantic partner, or nothing to do with their breakup at all (as his former lover has posited). Regardless of what it depicts, the painting represents two of Hockney’s most celebrated genres: his crystalline swimming pools and his double portraits, the latter capturing casual yet bold representations of individuals that vibrate with psychological connection. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4207,13 +4663,60 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>The British painter has continued to build on his record-breaking 2017 traveling retrospective—which made stops at London’s <a href=\\"https://www.artsy.net/tate-britain\\">Tate Britain</a>, Paris’s <a href=\\"https://www.artsy.net/centrepompidou\\">Centre Pompidou</a>, and New York’s <a href=\\"https://www.artsy.net/metmuseum\\">Metropolitan Museum of Art</a>—by persistently moving his work in new directions. The dynamic, reverse perspectives and unusually shaped canvases he’s been experimenting with in recent years, as well as his explorations into manipulated photography, were on full view at London’s <a href=\\"https://www.artsy.net/royal-academy\\">Royal Academy of Arts</a> this past summer, where he presented monumental collaged photographs showing miniature representations of his own paintings in the institution’s uproarious Summer Exhibition, organized by fellow British artist <a href=\\"https://www.artsy.net/artist/grayson-perry\\">Grayson Perry</a>. </p><p>Two of Hockey’s large-scale composite photographs, which explode single-point perspective, also went on view this spring at New York’s <a href=\\"https://www.artsy.net/pace-gallery\\">Pace Gallery</a>, alongside a series of riotously colored hexagonal canvases showing landscapes around his Hollywood and Yorkshire homes, as well as his now-familiar blue deck. Meanwhile, another circulating survey exhibition (focusing on his paintings of people), “82 Portraits and 1 Still-Life,” made a final stop at the <a href=\\"https://www.artsy.net/lacma\\">Los Angeles County Museum of Art</a> earlier this year, coming home to the sun-drenched city that has inspired Hockney’s irresistibly youthful palette over the years. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                The British painter has continued to build on his record-breaking 2017 traveling retrospective—which made stops at London’s 
+                <a
+                  href="https://www.artsy.net/tate-britain"
+                >
+                  Tate Britain
+                </a>
+                , Paris’s 
+                <a
+                  href="https://www.artsy.net/centrepompidou"
+                >
+                  Centre Pompidou
+                </a>
+                , and New York’s 
+                <a
+                  href="https://www.artsy.net/metmuseum"
+                >
+                  Metropolitan Museum of Art
+                </a>
+                —by persistently moving his work in new directions. The dynamic, reverse perspectives and unusually shaped canvases he’s been experimenting with in recent years, as well as his explorations into manipulated photography, were on full view at London’s 
+                <a
+                  href="https://www.artsy.net/royal-academy"
+                >
+                  Royal Academy of Arts
+                </a>
+                 this past summer, where he presented monumental collaged photographs showing miniature representations of his own paintings in the institution’s uproarious Summer Exhibition, organized by fellow British artist 
+                <a
+                  href="https://www.artsy.net/artist/grayson-perry"
+                >
+                  Grayson Perry
+                </a>
+                . 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Two of Hockey’s large-scale composite photographs, which explode single-point perspective, also went on view this spring at New York’s 
+                <a
+                  href="https://www.artsy.net/pace-gallery"
+                >
+                  Pace Gallery
+                </a>
+                , alongside a series of riotously colored hexagonal canvases showing landscapes around his Hollywood and Yorkshire homes, as well as his now-familiar blue deck. Meanwhile, another circulating survey exhibition (focusing on his paintings of people), “82 Portraits and 1 Still-Life,” made a final stop at the 
+                <a
+                  href="https://www.artsy.net/lacma"
+                >
+                  Los Angeles County Museum of Art
+                </a>
+                 earlier this year, coming home to the sun-drenched city that has inspired Hockney’s irresistibly youthful palette over the years. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4264,13 +4767,26 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><a href=\\"https://www.artsy.net/artist/wu-tsang\\">Wu Tsang</a>’s magical realist–inflected films place a fantastical lens over histories that have been neglected: the communities that take root in underground clubs and bars; queer love stories; and narratives of performers striving to maintain creative freedom amid oppression. In her best-known, breakout film, <em>Wildness </em>(2012), Tsang gives voice (literally) to the historic Los Angeles gay bar Silver Platter in MacArthur Park, long a gathering point for Latinos and, more recently, LGBT artists. (The artist herself ran a night at the club called “Wildness.”) In narrations, the bar itself recounts its life as a refuge for marginalized peoples. She also invited some of the Silver Platter’s trans clientele to perform in her film <em>Damelo Todo/Odot Olemad</em> (2010–15)—shown at the U.K.’s Nottingham Contemporary last year—in which they staged the story of a Salvadorian teenager who leaves the country amid civil war and winds up in L.A. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.artsy.net/artist/wu-tsang"
+                >
+                  Wu Tsang
+                </a>
+                ’s magical realist–inflected films place a fantastical lens over histories that have been neglected: the communities that take root in underground clubs and bars; queer love stories; and narratives of performers striving to maintain creative freedom amid oppression. In her best-known, breakout film, 
+                <em>
+                  Wildness 
+                </em>
+                (2012), Tsang gives voice (literally) to the historic Los Angeles gay bar Silver Platter in MacArthur Park, long a gathering point for Latinos and, more recently, LGBT artists. (The artist herself ran a night at the club called “Wildness.”) In narrations, the bar itself recounts its life as a refuge for marginalized peoples. She also invited some of the Silver Platter’s trans clientele to perform in her film 
+                <em>
+                  Damelo Todo/Odot Olemad
+                </em>
+                 (2010–15)—shown at the U.K.’s Nottingham Contemporary last year—in which they staged the story of a Salvadorian teenager who leaves the country amid civil war and winds up in L.A. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4421,13 +4937,38 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Tsang has become a consistently strong and influential figure in contemporary art and activism, earning a prestigious MacArthur Genius award this year. She is recognized as much for being an innovator in the medium of documentary film—where she blurs the borders between fact and fiction—as she is for being a powerful, searing voice among non-binary artists. Her films not only spotlight gender-nonconforming communities, they also bend time and genre. In <em>Into a Space of Love </em>(2018), an experimental documentary for which she partnered with Gucci this year (and which debuted at Frieze New York in May), Tsang explores the history of 1980s and ’90s house music in New York, touching on issues of gentrification and the cultural appropriation of queer communities; in it, she imagines iconic club performers from different eras coexisting in the film’s experimental present. </p><p>Her film <em>Girl Talk</em> (2015) also featured prominently in the <a href=\\"https://www.artsy.net/newmuseum\\">New Museum</a>’s exhibition “Trigger: Gender as a Tool and a Weapon,” which closed earlier this year. It depicts the revered poet and theorist Fred Moten wearing a crystal-encrusted gown and spinning dreamily in a garden to the soulful jazz singing of Josiah Wise. Tsang’s most frequent collaborator, though, is the artist <a href=\\"https://www.artsy.net/artist/boychild\\">boychild</a>, who creates otherworldly, sci-fi-inflected performances in which her muscular, gender-ambiguous body is often the center. The pair performed just this past month at Faena Forum in Art Basel in Miami Beach—Tsang playing the piano and singing, while boychild performed a rendition of “Carmen” from the famous opera of the same name. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Tsang has become a consistently strong and influential figure in contemporary art and activism, earning a prestigious MacArthur Genius award this year. She is recognized as much for being an innovator in the medium of documentary film—where she blurs the borders between fact and fiction—as she is for being a powerful, searing voice among non-binary artists. Her films not only spotlight gender-nonconforming communities, they also bend time and genre. In 
+                <em>
+                  Into a Space of Love 
+                </em>
+                (2018), an experimental documentary for which she partnered with Gucci this year (and which debuted at Frieze New York in May), Tsang explores the history of 1980s and ’90s house music in New York, touching on issues of gentrification and the cultural appropriation of queer communities; in it, she imagines iconic club performers from different eras coexisting in the film’s experimental present. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Her film 
+                <em>
+                  Girl Talk
+                </em>
+                 (2015) also featured prominently in the 
+                <a
+                  href="https://www.artsy.net/newmuseum"
+                >
+                  New Museum
+                </a>
+                ’s exhibition “Trigger: Gender as a Tool and a Weapon,” which closed earlier this year. It depicts the revered poet and theorist Fred Moten wearing a crystal-encrusted gown and spinning dreamily in a garden to the soulful jazz singing of Josiah Wise. Tsang’s most frequent collaborator, though, is the artist 
+                <a
+                  href="https://www.artsy.net/artist/boychild"
+                >
+                  boychild
+                </a>
+                , who creates otherworldly, sci-fi-inflected performances in which her muscular, gender-ambiguous body is often the center. The pair performed just this past month at Faena Forum in Art Basel in Miami Beach—Tsang playing the piano and singing, while boychild performed a rendition of “Carmen” from the famous opera of the same name. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4478,13 +5019,25 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>As <a href=\\"https://www.artsy.net/artist/tomas-saraceno\\">Tomás Saraceno</a>’s solar-powered balloons rise, so the ambitions of his work continue to expand. The Argentina-born artist has been experimenting with floating sculptures and forms of flight for years—one example of which he installed in Vienna’s <a href=\\"https://www.artsy.net/gene/baroque\\">Baroque</a> Karlskirche earlier this year. Two air-filled spheres are currently floating above the central axis of the opulent 18th-century church, reflecting its ornate surfaces back at onlookers. The sky-bound inflatables are part of his Aerocene project, initiated in 2015—an ongoing collaboration between Saraceno and other artists and scientists. His goal is advancing fossil fuel-free flight and reducing humanity’s footprint on the planet by “[collaborating] with the atmosphere,” as he puts it, and harnessing the sun’s energy. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                As 
+                <a
+                  href="https://www.artsy.net/artist/tomas-saraceno"
+                >
+                  Tomás Saraceno
+                </a>
+                ’s solar-powered balloons rise, so the ambitions of his work continue to expand. The Argentina-born artist has been experimenting with floating sculptures and forms of flight for years—one example of which he installed in Vienna’s 
+                <a
+                  href="https://www.artsy.net/gene/baroque"
+                >
+                  Baroque
+                </a>
+                 Karlskirche earlier this year. Two air-filled spheres are currently floating above the central axis of the opulent 18th-century church, reflecting its ornate surfaces back at onlookers. The sky-bound inflatables are part of his Aerocene project, initiated in 2015—an ongoing collaboration between Saraceno and other artists and scientists. His goal is advancing fossil fuel-free flight and reducing humanity’s footprint on the planet by “[collaborating] with the atmosphere,” as he puts it, and harnessing the sun’s energy. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4635,13 +5188,34 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>But Saraceno’s biggest moment this year came with his carte-blanche exhibition at the <a href=\\"https://www.artsy.net/palaisdetokyo\\">Palais de Tokyo</a> in Paris, where he created a giant web of string for visitors to navigate; the material registers their movements as vibrations, some of which are audible to the human ear; some can only be felt by lying on the ground. He also enlisted a team of hundreds of spiders to cast silk webs around the space—with the insects prompted to mobilize, in theory, by a vibrational frequency produced from gravitational waves. He also showed new work at New York’s <a href=\\"https://www.artsy.net/tanya-bonakdar-gallery\\">Tanya Bonakdar Gallery</a> that offered visitors the chance to imagine environmentally symbiotic travel, such as the <em>Aerocene Float Predictor</em>, which employs wind-forecast data to enable visitors to create wind-propelled flight trajectories. </p><p>More recently, at Art Basel in Miami Beach, Saraceno planted a series of upturned, solar-power-capturing umbrellas along the beach that fueled a giant air-filled kite into the air. In Saraceno’s ongoing invitation to tread lightly on the Earth, and to feel a closer bond to our fellow terrestrial species, his work feels achingly urgent. In January, the artist will make his debut in a part of the world that is already feeling the effects of our widespread exploitation of the environment—Los Angeles, where Tanya Bonakdar has a newly opened space.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                But Saraceno’s biggest moment this year came with his carte-blanche exhibition at the 
+                <a
+                  href="https://www.artsy.net/palaisdetokyo"
+                >
+                  Palais de Tokyo
+                </a>
+                 in Paris, where he created a giant web of string for visitors to navigate; the material registers their movements as vibrations, some of which are audible to the human ear; some can only be felt by lying on the ground. He also enlisted a team of hundreds of spiders to cast silk webs around the space—with the insects prompted to mobilize, in theory, by a vibrational frequency produced from gravitational waves. He also showed new work at New York’s 
+                <a
+                  href="https://www.artsy.net/tanya-bonakdar-gallery"
+                >
+                  Tanya Bonakdar Gallery
+                </a>
+                 that offered visitors the chance to imagine environmentally symbiotic travel, such as the 
+                <em>
+                  Aerocene Float Predictor
+                </em>
+                , which employs wind-forecast data to enable visitors to create wind-propelled flight trajectories. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                More recently, at Art Basel in Miami Beach, Saraceno planted a series of upturned, solar-power-capturing umbrellas along the beach that fueled a giant air-filled kite into the air. In Saraceno’s ongoing invitation to tread lightly on the Earth, and to feel a closer bond to our fellow terrestrial species, his work feels achingly urgent. In January, the artist will make his debut in a part of the world that is already feeling the effects of our widespread exploitation of the environment—Los Angeles, where Tanya Bonakdar has a newly opened space.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4692,13 +5266,31 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Towards the end of 2018—a year in which <a href=\\"https://www.artsy.net/artist/takashi-murakami\\">Takashi Murakami</a> had solo shows in New York, Shanghai, and Hong Kong, and collaborated with fashion designer <a href=\\"https://www.artsy.net/artist/virgil-abloh\\">Virgil Abloh</a> on three more shows at <a href=\\"https://www.artsy.net/gagosian-gallery\\">Gagosian</a> outlets in London, Paris, and Beverly Hills—the artist invited his friend Kanye West and his wife, Kim Kardashian, to visit his studio in the suburbs of Tokyo. Murakami posted an image of the three of them on Instagram, and suddenly, it was an international news story.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Towards the end of 2018—a year in which 
+                <a
+                  href="https://www.artsy.net/artist/takashi-murakami"
+                >
+                  Takashi Murakami
+                </a>
+                 had solo shows in New York, Shanghai, and Hong Kong, and collaborated with fashion designer 
+                <a
+                  href="https://www.artsy.net/artist/virgil-abloh"
+                >
+                  Virgil Abloh
+                </a>
+                 on three more shows at 
+                <a
+                  href="https://www.artsy.net/gagosian-gallery"
+                >
+                  Gagosian
+                </a>
+                 outlets in London, Paris, and Beverly Hills—the artist invited his friend Kanye West and his wife, Kim Kardashian, to visit his studio in the suburbs of Tokyo. Murakami posted an image of the three of them on Instagram, and suddenly, it was an international news story.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4849,13 +5441,34 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Is there any other fine artist in recent memory who has the immediate pop-culture pull of Murakami? The high-low, photo-ready aesthetic he has been peddling for more than two decades has now meshed perfectly with our life-on-Instagram moment; with over 1 million followers on the platform, the artist has built an audience for himself that exceeds what any gallery could provide. And while plenty of artists collaborate with fashion lines, Murakami takes the cake: 15 years after Marc Jacobs recruited him to design what became a hugely popular and influential Louis Vuitton bag, Murakami is more ubiquitous than ever, designing low-priced duds for Uniqlo and T-shirts for Abloh’s Off-White line that now sell to hypebeasts on Grailed for $650. The artist, quite simply, is everywhere—even in the recent Drake collaboration with former foe Meek Mill, in which Drake raps about having “a lot of Murakami in the hallway.” </p><p>But the busy Murakami is just as active in the white cube. He had so many gallery shows in 2018, it was as if the sun never set on one of his exhibitions. The collaborations with Abloh may have garnered a <em>mixed</em> critical response, to say the least, but a solo show at <a href=\\"https://www.artsy.net/perrotin\\">Perrotin</a>’s New York outpost this spring was ambitious enough to fill multiple floors of the Lower East Side building that the Paris-born gallery took over in 2017. The most wowing works were gigantic diptychs that nodded to the work of <a href=\\"https://www.artsy.net/artist/francis-bacon\\">Francis Bacon</a>. They were impressive in person, sure, but they also looked really great on Instagram. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Is there any other fine artist in recent memory who has the immediate pop-culture pull of Murakami? The high-low, photo-ready aesthetic he has been peddling for more than two decades has now meshed perfectly with our life-on-Instagram moment; with over 1 million followers on the platform, the artist has built an audience for himself that exceeds what any gallery could provide. And while plenty of artists collaborate with fashion lines, Murakami takes the cake: 15 years after Marc Jacobs recruited him to design what became a hugely popular and influential Louis Vuitton bag, Murakami is more ubiquitous than ever, designing low-priced duds for Uniqlo and T-shirts for Abloh’s Off-White line that now sell to hypebeasts on Grailed for $650. The artist, quite simply, is everywhere—even in the recent Drake collaboration with former foe Meek Mill, in which Drake raps about having “a lot of Murakami in the hallway.” 
+              </div>
+              <div
+                className="paragraph"
+              >
+                But the busy Murakami is just as active in the white cube. He had so many gallery shows in 2018, it was as if the sun never set on one of his exhibitions. The collaborations with Abloh may have garnered a 
+                <em>
+                  mixed
+                </em>
+                 critical response, to say the least, but a solo show at 
+                <a
+                  href="https://www.artsy.net/perrotin"
+                >
+                  Perrotin
+                </a>
+                ’s New York outpost this spring was ambitious enough to fill multiple floors of the Lower East Side building that the Paris-born gallery took over in 2017. The most wowing works were gigantic diptychs that nodded to the work of 
+                <a
+                  href="https://www.artsy.net/artist/francis-bacon"
+                >
+                  Francis Bacon
+                </a>
+                . They were impressive in person, sure, but they also looked really great on Instagram. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4906,13 +5519,40 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Decades after her 1992 death, <a href=\\"https://www.artsy.net/artist/joan-mitchell\\">Joan Mitchell</a> remains a major subject of art world awe for both her lush <a href=\\"https://www.artsy.net/gene/abstract-expressionism\\">Abstract Expressionist</a> canvases and her legendarily difficult personality. This year, Mitchell’s market exploded: She made news in May when her 1969 painting <em>Blueberry</em> achieved $16.6 million at auction (with fees) and set a new auction record for her estate. The canvas features splotchy yellow and blue shapes, floating in a creamy field. Highly textured with intricately built-up layers, the composition is both cheery and infinitely complex: Each brushstroke possesses its own character. </p><p>Born in Chicago in 1925, Mitchell advocated for the unlimited potential of gestural abstraction. This past fall, New York gallery <a href=\\"https://www.artsy.net/cheim-and-read\\">Cheim &amp; Read</a> mounted an exhibition of her work spanning 1953 to 1962. From the beginning of her career, the show posited, the virtuosic Mitchell had already landed on her signature style: energetic oil brushstrokes and delicate drips; swirling centers that calm toward the canvas edges; and abstracted natural motifs that suggest fields, flowers, and bodies of water. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Decades after her 1992 death, 
+                <a
+                  href="https://www.artsy.net/artist/joan-mitchell"
+                >
+                  Joan Mitchell
+                </a>
+                 remains a major subject of art world awe for both her lush 
+                <a
+                  href="https://www.artsy.net/gene/abstract-expressionism"
+                >
+                  Abstract Expressionist
+                </a>
+                 canvases and her legendarily difficult personality. This year, Mitchell’s market exploded: She made news in May when her 1969 painting 
+                <em>
+                  Blueberry
+                </em>
+                 achieved $16.6 million at auction (with fees) and set a new auction record for her estate. The canvas features splotchy yellow and blue shapes, floating in a creamy field. Highly textured with intricately built-up layers, the composition is both cheery and infinitely complex: Each brushstroke possesses its own character. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Born in Chicago in 1925, Mitchell advocated for the unlimited potential of gestural abstraction. This past fall, New York gallery 
+                <a
+                  href="https://www.artsy.net/cheim-and-read"
+                >
+                  Cheim & Read
+                </a>
+                 mounted an exhibition of her work spanning 1953 to 1962. From the beginning of her career, the show posited, the virtuosic Mitchell had already landed on her signature style: energetic oil brushstrokes and delicate drips; swirling centers that calm toward the canvas edges; and abstracted natural motifs that suggest fields, flowers, and bodies of water. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5063,13 +5703,39 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Mitchell’s biography itself reached mainstream readers when writer Mary Gabriel published <em>Ninth Street Women </em>this past fall. The artist’s precocious success (she was a competitive figure skating champion as a teenager, and a published poet by age 10) and her expletive-ridden conversational habits made her a vibrant stand-out personality in Gabriel’s definitive volume on the women of Abstract Expressionism.</p><p>Throughout her career, Mitchell abstracted sunflowers, took inspiration from poetry (Frank O’Hara was a friend), and explored the diptych form in artworks that vaguely evoke Rorschach blots (Mitchell was in psychoanalysis for decades). She painted from New York and the outskirts of Paris until the year of her death. </p><p>In 2020, the Baltimore Museum of Art (BMA) and the <a href=\\"https://www.artsy.net/sfmoma\\">San Francisco Museum of Modern Art</a> will mount a major retrospective of her work. “I think if you spoke to the majority of scholars, [they’d say she’s] the most significant gestural painter, along with <a href=\\"https://www.artsy.net/artist/willem-de-kooning\\">[Willem] de Kooning</a>, during the post-war period,” said Christopher Bedford, Dorothy Wagner Wallis Director of the BMA. “She’s a titan.” Stay tuned—the Mitchell hype is just beginning.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Mitchell’s biography itself reached mainstream readers when writer Mary Gabriel published 
+                <em>
+                  Ninth Street Women 
+                </em>
+                this past fall. The artist’s precocious success (she was a competitive figure skating champion as a teenager, and a published poet by age 10) and her expletive-ridden conversational habits made her a vibrant stand-out personality in Gabriel’s definitive volume on the women of Abstract Expressionism.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Throughout her career, Mitchell abstracted sunflowers, took inspiration from poetry (Frank O’Hara was a friend), and explored the diptych form in artworks that vaguely evoke Rorschach blots (Mitchell was in psychoanalysis for decades). She painted from New York and the outskirts of Paris until the year of her death. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                In 2020, the Baltimore Museum of Art (BMA) and the 
+                <a
+                  href="https://www.artsy.net/sfmoma"
+                >
+                  San Francisco Museum of Modern Art
+                </a>
+                 will mount a major retrospective of her work. “I think if you spoke to the majority of scholars, [they’d say she’s] the most significant gestural painter, along with 
+                <a
+                  href="https://www.artsy.net/artist/willem-de-kooning"
+                >
+                  [Willem] de Kooning
+                </a>
+                , during the post-war period,” said Christopher Bedford, Dorothy Wagner Wallis Director of the BMA. “She’s a titan.” Stay tuned—the Mitchell hype is just beginning.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5120,13 +5786,24 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>At Documenta in 2017, an installation in the corner of the Neue Neue Galerie in Kassel, Germany, drew a constant, rapt crowd. Visitors watched a video that recreated the scene of a crime—the racist killing of a man named Halit Yozgat, who was murdered by a member of the neo-Nazi group National Socialist Underground in an internet café in Kassel on April 6, 2006. Collaborating with the Society of Friends of Halit and using a combination of research, simulations, and architectural renderings, a collective known as <a href=\\"https://www.artsy.net/artist/forensic-architecture\\">Forensic Architecture</a> had been piecing together the events that took place the day he was shot. What does the path toward justice have to do with art, one might ask? </p><p>Bringing together a team of artists, designers, architects, filmmakers, coders, journalists, lawyers, and scientists to investigate instances of state violence, the collective—based at London’s Goldsmiths College—has indeed pushed the boundaries of art to encompass reportage, data, and science. Forensic Architecture has proved that artists’ truth-seeking and ability to think outside of the box, combined with an interdisciplinary approach, can yield results in the real world. The evidence the collective has amassed on human rights abuses has been used in court cases around the world. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                At Documenta in 2017, an installation in the corner of the Neue Neue Galerie in Kassel, Germany, drew a constant, rapt crowd. Visitors watched a video that recreated the scene of a crime—the racist killing of a man named Halit Yozgat, who was murdered by a member of the neo-Nazi group National Socialist Underground in an internet café in Kassel on April 6, 2006. Collaborating with the Society of Friends of Halit and using a combination of research, simulations, and architectural renderings, a collective known as 
+                <a
+                  href="https://www.artsy.net/artist/forensic-architecture"
+                >
+                  Forensic Architecture
+                </a>
+                 had been piecing together the events that took place the day he was shot. What does the path toward justice have to do with art, one might ask? 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Bringing together a team of artists, designers, architects, filmmakers, coders, journalists, lawyers, and scientists to investigate instances of state violence, the collective—based at London’s Goldsmiths College—has indeed pushed the boundaries of art to encompass reportage, data, and science. Forensic Architecture has proved that artists’ truth-seeking and ability to think outside of the box, combined with an interdisciplinary approach, can yield results in the real world. The evidence the collective has amassed on human rights abuses has been used in court cases around the world. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5277,13 +5954,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Forensic Architecture has researched drone strikes carried out in the Middle East and worked with Amnesty International to determine the presence of a secret prison in Syria administered by the Bashar al-Assad regime, among other investigations. The art world apparently has seen the value in this expansion of the field: This year, the collective, founded by Eyal Weizman in 2010, received one of the art world’s greatest accolades—a nomination for the Turner Prize.</p><p>The collective received the honor for their participation in Documenta 14, as well as for recent exhibitions at MUAC in Mexico City; MACBA in Barcelona; and <a href=\\"https://www.artsy.net/ica-london\\">London’s Institute of Contemporary Art</a>. At the latter institution, they presented evidence of the existence of the Bedouin village of al-Araqib in the Negev/Naqab Desert before Israeli settlers arrived in the territory after World War II. (The Israeli state has claimed that it did not exist.) Forensic Architecture’s work around this—produced in large part through analysis of aerial photographs from 1945—is being prepared for use in a land-claim trial advanced by the al-Turi family of al-Araqib. While the collective may not have ultimately snagged the Turner Prize itself (that honor went to <a href=\\"https://www.artsy.net/artist/charlotte-prodger\\">Charlotte Prodger</a>), Forensic Architecture continues to push the boundaries of what we consider art.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Forensic Architecture has researched drone strikes carried out in the Middle East and worked with Amnesty International to determine the presence of a secret prison in Syria administered by the Bashar al-Assad regime, among other investigations. The art world apparently has seen the value in this expansion of the field: This year, the collective, founded by Eyal Weizman in 2010, received one of the art world’s greatest accolades—a nomination for the Turner Prize.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The collective received the honor for their participation in Documenta 14, as well as for recent exhibitions at MUAC in Mexico City; MACBA in Barcelona; and 
+                <a
+                  href="https://www.artsy.net/ica-london"
+                >
+                  London’s Institute of Contemporary Art
+                </a>
+                . At the latter institution, they presented evidence of the existence of the Bedouin village of al-Araqib in the Negev/Naqab Desert before Israeli settlers arrived in the territory after World War II. (The Israeli state has claimed that it did not exist.) Forensic Architecture’s work around this—produced in large part through analysis of aerial photographs from 1945—is being prepared for use in a land-claim trial advanced by the al-Turi family of al-Araqib. While the collective may not have ultimately snagged the Turner Prize itself (that honor went to 
+                <a
+                  href="https://www.artsy.net/artist/charlotte-prodger"
+                >
+                  Charlotte Prodger
+                </a>
+                ), Forensic Architecture continues to push the boundaries of what we consider art.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5334,13 +6028,51 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>One of the greatest visual poets of a generation, <a href=\\"https://www.artsy.net/artist/wolfgang-tillmans\\">Wolfgang Tillmans</a> employs the camera to weave lyrical, life-affirming vignettes in photographs that he displays in intuitive arrangements. Some of these can seem mundane—a weed taking root between two paving stones, a pair of men making out, a cresting wave—but they render simple moments and details in the built environment searingly poignant, even transcendent. </p><p>Building on his major survey exhibitions at the <a href=\\"https://www.artsy.net/tate\\">Tate Modern</a> and <a href=\\"https://www.artsy.net/fondationbeyeler\\">Fondation Beyeler</a> last year, in 2018, Tillmans unveiled solo presentations in Hong Kong (at <a href=\\"https://www.artsy.net/david-zwirner\\">David Zwirner</a>’s new Asian outpost) and at the Musée d’Art Contemporain et Multimédias in Kinshasa, Democratic Republic of the Congo (his first show in Africa). He also won Germany’s Goslar art prize, released an EP with electronic musician Powell (Tillmans is a veteran DJ), enjoyed a solo exhibition at Zwirner’s New York space, and found himself the subject of a glowing <em>New Yorker </em><a href=\\"https://www.newyorker.com/magazine/2018/09/10/the-life-and-art-of-wolfgang-tillmans\\">profile</a>. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                One of the greatest visual poets of a generation, 
+                <a
+                  href="https://www.artsy.net/artist/wolfgang-tillmans"
+                >
+                  Wolfgang Tillmans
+                </a>
+                 employs the camera to weave lyrical, life-affirming vignettes in photographs that he displays in intuitive arrangements. Some of these can seem mundane—a weed taking root between two paving stones, a pair of men making out, a cresting wave—but they render simple moments and details in the built environment searingly poignant, even transcendent. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Building on his major survey exhibitions at the 
+                <a
+                  href="https://www.artsy.net/tate"
+                >
+                  Tate Modern
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/fondationbeyeler"
+                >
+                  Fondation Beyeler
+                </a>
+                 last year, in 2018, Tillmans unveiled solo presentations in Hong Kong (at 
+                <a
+                  href="https://www.artsy.net/david-zwirner"
+                >
+                  David Zwirner
+                </a>
+                ’s new Asian outpost) and at the Musée d’Art Contemporain et Multimédias in Kinshasa, Democratic Republic of the Congo (his first show in Africa). He also won Germany’s Goslar art prize, released an EP with electronic musician Powell (Tillmans is a veteran DJ), enjoyed a solo exhibition at Zwirner’s New York space, and found himself the subject of a glowing 
+                <em>
+                  New Yorker 
+                </em>
+                <a
+                  href="https://www.newyorker.com/magazine/2018/09/10/the-life-and-art-of-wolfgang-tillmans"
+                >
+                  profile
+                </a>
+                . 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5491,13 +6223,27 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>As if that wasn’t enough, Tillmans designed a set for Benjamin Britten’s <em>War Requiem</em> at the English National Opera in London, programmed to mark the centenary of the armistice. His backdrops featured vastly blown-up versions of his images—giant projections of apocalyptic clouds, atmospheric monochromes, fields of grass, and close-ups of swamps. Tillmans makes a fitting contributor to an opera that reflects on global conflict and old national divisions; the artist has been one of Europe’s most outspoken critics against Brexit and the rise of the right wing across the continent and further afield. His concern with the issue instigated him to embark on a research project about our so-called post-truth world; his book <em>What Is Different?</em>—a collection of interviews with journalists, politicians, social workers, and scientists about the human response to falsehoods—was published this year by David Zwirner Books. Tillmans’s star will surely continue to rise with another retrospective, at the <a href=\\"https://www.artsy.net/museum-of-modern-art\\">Museum of Modern Art</a>, scheduled for 2021.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                As if that wasn’t enough, Tillmans designed a set for Benjamin Britten’s 
+                <em>
+                  War Requiem
+                </em>
+                 at the English National Opera in London, programmed to mark the centenary of the armistice. His backdrops featured vastly blown-up versions of his images—giant projections of apocalyptic clouds, atmospheric monochromes, fields of grass, and close-ups of swamps. Tillmans makes a fitting contributor to an opera that reflects on global conflict and old national divisions; the artist has been one of Europe’s most outspoken critics against Brexit and the rise of the right wing across the continent and further afield. His concern with the issue instigated him to embark on a research project about our so-called post-truth world; his book 
+                <em>
+                  What Is Different?
+                </em>
+                —a collection of interviews with journalists, politicians, social workers, and scientists about the human response to falsehoods—was published this year by David Zwirner Books. Tillmans’s star will surely continue to rise with another retrospective, at the 
+                <a
+                  href="https://www.artsy.net/museum-of-modern-art"
+                >
+                  Museum of Modern Art
+                </a>
+                , scheduled for 2021.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5548,13 +6294,36 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>The most remarkable aspect of <a href=\\"https://www.artsy.net/artist/charline-von-heyl\\">Charline von Heyl</a>’s paintings is how eclectic and contrary they can be, as a masterful solo show at <a href=\\"https://www.artsy.net/petzel-gallery\\">Petzel Gallery</a> in New York this year attested to. The German artist, who now splits her time between New York and Marfa, Texas, has spent the last three decades of her career consciously avoiding a consistent, recognizable style. And yet, “when you see a Charline von Heyl, you know it’s her work,” said Evelyn C. Hankins, co-curator of the artist’s mid-career survey “Snake Eyes” at the <a href=\\"https://www.artsy.net/hirshhorn\\">Hirshhorn Museum</a> in Washington, D.C., which is up through January 27, 2019.</p><p>In spellbinding, chaotic, near-abstract paintings layered with wonderfully contrasting styles and techniques, von Heyl draws together influences from disparate sources including art history, pop culture, literature, and her own life—a tantalizingly allusive array that challenges conventions about taste, as well as what belongs in a painting. Many contemporary painters look to her, Hankins said, because “she is fearless in both her formal vocabulary and in the things she’s looking at.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                The most remarkable aspect of 
+                <a
+                  href="https://www.artsy.net/artist/charline-von-heyl"
+                >
+                  Charline von Heyl
+                </a>
+                ’s paintings is how eclectic and contrary they can be, as a masterful solo show at 
+                <a
+                  href="https://www.artsy.net/petzel-gallery"
+                >
+                  Petzel Gallery
+                </a>
+                 in New York this year attested to. The German artist, who now splits her time between New York and Marfa, Texas, has spent the last three decades of her career consciously avoiding a consistent, recognizable style. And yet, “when you see a Charline von Heyl, you know it’s her work,” said Evelyn C. Hankins, co-curator of the artist’s mid-career survey “Snake Eyes” at the 
+                <a
+                  href="https://www.artsy.net/hirshhorn"
+                >
+                  Hirshhorn Museum
+                </a>
+                 in Washington, D.C., which is up through January 27, 2019.
+              </div>
+              <div
+                className="paragraph"
+              >
+                In spellbinding, chaotic, near-abstract paintings layered with wonderfully contrasting styles and techniques, von Heyl draws together influences from disparate sources including art history, pop culture, literature, and her own life—a tantalizingly allusive array that challenges conventions about taste, as well as what belongs in a painting. Many contemporary painters look to her, Hankins said, because “she is fearless in both her formal vocabulary and in the things she’s looking at.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5705,13 +6474,36 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Coming up in Hamburg in the 1980s, von Heyl joined a raucous, punk-inflected scene of (mostly male) artists—including <a href=\\"https://www.artsy.net/artist/albert-oehlen\\">Albert Oehlen</a>, <a href=\\"https://www.artsy.net/artist/sigmar-polke\\">Sigmar Polke</a>, and <a href=\\"https://www.artsy.net/artist/martin-kippenberger\\">Martin Kippenberger</a>—who embraced a firmly ironic stance toward the medium. The comic undertones of von Heyl’s work, by contrast, largely take the guise of formalist jokes, but offer little irony.</p><p>With “Snake Eyes,” the largest survey of von Heyl’s work in the United States (the show traveled from the Deichtorhallen Hamburg in the artist’s home country), Hankins hopes to reorient the narrative of von Heyl as an artist without a style. Although she doesn’t follow a chronological or linear narrative in the way she makes her paintings, “there is a consistency in her work,” Hankins contended. “Every painting is a unique challenge to tackle when standing in front of the canvas.” This openness also makes von Heyl appealing to artists, she continued, especially “the idea that you can have a cohesive body of work that at the same time challenges how we conventionally talk about the arc of an artist’s career.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Coming up in Hamburg in the 1980s, von Heyl joined a raucous, punk-inflected scene of (mostly male) artists—including 
+                <a
+                  href="https://www.artsy.net/artist/albert-oehlen"
+                >
+                  Albert Oehlen
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/sigmar-polke"
+                >
+                  Sigmar Polke
+                </a>
+                , and 
+                <a
+                  href="https://www.artsy.net/artist/martin-kippenberger"
+                >
+                  Martin Kippenberger
+                </a>
+                —who embraced a firmly ironic stance toward the medium. The comic undertones of von Heyl’s work, by contrast, largely take the guise of formalist jokes, but offer little irony.
+              </div>
+              <div
+                className="paragraph"
+              >
+                With “Snake Eyes,” the largest survey of von Heyl’s work in the United States (the show traveled from the Deichtorhallen Hamburg in the artist’s home country), Hankins hopes to reorient the narrative of von Heyl as an artist without a style. Although she doesn’t follow a chronological or linear narrative in the way she makes her paintings, “there is a consistency in her work,” Hankins contended. “Every painting is a unique challenge to tackle when standing in front of the canvas.” This openness also makes von Heyl appealing to artists, she continued, especially “the idea that you can have a cohesive body of work that at the same time challenges how we conventionally talk about the arc of an artist’s career.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5762,13 +6554,66 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>A virtuosic draftsman, printmaker, and painter, <a href=\\"https://www.artsy.net/artist/charles-white-1\\">Charles White</a> lent his meticulous style to powerfully dignified representations of historical and living African-Americans. His most vocal—and famous—advocate might be the venerated painter <a href=\\"https://www.artsy.net/artist/kerry-james-marshall\\">Kerry James Marshall</a>, who studied with the artist at the Otis Art Institute of Los Angeles County in the 1970s. “He was a kind of spiritual father for many of us,” Marshall <a href=\\"https://www.theparisreview.org/blog/2018/05/31/a-black-artist-named-white/\\">opined</a> in “A Black Artist Named White,” a personal essay included in the catalogue for the late artist’s largest exhibition to date: a retrospective that traveled from the <a href=\\"https://www.artsy.net/artic\\">Art Institute of Chicago</a> (his hometown) to the <a href=\\"https://www.artsy.net/museum-of-modern-art\\">Museum of Modern Art</a>, where it is on view through January 13, 2019. (The show arrives at the <a href=\\"https://www.artsy.net/lacma\\">Los Angeles County Museum of Art</a> next February.)</p><p>White inspired an entire generation of black artists, including acclaimed contemporary figures like <a href=\\"https://www.artsy.net/artist/david-hammons\\">David Hammons</a> and <a href=\\"https://www.artsy.net/artist/timothy-washington\\">Timothy Washington</a>. Nearly 40 years after his death, this retrospective puts White firmly in the spotlight. “Life Model: Charles White and His Students,” opening at LACMA this February as a supplement to the retrospective, looks specifically at the influence he wielded as a beloved educator. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                A virtuosic draftsman, printmaker, and painter, 
+                <a
+                  href="https://www.artsy.net/artist/charles-white-1"
+                >
+                  Charles White
+                </a>
+                 lent his meticulous style to powerfully dignified representations of historical and living African-Americans. His most vocal—and famous—advocate might be the venerated painter 
+                <a
+                  href="https://www.artsy.net/artist/kerry-james-marshall"
+                >
+                  Kerry James Marshall
+                </a>
+                , who studied with the artist at the Otis Art Institute of Los Angeles County in the 1970s. “He was a kind of spiritual father for many of us,” Marshall 
+                <a
+                  href="https://www.theparisreview.org/blog/2018/05/31/a-black-artist-named-white/"
+                >
+                  opined
+                </a>
+                 in “A Black Artist Named White,” a personal essay included in the catalogue for the late artist’s largest exhibition to date: a retrospective that traveled from the 
+                <a
+                  href="https://www.artsy.net/artic"
+                >
+                  Art Institute of Chicago
+                </a>
+                 (his hometown) to the 
+                <a
+                  href="https://www.artsy.net/museum-of-modern-art"
+                >
+                  Museum of Modern Art
+                </a>
+                , where it is on view through January 13, 2019. (The show arrives at the 
+                <a
+                  href="https://www.artsy.net/lacma"
+                >
+                  Los Angeles County Museum of Art
+                </a>
+                 next February.)
+              </div>
+              <div
+                className="paragraph"
+              >
+                White inspired an entire generation of black artists, including acclaimed contemporary figures like 
+                <a
+                  href="https://www.artsy.net/artist/david-hammons"
+                >
+                  David Hammons
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/artist/timothy-washington"
+                >
+                  Timothy Washington
+                </a>
+                . Nearly 40 years after his death, this retrospective puts White firmly in the spotlight. “Life Model: Charles White and His Students,” opening at LACMA this February as a supplement to the retrospective, looks specifically at the influence he wielded as a beloved educator. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5919,13 +6764,30 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>White endeavored with his socially engaged work to present the too-often-ignored narratives of black history, once insisting that “an artist must bear a special responsibility. He must be accountable for the content of his work. And that work should reflect a deep, abiding concern for humanity.” To that end, White consciously avoided artistic trends to achieve a more timeless effect. Throughout his life, he remained committed to representational art, even as its popularity waned during the <a href=\\"https://www.artsy.net/gene/abstract-expressionism\\">Abstract Expressionist</a> years of the 1940s and ’50s and as multidisciplinary <a href=\\"https://www.artsy.net/gene/conceptual-art\\">Conceptualism</a> took over in the 1970s. </p><p>Today, figuration is back in vogue, as is the imperative for young artists to occupy themselves with issues of identity, community, and social justice. White has become recognized not only as one of the 20th century’s most influential teachers, but as the exemplar artist who married skill with conviction.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                White endeavored with his socially engaged work to present the too-often-ignored narratives of black history, once insisting that “an artist must bear a special responsibility. He must be accountable for the content of his work. And that work should reflect a deep, abiding concern for humanity.” To that end, White consciously avoided artistic trends to achieve a more timeless effect. Throughout his life, he remained committed to representational art, even as its popularity waned during the 
+                <a
+                  href="https://www.artsy.net/gene/abstract-expressionism"
+                >
+                  Abstract Expressionist
+                </a>
+                 years of the 1940s and ’50s and as multidisciplinary 
+                <a
+                  href="https://www.artsy.net/gene/conceptual-art"
+                >
+                  Conceptualism
+                </a>
+                 took over in the 1970s. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Today, figuration is back in vogue, as is the imperative for young artists to occupy themselves with issues of identity, community, and social justice. White has become recognized not only as one of the 20th century’s most influential teachers, but as the exemplar artist who married skill with conviction.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5976,13 +6838,19 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>For centuries, culture has been patronized by wealthy elites, some of whose fortunes have been built from ethically questionable industries—but at what cost? At a time of deep political division in America, such relationships have increasingly been scrutinized, most recently with the <a href=\\"https://www.artsy.net/whitneymuseum\\">Whitney Museum</a>’s board vice-chairman Warren B. Kanders coming under fire for his connection to the tear gas being fired at asylum seekers at the U.S.–Mexico border. (Kanders owns Safariland, a company that produces munitions, including tear gas.) </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                For centuries, culture has been patronized by wealthy elites, some of whose fortunes have been built from ethically questionable industries—but at what cost? At a time of deep political division in America, such relationships have increasingly been scrutinized, most recently with the 
+                <a
+                  href="https://www.artsy.net/whitneymuseum"
+                >
+                  Whitney Museum
+                </a>
+                ’s board vice-chairman Warren B. Kanders coming under fire for his connection to the tear gas being fired at asylum seekers at the U.S.–Mexico border. (Kanders owns Safariland, a company that produces munitions, including tear gas.) 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6133,13 +7001,42 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>So the release this year of <a href=\\"https://www.artsy.net/artist/andrea-fraser\\">Andrea Fraser</a>’s tome-sized exploration of institutional board members’ political donations in the 2016 presidential election, <em>2016</em> <em>in Museums, Money, and Politics</em>, is particularly timely and urgent. In it, the artist brings to light the political contributions of over 5,000 board members at more than 125 art institutions across the United States. Among her discoveries was the frequency with which board members have donated to Republican causes—underlining the tension between the progressive values generally upheld by the art world (freedom of speech, equality, and human rights) and those of a political party whose establishment is increasingly moving towards the far right, driving forward a hardline immigration agenda, privileging corporations over individuals and the environment, and supporting a president who has called the press “the enemy of the American people.” </p><p>In addition to creating a powerful resource that surfaces the fraught relationship between culture and money, Fraser—who has been a crucial proponent of institutional critique throughout her career—herself joined the board of an institution this year: the <a href=\\"https://www.artsy.net/ica-la\\">Institute of Contemporary Art, Los Angeles</a>. And in addition to her ongoing teaching at UCLA, where she is an influential voice on the faculty, she has on view a graphic representation of her research from <em>2016 in Museums, Money, and Politics </em>at this year’s Shanghai Biennale. Fraser remains one of the most cogent and insightful voices challenging the art world from within.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                So the release this year of 
+                <a
+                  href="https://www.artsy.net/artist/andrea-fraser"
+                >
+                  Andrea Fraser
+                </a>
+                ’s tome-sized exploration of institutional board members’ political donations in the 2016 presidential election, 
+                <em>
+                  2016
+                </em>
+                 
+                <em>
+                  in Museums, Money, and Politics
+                </em>
+                , is particularly timely and urgent. In it, the artist brings to light the political contributions of over 5,000 board members at more than 125 art institutions across the United States. Among her discoveries was the frequency with which board members have donated to Republican causes—underlining the tension between the progressive values generally upheld by the art world (freedom of speech, equality, and human rights) and those of a political party whose establishment is increasingly moving towards the far right, driving forward a hardline immigration agenda, privileging corporations over individuals and the environment, and supporting a president who has called the press “the enemy of the American people.” 
+              </div>
+              <div
+                className="paragraph"
+              >
+                In addition to creating a powerful resource that surfaces the fraught relationship between culture and money, Fraser—who has been a crucial proponent of institutional critique throughout her career—herself joined the board of an institution this year: the 
+                <a
+                  href="https://www.artsy.net/ica-la"
+                >
+                  Institute of Contemporary Art, Los Angeles
+                </a>
+                . And in addition to her ongoing teaching at UCLA, where she is an influential voice on the faculty, she has on view a graphic representation of her research from 
+                <em>
+                  2016 in Museums, Money, and Politics 
+                </em>
+                at this year’s Shanghai Biennale. Fraser remains one of the most cogent and insightful voices challenging the art world from within.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6190,13 +7087,54 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>With a flair for the grotesque, <a href=\\"https://www.artsy.net/artist/john-bock\\">John Bock</a> undertakes intense, multi-year projects that combine film, performance, drawing, and sculpture. His horror-comedy aesthetic shares a kinship with artists like <a href=\\"https://www.artsy.net/artist/paul-mccarthy\\">Paul McCarthy</a> or the late <a href=\\"https://www.artsy.net/artist/mike-kelley\\">Mike Kelley</a>. Yet he’s also a stylistic chameleon, eager to quote from various genres and moments in cinema history, from <a href=\\"https://www.artsy.net/gene/german-expressionism\\">German Expressionism</a> to Quentin Tarantino to the stereotypical American western. It wouldn’t be wrong to think of Bock as a kind of B-movie <a href=\\"https://www.artsy.net/artist/matthew-barney\\">Matthew Barney</a>, creating similarly hermetic, wild universes that cross media (but with considerably more of a sense of humor).</p><p>2018 brought a suite of exhibitions for the artist, including “Dead + Juicy” at <a href=\\"https://www.artsy.net/anton-kern-gallery\\">Anton Kern Gallery</a> in New York, which opened, very appropriately, on Halloween. Bock gave the gallery’s elegant Midtown townhouse a campy makeover, installing a decrepit shed in its front space and building a bizarro bar area decorated with misshapen, hanging sculptures. The show’s centerpiece was a film by the same name, shot in Austin, Texas. Much of its action unfolds in a barbershop; a particularly indelible scene features one of the protagonists slowly shaving a taxidermied rat. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                With a flair for the grotesque, 
+                <a
+                  href="https://www.artsy.net/artist/john-bock"
+                >
+                  John Bock
+                </a>
+                 undertakes intense, multi-year projects that combine film, performance, drawing, and sculpture. His horror-comedy aesthetic shares a kinship with artists like 
+                <a
+                  href="https://www.artsy.net/artist/paul-mccarthy"
+                >
+                  Paul McCarthy
+                </a>
+                 or the late 
+                <a
+                  href="https://www.artsy.net/artist/mike-kelley"
+                >
+                  Mike Kelley
+                </a>
+                . Yet he’s also a stylistic chameleon, eager to quote from various genres and moments in cinema history, from 
+                <a
+                  href="https://www.artsy.net/gene/german-expressionism"
+                >
+                  German Expressionism
+                </a>
+                 to Quentin Tarantino to the stereotypical American western. It wouldn’t be wrong to think of Bock as a kind of B-movie 
+                <a
+                  href="https://www.artsy.net/artist/matthew-barney"
+                >
+                  Matthew Barney
+                </a>
+                , creating similarly hermetic, wild universes that cross media (but with considerably more of a sense of humor).
+              </div>
+              <div
+                className="paragraph"
+              >
+                2018 brought a suite of exhibitions for the artist, including “Dead + Juicy” at 
+                <a
+                  href="https://www.artsy.net/anton-kern-gallery"
+                >
+                  Anton Kern Gallery
+                </a>
+                 in New York, which opened, very appropriately, on Halloween. Bock gave the gallery’s elegant Midtown townhouse a campy makeover, installing a decrepit shed in its front space and building a bizarro bar area decorated with misshapen, hanging sculptures. The show’s centerpiece was a film by the same name, shot in Austin, Texas. Much of its action unfolds in a barbershop; a particularly indelible scene features one of the protagonists slowly shaving a taxidermied rat. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6347,13 +7285,38 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>The <a href=\\"https://www.artsy.net/fondazione-prada\\">Fondazione Prada</a> in Milan, Italy, also hosted Bock’s “The Next Quasi-Complex” this year, an exhibition of over-the-top installations and sculptures that coincided with a tongue-in-cheek “lecture” dubbed <em>When I’m Looking into the Goat Cheese Baiser</em> (2001). And in November, at <a href=\\"https://www.artsy.net/spruth-magers\\">Sprüth Magers</a> in Berlin, the artist debuted <em>Unheil (Mischief)</em> (2018), a new, dread-soaked, feature-length film set in the Dark Ages. </p><p>Perhaps Bock’s most salient achievement is bringing a Hollywood-style level of production to bear on themes that are decidedly esoteric. His exhibitions, with all their glorious mess and sprawl, provide a peek into the artist’s process—and brain—with film sets and props repurposed as sculptural environments meant to be wandered through and marveled over. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                The 
+                <a
+                  href="https://www.artsy.net/fondazione-prada"
+                >
+                  Fondazione Prada
+                </a>
+                 in Milan, Italy, also hosted Bock’s “The Next Quasi-Complex” this year, an exhibition of over-the-top installations and sculptures that coincided with a tongue-in-cheek “lecture” dubbed 
+                <em>
+                  When I’m Looking into the Goat Cheese Baiser
+                </em>
+                 (2001). And in November, at 
+                <a
+                  href="https://www.artsy.net/spruth-magers"
+                >
+                  Sprüth Magers
+                </a>
+                 in Berlin, the artist debuted 
+                <em>
+                  Unheil (Mischief)
+                </em>
+                 (2018), a new, dread-soaked, feature-length film set in the Dark Ages. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Perhaps Bock’s most salient achievement is bringing a Hollywood-style level of production to bear on themes that are decidedly esoteric. His exhibitions, with all their glorious mess and sprawl, provide a peek into the artist’s process—and brain—with film sets and props repurposed as sculptural environments meant to be wandered through and marveled over. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6404,13 +7367,36 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>When the artists <a href=\\"https://www.artsy.net/artist/kehinde-wiley\\">Kehinde Wiley</a> and <a href=\\"https://www.artsy.net/artist/amy-sherald\\">Amy Sherald</a> unveiled official portraits of the Obamas earlier this year, they received <a href=\\"https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama\\">a rapturous, emotional reception</a>. Rarely, if ever, has a presidential portrait received quite so much fanfare. It was the first time African-American artists had been selected for the honor of representing the president and first lady, and both artists moved the dial. Breaking from the more stiff, dull convention of portraiture that typifies presidential portraits of old, Wiley rendered Barack Obama against a hyperreal, abundant backdrop of vines and flowers.</p><p>The artist has, for some 17 years, proudly placed ordinary black Americans into the history of art—often “street casting” subjects and placing them in what have been referred to as “power portraits” that evoke the lavish style and tradition of canonizing aristocrats and politicians in European portraiture. For this intensely high-profile commission, Wiley depicted Barack Obama leaning forward slightly in a wooden chair, arms crossed, and surrounded—almost consumed—by a thicket of encroaching vines. He is engaged and alert, as though ruminating on a brief or intently listening to the words of his advisors.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                When the artists 
+                <a
+                  href="https://www.artsy.net/artist/kehinde-wiley"
+                >
+                  Kehinde Wiley
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/artist/amy-sherald"
+                >
+                  Amy Sherald
+                </a>
+                 unveiled official portraits of the Obamas earlier this year, they received 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama"
+                >
+                  a rapturous, emotional reception
+                </a>
+                . Rarely, if ever, has a presidential portrait received quite so much fanfare. It was the first time African-American artists had been selected for the honor of representing the president and first lady, and both artists moved the dial. Breaking from the more stiff, dull convention of portraiture that typifies presidential portraits of old, Wiley rendered Barack Obama against a hyperreal, abundant backdrop of vines and flowers.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The artist has, for some 17 years, proudly placed ordinary black Americans into the history of art—often “street casting” subjects and placing them in what have been referred to as “power portraits” that evoke the lavish style and tradition of canonizing aristocrats and politicians in European portraiture. For this intensely high-profile commission, Wiley depicted Barack Obama leaning forward slightly in a wooden chair, arms crossed, and surrounded—almost consumed—by a thicket of encroaching vines. He is engaged and alert, as though ruminating on a brief or intently listening to the words of his advisors.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6561,13 +7547,24 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>This is the president not as a monument of poise and power, but one who is active, bringing all of his intellect and energy to the task of grappling with the country’s challenges. The flowers that emerge from the greenery are symbolic—African blue lilies a nod to Barack’s Kenyan roots, chrysanthemums for the Obamas’ longtime home of Chicago, and jasmine to represent Hawaii, the former president’s birthplace—but they also disrupt the masculine tropes of power, suggesting the softer model of leadership that President Obama often cultivated. </p><p>The portraits received so much interest that they helped the National Portrait Gallery in Washington, D.C., smash its attendance records this year, drawing in over 2 million visitors in the last fiscal year, a large proportion of them millennials and Gen Z-ers. And Wiley was bestowed with the W.E.B. Du Bois medal, one of Harvard University’s most esteemed honors, alongside other black luminaries: comedian Dave Chappelle, art collector Pamela Joyner, and NFL player and activist Colin Kaepernick. Wiley also unveiled new, regal portraits of everyday black St. Louisans at the <a href=\\"https://www.artsy.net/stlartmuseum\\">Saint Louis Art Museum</a> later in the year. Now, he will leverage his considerable influence to place a spotlight on the Nigerian art scene; he has plans to open a studio in Lagos.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                This is the president not as a monument of poise and power, but one who is active, bringing all of his intellect and energy to the task of grappling with the country’s challenges. The flowers that emerge from the greenery are symbolic—African blue lilies a nod to Barack’s Kenyan roots, chrysanthemums for the Obamas’ longtime home of Chicago, and jasmine to represent Hawaii, the former president’s birthplace—but they also disrupt the masculine tropes of power, suggesting the softer model of leadership that President Obama often cultivated. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The portraits received so much interest that they helped the National Portrait Gallery in Washington, D.C., smash its attendance records this year, drawing in over 2 million visitors in the last fiscal year, a large proportion of them millennials and Gen Z-ers. And Wiley was bestowed with the W.E.B. Du Bois medal, one of Harvard University’s most esteemed honors, alongside other black luminaries: comedian Dave Chappelle, art collector Pamela Joyner, and NFL player and activist Colin Kaepernick. Wiley also unveiled new, regal portraits of everyday black St. Louisans at the 
+                <a
+                  href="https://www.artsy.net/stlartmuseum"
+                >
+                  Saint Louis Art Museum
+                </a>
+                 later in the year. Now, he will leverage his considerable influence to place a spotlight on the Nigerian art scene; he has plans to open a studio in Lagos.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6584,13 +7581,15 @@ exports[`EditorialFeature EOY_2018_ARTISTS Matches snapshot 1`] = `
             className="article__text-section c27 c28"
             color="black"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><em>Visual design by Wax Studios.</em></p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <em>
+                  Visual design by Wax Studios.
+                </em>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -8648,13 +9647,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>A duo creating extraordinary narratives about black American life.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                A duo creating extraordinary narratives about black American life.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -8796,13 +9793,77 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>This spring, when actor-comedian Donald Glover released the music video for his rapper alter-ego Childish Gambino’s “This Is America,” it set the internet ablaze. Glover and longtime collaborator Hiro Murai, a filmmaker, had created an utterly engrossing and disturbing masterpiece. In four minutes, the duo summed up the troubling undercurrent in America’s racial climate in a beautiful but often-brutal spectacle: Violence erupts around Glover as he moves through the video, his gestures and choreography referencing Jim Crow, minstrel shows, and viral internet dances. Glover himself ruthlessly executes witnesses to his performance.</p><p>In 48 hours, the video racked up more than 30 million views (to date, it has been watched over 445 million times). Viewers, knowing there was a wealth of symbolism to unpack, were hungry for critical analysis; seemingly every major publication—from <em><a href=\\"https://www.newyorker.com/culture/culture-desk/the-carnage-and-chaos-of-childish-gambinos-this-is-america\\">The New Yorker</a></em> and <em><a href=\\"https://www.npr.org/2018/05/07/609150167/donald-glovers-this-is-america-holds-ugly-truths-to-be-self-evident\\">NPR</a></em> to <em><a href=\\"http://www.dazeddigital.com/music/article/39966/1/childish-gambino-this-is-america-meaning-jim-crow-dancing-liberty\\">Dazed</a></em> and <em><a href=\\"https://www.complex.com/pop-culture/2018/05/the-real-meaning-behind-childish-gambino-this-is-america-video/\\">Complex</a></em>—responded with its own take. When was the last time a music video required such meticulous dissection? Before, Glover had enjoyed a dedicated fanbase for his music, but after “This Is America,” he had everyone’s attention.</p><p>The “This Is America” video dovetailed with the end of the second season of the FX show <em>Atlanta</em>, created by and starring Glover, who plays Earn, a man trying to find himself as he manages his cousin’s rap career in the eponymous city. The comedy-drama, which is almost entirely directed by Murai, has solidified its barrier-breaking power.</p><p><em>Atlanta</em> is about black life in America, but it also embraces the uncanny—particularly in this year’s season. In one episode, deep loss and existential dread color rapper Paper Boi’s disorienting journey through the woods; in another, Glover wears whiteface to play the bizarre, wealthy recluse Teddy Perkins, the episode leaning into the same mix of eeriness, humor, and acute racial symbolism that powered the 2017 hit film <em>Get Out.</em> (Someone, not Glover, <a href=\\"https://www.vanityfair.com/hollywood/2018/09/teddy-perkins-donald-glover-lakeith-stanfield-atlanta-emmys\\">dressed up</a> as Perkins at the 2018 Emmys, continuing the character’s unsettling narrative.) It’s a world that only Glover and Murai could imagine—their collaboration has been one of the most potent forces in entertainment this year.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                This spring, when actor-comedian Donald Glover released the music video for his rapper alter-ego Childish Gambino’s “This Is America,” it set the internet ablaze. Glover and longtime collaborator Hiro Murai, a filmmaker, had created an utterly engrossing and disturbing masterpiece. In four minutes, the duo summed up the troubling undercurrent in America’s racial climate in a beautiful but often-brutal spectacle: Violence erupts around Glover as he moves through the video, his gestures and choreography referencing Jim Crow, minstrel shows, and viral internet dances. Glover himself ruthlessly executes witnesses to his performance.
+              </div>
+              <div
+                className="paragraph"
+              >
+                In 48 hours, the video racked up more than 30 million views (to date, it has been watched over 445 million times). Viewers, knowing there was a wealth of symbolism to unpack, were hungry for critical analysis; seemingly every major publication—from 
+                <em>
+                  <a
+                    href="https://www.newyorker.com/culture/culture-desk/the-carnage-and-chaos-of-childish-gambinos-this-is-america"
+                  >
+                    The New Yorker
+                  </a>
+                </em>
+                 and 
+                <em>
+                  <a
+                    href="https://www.npr.org/2018/05/07/609150167/donald-glovers-this-is-america-holds-ugly-truths-to-be-self-evident"
+                  >
+                    NPR
+                  </a>
+                </em>
+                 to 
+                <em>
+                  <a
+                    href="http://www.dazeddigital.com/music/article/39966/1/childish-gambino-this-is-america-meaning-jim-crow-dancing-liberty"
+                  >
+                    Dazed
+                  </a>
+                </em>
+                 and 
+                <em>
+                  <a
+                    href="https://www.complex.com/pop-culture/2018/05/the-real-meaning-behind-childish-gambino-this-is-america-video/"
+                  >
+                    Complex
+                  </a>
+                </em>
+                —responded with its own take. When was the last time a music video required such meticulous dissection? Before, Glover had enjoyed a dedicated fanbase for his music, but after “This Is America,” he had everyone’s attention.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The “This Is America” video dovetailed with the end of the second season of the FX show 
+                <em>
+                  Atlanta
+                </em>
+                , created by and starring Glover, who plays Earn, a man trying to find himself as he manages his cousin’s rap career in the eponymous city. The comedy-drama, which is almost entirely directed by Murai, has solidified its barrier-breaking power.
+              </div>
+              <div
+                className="paragraph"
+              >
+                <em>
+                  Atlanta
+                </em>
+                 is about black life in America, but it also embraces the uncanny—particularly in this year’s season. In one episode, deep loss and existential dread color rapper Paper Boi’s disorienting journey through the woods; in another, Glover wears whiteface to play the bizarre, wealthy recluse Teddy Perkins, the episode leaning into the same mix of eeriness, humor, and acute racial symbolism that powered the 2017 hit film 
+                <em>
+                  Get Out.
+                </em>
+                 (Someone, not Glover, 
+                <a
+                  href="https://www.vanityfair.com/hollywood/2018/09/teddy-perkins-donald-glover-lakeith-stanfield-atlanta-emmys"
+                >
+                  dressed up
+                </a>
+                 as Perkins at the 2018 Emmys, continuing the character’s unsettling narrative.) It’s a world that only Glover and Murai could imagine—their collaboration has been one of the most potent forces in entertainment this year.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -8961,13 +10022,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Created the iconic official portrait of former first lady Michelle Obama.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Created the iconic official portrait of former first lady Michelle Obama.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -9109,13 +10168,105 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>“Let’s just start by saying ‘wow,’” <a href=\\"https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama\\">said</a> former first lady Michelle Obama, standing beside her just-unveiled official portrait, painted by artist <a href=\\"https://www.artsy.net/artist/amy-sherald\\">Amy Sherald</a>. The February ceremony at the National Portrait Gallery in Washington, D.C.—which also revealed <a href=\\"https://www.artsy.net/artist/kehinde-wiley\\">Kehinde Wiley</a>’s portrait of former president Barack Obama—was the star-making moment for the Baltimore-based painter, whose profile had been on the rise since 2016, following her <a href=\\"http://moniquemeloche.com/exhibitions/a-wonderful-dream/\\">first solo show</a> at Monique Meloche and <a href=\\"https://portraitcompetition.si.edu/content/amy-sherald\\">an award</a> from Smithsonian.</p><p>Demand for Sherald’s boldly colorful, classically posed portraits of black subjects <a href=\\"https://www.artsy.net/article/artsy-editorial-demand-soars-amy-sheralds-work-obama-portrait-reveal\\">skyrocketed</a> following the unveiling, and, in March, she signed with global mega-gallery <a href=\\"https://www.artsy.net/hauser-and-wirth\\">Hauser &amp; Wirth</a>. Institutional recognition of Sherald has also been building: Her first major solo museum show is currently on view at the <a href=\\"https://www.artsy.net/crystal-bridges\\">Crystal Bridges Museum of American Art</a> after a debut at the Contemporary Art Museum St. Louis in May. </p><p>“In her choice to paint black sitters, she firmly and declaratively adds to an art-historical lineage, expanding the notion of who gets to be seen and how,” said Lisa Melandri, who curated Sherald’s St. Louis show and also serves as the museum’s executive director.</p><p>But Sherald’s impact on 2018 went far beyond market forces and institutional support. Indeed, her Michelle Obama portrait proved so popular that it had to be moved to accommodate the crowds flocking to see it. One of the viewers, a two-year-old named Parker Curry, stood awestruck in front of the painting, and a photo of the moment went <a href=\\"https://www.instagram.com/p/Bf1tL5bgf5w/\\">viral</a>. Curry subsequently met the former first lady and dressed as Sherald’s portrait for <a href=\\"https://twitter.com/_parkercurry/status/1057838924238872576\\">Halloween</a>, while another <a href=\\"https://www.instagram.com/p/Bpo3r4YnNbA/\\">trick-or-treater</a> went as Sherald herself at the National Portrait Gallery unveiling, giving credence to Obama’s own prescient speech about Sherald’s painting. </p><p>“I’m also thinking about all the young people, particularly girls and girls of color,” the former first lady <a href=\\"https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama\\">said</a>, “who in years ahead will come to this place, and they will look up and they will see an image of someone who looks like them hanging on the wall of this great American institution—and I know the kind of impact that will have on their lives, because I was one of those girls.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                “Let’s just start by saying ‘wow,’” 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama"
+                >
+                  said
+                </a>
+                 former first lady Michelle Obama, standing beside her just-unveiled official portrait, painted by artist 
+                <a
+                  href="https://www.artsy.net/artist/amy-sherald"
+                >
+                  Amy Sherald
+                </a>
+                . The February ceremony at the National Portrait Gallery in Washington, D.C.—which also revealed 
+                <a
+                  href="https://www.artsy.net/artist/kehinde-wiley"
+                >
+                  Kehinde Wiley
+                </a>
+                ’s portrait of former president Barack Obama—was the star-making moment for the Baltimore-based painter, whose profile had been on the rise since 2016, following her 
+                <a
+                  href="http://moniquemeloche.com/exhibitions/a-wonderful-dream/"
+                >
+                  first solo show
+                </a>
+                 at Monique Meloche and 
+                <a
+                  href="https://portraitcompetition.si.edu/content/amy-sherald"
+                >
+                  an award
+                </a>
+                 from Smithsonian.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Demand for Sherald’s boldly colorful, classically posed portraits of black subjects 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-demand-soars-amy-sheralds-work-obama-portrait-reveal"
+                >
+                  skyrocketed
+                </a>
+                 following the unveiling, and, in March, she signed with global mega-gallery 
+                <a
+                  href="https://www.artsy.net/hauser-and-wirth"
+                >
+                  Hauser & Wirth
+                </a>
+                . Institutional recognition of Sherald has also been building: Her first major solo museum show is currently on view at the 
+                <a
+                  href="https://www.artsy.net/crystal-bridges"
+                >
+                  Crystal Bridges Museum of American Art
+                </a>
+                 after a debut at the Contemporary Art Museum St. Louis in May. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                “In her choice to paint black sitters, she firmly and declaratively adds to an art-historical lineage, expanding the notion of who gets to be seen and how,” said Lisa Melandri, who curated Sherald’s St. Louis show and also serves as the museum’s executive director.
+              </div>
+              <div
+                className="paragraph"
+              >
+                But Sherald’s impact on 2018 went far beyond market forces and institutional support. Indeed, her Michelle Obama portrait proved so popular that it had to be moved to accommodate the crowds flocking to see it. One of the viewers, a two-year-old named Parker Curry, stood awestruck in front of the painting, and a photo of the moment went 
+                <a
+                  href="https://www.instagram.com/p/Bf1tL5bgf5w/"
+                >
+                  viral
+                </a>
+                . Curry subsequently met the former first lady and dressed as Sherald’s portrait for 
+                <a
+                  href="https://twitter.com/_parkercurry/status/1057838924238872576"
+                >
+                  Halloween
+                </a>
+                , while another 
+                <a
+                  href="https://www.instagram.com/p/Bpo3r4YnNbA/"
+                >
+                  trick-or-treater
+                </a>
+                 went as Sherald herself at the National Portrait Gallery unveiling, giving credence to Obama’s own prescient speech about Sherald’s painting. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                “I’m also thinking about all the young people, particularly girls and girls of color,” the former first lady 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-masterful-history-making-portraits-barack-michelle-obama"
+                >
+                  said
+                </a>
+                , “who in years ahead will come to this place, and they will look up and they will see an image of someone who looks like them hanging on the wall of this great American institution—and I know the kind of impact that will have on their lives, because I was one of those girls.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -9274,13 +10425,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Opened the world’s first digital art museum.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Opened the world’s first digital art museum.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -9422,13 +10571,40 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In June, the interdisciplinary mega-collective <a href=\\"https://www.artsy.net/artist/teamlab\\">teamLab</a> unveiled its biggest project yet: a 10,000-square-meter digital art museum in Tokyo. Called the Mori Building Digital Art Museum, it’s the first museum in the world devoted to <a href=\\"https://www.artsy.net/gene/digital-art\\">digital art</a>. It also completely defies the traditional art-viewing experience: No maps, guides, or artwork captions are provided, and visitors are encouraged to touch and interact with the art.</p><p>Imagine traversing a forest of lamps that change hues as you approach; jumping on a trampoline, creating planets and stars in your midst; or finding respite in a room full of crashing waves. All of this, and much more, is possible inside the exhibition, entitled “Borderless.” Powered by 520 computers and 470 projectors, more than 50 artworks are seamlessly connected, responding to one another and to visitors. Inside the museum, teamLab strives to erase the borders between individual artworks, between art and the audience, and between visitors as they partake in a collective artmaking experience.</p><p>TeamLab was founded in 2001 by engineer Toshiyuki Inoko and now consists of over 500 members, from artists and animators to programmers and mathematicians. Though initially shunned by the Tokyo art world, their transportative, technicolor exhibitions have since won popular and critical acclaim, and have been staged in arts venues around the world. But no major cultural institution had the resources to support their installations at a large scale, so they decided to create their own, with support from urban developer Mori Building (founded by the prominent Japanese real estate and art collecting family). </p><p>The museum has welcomed over a million visitors in the five months since it opened. Bella Hadid, Abel Makkonen Tesfaye (a.k.a. The Weeknd), Sofia Richie, and Hailey Baldwin all paid visits, sharing selfies in the multicolor glow of the ever-evolving installations. But beyond its status as prime Instagram eye candy, “Borderless” also provides a glimpse of a future in which art, powered by technology, provides a totally immersive, collective experience. TeamLab’s ultimate goal? Turning entire cities into interactive works of art.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In June, the interdisciplinary mega-collective 
+                <a
+                  href="https://www.artsy.net/artist/teamlab"
+                >
+                  teamLab
+                </a>
+                 unveiled its biggest project yet: a 10,000-square-meter digital art museum in Tokyo. Called the Mori Building Digital Art Museum, it’s the first museum in the world devoted to 
+                <a
+                  href="https://www.artsy.net/gene/digital-art"
+                >
+                  digital art
+                </a>
+                . It also completely defies the traditional art-viewing experience: No maps, guides, or artwork captions are provided, and visitors are encouraged to touch and interact with the art.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Imagine traversing a forest of lamps that change hues as you approach; jumping on a trampoline, creating planets and stars in your midst; or finding respite in a room full of crashing waves. All of this, and much more, is possible inside the exhibition, entitled “Borderless.” Powered by 520 computers and 470 projectors, more than 50 artworks are seamlessly connected, responding to one another and to visitors. Inside the museum, teamLab strives to erase the borders between individual artworks, between art and the audience, and between visitors as they partake in a collective artmaking experience.
+              </div>
+              <div
+                className="paragraph"
+              >
+                TeamLab was founded in 2001 by engineer Toshiyuki Inoko and now consists of over 500 members, from artists and animators to programmers and mathematicians. Though initially shunned by the Tokyo art world, their transportative, technicolor exhibitions have since won popular and critical acclaim, and have been staged in arts venues around the world. But no major cultural institution had the resources to support their installations at a large scale, so they decided to create their own, with support from urban developer Mori Building (founded by the prominent Japanese real estate and art collecting family). 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The museum has welcomed over a million visitors in the five months since it opened. Bella Hadid, Abel Makkonen Tesfaye (a.k.a. The Weeknd), Sofia Richie, and Hailey Baldwin all paid visits, sharing selfies in the multicolor glow of the ever-evolving installations. But beyond its status as prime Instagram eye candy, “Borderless” also provides a glimpse of a future in which art, powered by technology, provides a totally immersive, collective experience. TeamLab’s ultimate goal? Turning entire cities into interactive works of art.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -9587,13 +10763,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Brought the fight against the opioid epidemic to the art world.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Brought the fight against the opioid epidemic to the art world.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -9735,13 +10909,64 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In the 1970s and ’80s, <a href=\\"https://www.artsy.net/artist/nan-goldin\\">Nan Goldin</a> made a name for herself with hedonistic, drug-fueled depictions of New York City street life. While the struggles of addiction play out in her gritty photographs—and have colored her own life—a near-death overdose in 2017 prompted Goldin’s secondary career as an activist. </p><p><a href=\\"https://www.artforum.com/print/201801/nan-goldin-73181\\">A confessional essay</a> published in the January 2018 issue of <em>Artforum</em> details Goldin’s harrowing, three-year addiction to OxyContin, and establishes her opposition to the drug’s manufacturer, Purdue Pharmaceuticals, as well as the company’s principal owners, the Sackler family, for their role in fostering and profiting from the opioid epidemic. Soon after the essay was published, Goldin organized <a href=\\"https://www.sacklerpain.org/mission-statement\\">Prescription Addiction Intervention Now</a>, or P.A.I.N., with the aim of creating legislation to restrict access to opioids, pressuring Purdue to redirect profits to fund treatment facilities, and, in a lateral move, persuading cultural institutions to stop accepting Sackler money.</p><p>The grassroots group meets regularly at Goldin’s Brooklyn apartment to coordinate protests at the many museums bearing the Sackler name. In an interview with <em>Artsy</em>, community organizer Jennifer Flynn Walker of the Center for Popular Democracy, who began working with Goldin and P.A.I.N. this year, said the artistic group’s visual sensibility is a crucial component to its success in an era when protests are increasingly recognized for their slick messaging. </p><p>At the <a href=\\"https://www.artsy.net/metmuseum\\">Metropolitan Museum of Art</a> in March, Goldin and her collaborators staged a news-making protest in the Sackler Wing, with participants tossing prescription pill bottles into the pool in front of the Temple of Dendur, while others passed out P.A.I.N.-branded pamphlets designed to mimic the museum’s printed maps. The affair ended with an old-school “die-in.”</p><p>“That action was the most beautiful I’ve ever seen—it was powerful, moving, emotional,” Flynn Walker recalled, adding that Goldin approached the action “like a cinematographer.” The resulting photographs of the event that circulated in newspapers and online are remarkably striking, making it impossible to ignore the art world’s complicity in real-world events.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In the 1970s and ’80s, 
+                <a
+                  href="https://www.artsy.net/artist/nan-goldin"
+                >
+                  Nan Goldin
+                </a>
+                 made a name for herself with hedonistic, drug-fueled depictions of New York City street life. While the struggles of addiction play out in her gritty photographs—and have colored her own life—a near-death overdose in 2017 prompted Goldin’s secondary career as an activist. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.artforum.com/print/201801/nan-goldin-73181"
+                >
+                  A confessional essay
+                </a>
+                 published in the January 2018 issue of 
+                <em>
+                  Artforum
+                </em>
+                 details Goldin’s harrowing, three-year addiction to OxyContin, and establishes her opposition to the drug’s manufacturer, Purdue Pharmaceuticals, as well as the company’s principal owners, the Sackler family, for their role in fostering and profiting from the opioid epidemic. Soon after the essay was published, Goldin organized 
+                <a
+                  href="https://www.sacklerpain.org/mission-statement"
+                >
+                  Prescription Addiction Intervention Now
+                </a>
+                , or P.A.I.N., with the aim of creating legislation to restrict access to opioids, pressuring Purdue to redirect profits to fund treatment facilities, and, in a lateral move, persuading cultural institutions to stop accepting Sackler money.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The grassroots group meets regularly at Goldin’s Brooklyn apartment to coordinate protests at the many museums bearing the Sackler name. In an interview with 
+                <em>
+                  Artsy
+                </em>
+                , community organizer Jennifer Flynn Walker of the Center for Popular Democracy, who began working with Goldin and P.A.I.N. this year, said the artistic group’s visual sensibility is a crucial component to its success in an era when protests are increasingly recognized for their slick messaging. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                At the 
+                <a
+                  href="https://www.artsy.net/metmuseum"
+                >
+                  Metropolitan Museum of Art
+                </a>
+                 in March, Goldin and her collaborators staged a news-making protest in the Sackler Wing, with participants tossing prescription pill bottles into the pool in front of the Temple of Dendur, while others passed out P.A.I.N.-branded pamphlets designed to mimic the museum’s printed maps. The affair ended with an old-school “die-in.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                “That action was the most beautiful I’ve ever seen—it was powerful, moving, emotional,” Flynn Walker recalled, adding that Goldin approached the action “like a cinematographer.” The resulting photographs of the event that circulated in newspapers and online are remarkably striking, making it impossible to ignore the art world’s complicity in real-world events.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -9900,13 +11125,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Created the year’s most impactful magazine covers, commenting on school shootings, violence against journalists, and White House chaos.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Created the year’s most impactful magazine covers, commenting on school shootings, violence against journalists, and White House chaos.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -10048,13 +11271,60 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In the era of digital media, magazine covers rarely generate the amount of attention they garnered in decades past. Though <em>Time </em>has a long history of delivering powerful news succinctly within its iconic red frame, D.W. Pine, the magazine’s creative director since 2010, has had the unique challenge of keeping the magazine’s cover relevant when most readers don’t buy print subscriptions.</p><p>Pine has risen to that challenge. As <em>Time</em>’s director of multimedia, Katherine Pomerantz, has pointed out, his designs this year “have been so iconic that they too have become part of the story.” Consider the magazine’s April 2nd cover featuring the resolute Parkland student survivors behind the word “ENOUGH” in bold sans-serif; the composite portrait of presidents Trump and Putin on July 30th’s cover, their faces morphed together; the four-cover Person of the Year double issue, featuring journalists who have been jailed or murdered; and the three-issue series illustrating the Oval Office in progressively stormier chaos, which won <em>Adweek</em>’s Cover of the Year award. Pine collaborates with a roster of talented creatives to achieve his vision—for those covers, he worked with photographer Peter Hapak, photographer Moises Saman, artist <a href=\\"https://www.artsy.net/artist/nancy-burson\\">Nancy Burson</a>, and illustrator Tim O’Brien, respectively.</p><p>“The current news cycle is so relentless, it is nearly impossible to keep up—this morning’s big story is stale by lunchtime,” Pomerantz explained. “Yet each week, D.W. masterminds a <em>Time</em> cover that makes sense of the chaos, turning complex topics into a visually arresting piece of art that not only informs, but also serves as a catalyst for further inquiry.”</p><p>Amplifying the impact of Pine’s <em>Time</em> covers is their ability to be consumed and shared in different forms online. Animated versions are disseminated on social media (in the aforementioned three-part series, Trump is pummeled with wind and rain until, finally, the Oval Office is flooded with water), and behind-the-scenes videos are posted for larger projects, such as the magazine’s <a href=\\"https://www.youtube.com/watch?v=kKDkUIoosfo\\">drone issue</a> on June 11th that utilized 958 Intel drones to form the image that eventually became the cover in the sky. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In the era of digital media, magazine covers rarely generate the amount of attention they garnered in decades past. Though 
+                <em>
+                  Time 
+                </em>
+                has a long history of delivering powerful news succinctly within its iconic red frame, D.W. Pine, the magazine’s creative director since 2010, has had the unique challenge of keeping the magazine’s cover relevant when most readers don’t buy print subscriptions.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Pine has risen to that challenge. As 
+                <em>
+                  Time
+                </em>
+                ’s director of multimedia, Katherine Pomerantz, has pointed out, his designs this year “have been so iconic that they too have become part of the story.” Consider the magazine’s April 2nd cover featuring the resolute Parkland student survivors behind the word “ENOUGH” in bold sans-serif; the composite portrait of presidents Trump and Putin on July 30th’s cover, their faces morphed together; the four-cover Person of the Year double issue, featuring journalists who have been jailed or murdered; and the three-issue series illustrating the Oval Office in progressively stormier chaos, which won 
+                <em>
+                  Adweek
+                </em>
+                ’s Cover of the Year award. Pine collaborates with a roster of talented creatives to achieve his vision—for those covers, he worked with photographer Peter Hapak, photographer Moises Saman, artist 
+                <a
+                  href="https://www.artsy.net/artist/nancy-burson"
+                >
+                  Nancy Burson
+                </a>
+                , and illustrator Tim O’Brien, respectively.
+              </div>
+              <div
+                className="paragraph"
+              >
+                “The current news cycle is so relentless, it is nearly impossible to keep up—this morning’s big story is stale by lunchtime,” Pomerantz explained. “Yet each week, D.W. masterminds a 
+                <em>
+                  Time
+                </em>
+                 cover that makes sense of the chaos, turning complex topics into a visually arresting piece of art that not only informs, but also serves as a catalyst for further inquiry.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                Amplifying the impact of Pine’s 
+                <em>
+                  Time
+                </em>
+                 covers is their ability to be consumed and shared in different forms online. Animated versions are disseminated on social media (in the aforementioned three-part series, Trump is pummeled with wind and rain until, finally, the Oval Office is flooded with water), and behind-the-scenes videos are posted for larger projects, such as the magazine’s 
+                <a
+                  href="https://www.youtube.com/watch?v=kKDkUIoosfo"
+                >
+                  drone issue
+                </a>
+                 on June 11th that utilized 958 Intel drones to form the image that eventually became the cover in the sky. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -10213,13 +11483,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Became the first black artistic director at Louis Vuitton. </blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Became the first black artistic director at Louis Vuitton. 
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -10361,13 +11629,75 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In 2002, Kanye West anointed then-22-year-old <a href=\\"https://www.artsy.net/artist/virgil-abloh\\">Virgil Abloh</a> as an arbiter of taste when the rapper hired him as a collaborator, eventually becoming his creative director. This year, <a href=\\"https://www.artsy.net/artist/louis-vuitton\\">Louis Vuitton</a> consecrated Abloh when the brand named him its new artistic director for menswear. He’s one of the few black men to helm a major luxury label, and the first at Louis Vuitton. His first collection for the brand debuted this past summer, featuring wallets with bright orange detailing, garments inspired by the <em>Wizard of Oz</em>, and sneakers with high, bright-white midsoles. In the intervening years, Abloh, who is also a music producer and DJ, has infiltrated the worlds of music, art, fashion, and sports with his multidisciplinary practice and ironic, laid-back style. </p><p>Abloh began his rise as a fashion icon in 2013, when the native Chicagoan established his label, Off-White. The brand, which also gained ubiquity this year, became famous for garments decorated with text in quotation marks. By printing “foam” on sneaker midsoles or “raincoat” on a <a href=\\"https://www.lyst.com/clothing/off-white-co-virgil-abloh-quote-raincoat-1/\\">raincoat</a>, Abloh reminds his fans not to take themselves, his designs, or fashion too seriously. This summer, he created a series of rugs for Ikea that read “keep off,” “blue,” and “wet grass” in bold lettering. It followed collaborations with companies that range from Champion to Sunglass Hut and Heron Preston to Levi’s. Earlier this year, Abloh and Nike united to create a wardrobe for Her Lady of Tennis, Serena Williams. </p><p>Given Abloh’s engagement with pop culture and the vernacular, a collaboration with artist <a href=\\"https://www.artsy.net/artist/takashi-murakami\\">Takashi Murakami</a> was a no-brainer. Earlier this year, <a href=\\"https://www.artsy.net/gagosian-gallery\\">Gagosian</a> gallery opened an Abloh–Murakami exhibition in Los Angeles, for which the pair created bright, symbol-laden canvases and neons (the gallery also hosted joint exhibitions in its London and Paris spaces, and works by the pair have been a regular feature at art fairs this fall). Next June, the <a href=\\"https://www.artsy.net/mcachicago\\">Museum of Contemporary Art, Chicago</a> will honor Abloh with a solo exhibition of his clothing, as well as collaborations with other artists, including <a href=\\"https://www.artsy.net/artist/tom-sachs\\">Tom Sachs</a> and <a href=\\"https://www.artsy.net/artist/peter-saville\\">Peter Saville</a>. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In 2002, Kanye West anointed then-22-year-old 
+                <a
+                  href="https://www.artsy.net/artist/virgil-abloh"
+                >
+                  Virgil Abloh
+                </a>
+                 as an arbiter of taste when the rapper hired him as a collaborator, eventually becoming his creative director. This year, 
+                <a
+                  href="https://www.artsy.net/artist/louis-vuitton"
+                >
+                  Louis Vuitton
+                </a>
+                 consecrated Abloh when the brand named him its new artistic director for menswear. He’s one of the few black men to helm a major luxury label, and the first at Louis Vuitton. His first collection for the brand debuted this past summer, featuring wallets with bright orange detailing, garments inspired by the 
+                <em>
+                  Wizard of Oz
+                </em>
+                , and sneakers with high, bright-white midsoles. In the intervening years, Abloh, who is also a music producer and DJ, has infiltrated the worlds of music, art, fashion, and sports with his multidisciplinary practice and ironic, laid-back style. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Abloh began his rise as a fashion icon in 2013, when the native Chicagoan established his label, Off-White. The brand, which also gained ubiquity this year, became famous for garments decorated with text in quotation marks. By printing “foam” on sneaker midsoles or “raincoat” on a 
+                <a
+                  href="https://www.lyst.com/clothing/off-white-co-virgil-abloh-quote-raincoat-1/"
+                >
+                  raincoat
+                </a>
+                , Abloh reminds his fans not to take themselves, his designs, or fashion too seriously. This summer, he created a series of rugs for Ikea that read “keep off,” “blue,” and “wet grass” in bold lettering. It followed collaborations with companies that range from Champion to Sunglass Hut and Heron Preston to Levi’s. Earlier this year, Abloh and Nike united to create a wardrobe for Her Lady of Tennis, Serena Williams. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Given Abloh’s engagement with pop culture and the vernacular, a collaboration with artist 
+                <a
+                  href="https://www.artsy.net/artist/takashi-murakami"
+                >
+                  Takashi Murakami
+                </a>
+                 was a no-brainer. Earlier this year, 
+                <a
+                  href="https://www.artsy.net/gagosian-gallery"
+                >
+                  Gagosian
+                </a>
+                 gallery opened an Abloh–Murakami exhibition in Los Angeles, for which the pair created bright, symbol-laden canvases and neons (the gallery also hosted joint exhibitions in its London and Paris spaces, and works by the pair have been a regular feature at art fairs this fall). Next June, the 
+                <a
+                  href="https://www.artsy.net/mcachicago"
+                >
+                  Museum of Contemporary Art, Chicago
+                </a>
+                 will honor Abloh with a solo exhibition of his clothing, as well as collaborations with other artists, including 
+                <a
+                  href="https://www.artsy.net/artist/tom-sachs"
+                >
+                  Tom Sachs
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/artist/peter-saville"
+                >
+                  Peter Saville
+                </a>
+                . 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -10526,13 +11856,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Designed the widely popular e-cigarette that achieved ubiquity in 2018.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Designed the widely popular e-cigarette that achieved ubiquity in 2018.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -10674,13 +12002,44 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>For an object that resembles an elongated USB drive, the Juul captured an outsize slice of America’s public attention this year. The electronic cigarette, which offers interchangeable nicotine “pods” in flavors ranging from mango to mint and arrives in Apple-esque minimalist white packaging, arrived on the market in 2015, and topped U.S. e-cigarette sales by the end of 2017. But this year, Juul became a cultural phenomenon.</p><p>Stanford business school graduates James Monsees and Adam Bowen initially conceived of the Juul during a series of smoking breaks circa 2003, and launched their brand over 10 years later with an upbeat campaign. Filled with bright hues, geometric shapes, and photogenic young people, their ads turned a previously unsexy object into a lifestyle necessity. But Juul’s rapid growth—particularly among underage teen users—has brought regulatory scrutiny. In April, Juul Labs’s marketing efforts were scrutinized by both the Food and Drug Administration and U.S. Congress, with one question at the center of their investigation: Did the company’s advertisements target minors?</p><p>Looking at the countless memes the Juul has spawned, it’s easy to understand why one might think so. Many exaggerate how crucial Juuls are to their owners: In one <a href=\\"https://i.redd.it/jexe5m6ea2d01.png\\">meme</a>, losing a Juul ranks as more traumatic than “failing an exam,” “getting rejected,” and “your dog dying.” In May, writer Jia Tolentino published a buzzy <a href=\\"https://www.newyorker.com/magazine/2018/05/14/the-promise-of-vaping-and-the-rise-of-juul\\">article</a> in <em>The New Yorker </em>that investigated the youth culture of Juuling (yes, the activity has become ubiquitous enough to become its own verb). It and other reports noted that high school students, in particular, are getting hooked on Juuls, personalizing them with stickers and smoking illicitly during class and bathroom breaks. </p><p>The company has maintained that its product is intended for adults who want to quit smoking cigarettes, not for underage or non-smokers. Nevertheless, it has already promised $30 million in smoking prevention efforts for the youth.In November, just after the FDA announced plans to enact explicit regulations against e-cigarette sales, Juul revealed that it would cease social media promotions and sales of flavored pods in brick-and-mortar locations, such as mango and cucumber (excluding tobacco, mint, and menthol). Though the Juul’s regulatory future may appear tenuous, its cultural status isn’t likely to decline any time soon. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                For an object that resembles an elongated USB drive, the Juul captured an outsize slice of America’s public attention this year. The electronic cigarette, which offers interchangeable nicotine “pods” in flavors ranging from mango to mint and arrives in Apple-esque minimalist white packaging, arrived on the market in 2015, and topped U.S. e-cigarette sales by the end of 2017. But this year, Juul became a cultural phenomenon.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Stanford business school graduates James Monsees and Adam Bowen initially conceived of the Juul during a series of smoking breaks circa 2003, and launched their brand over 10 years later with an upbeat campaign. Filled with bright hues, geometric shapes, and photogenic young people, their ads turned a previously unsexy object into a lifestyle necessity. But Juul’s rapid growth—particularly among underage teen users—has brought regulatory scrutiny. In April, Juul Labs’s marketing efforts were scrutinized by both the Food and Drug Administration and U.S. Congress, with one question at the center of their investigation: Did the company’s advertisements target minors?
+              </div>
+              <div
+                className="paragraph"
+              >
+                Looking at the countless memes the Juul has spawned, it’s easy to understand why one might think so. Many exaggerate how crucial Juuls are to their owners: In one 
+                <a
+                  href="https://i.redd.it/jexe5m6ea2d01.png"
+                >
+                  meme
+                </a>
+                , losing a Juul ranks as more traumatic than “failing an exam,” “getting rejected,” and “your dog dying.” In May, writer Jia Tolentino published a buzzy 
+                <a
+                  href="https://www.newyorker.com/magazine/2018/05/14/the-promise-of-vaping-and-the-rise-of-juul"
+                >
+                  article
+                </a>
+                 in 
+                <em>
+                  The New Yorker 
+                </em>
+                that investigated the youth culture of Juuling (yes, the activity has become ubiquitous enough to become its own verb). It and other reports noted that high school students, in particular, are getting hooked on Juuls, personalizing them with stickers and smoking illicitly during class and bathroom breaks. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The company has maintained that its product is intended for adults who want to quit smoking cigarettes, not for underage or non-smokers. Nevertheless, it has already promised $30 million in smoking prevention efforts for the youth.In November, just after the FDA announced plans to enact explicit regulations against e-cigarette sales, Juul revealed that it would cease social media promotions and sales of flavored pods in brick-and-mortar locations, such as mango and cucumber (excluding tobacco, mint, and menthol). Though the Juul’s regulatory future may appear tenuous, its cultural status isn’t likely to decline any time soon. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -10839,13 +12198,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Helping machines see, in both consumer applications and government surveillance. </blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Helping machines see, in both consumer applications and government surveillance. 
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -10873,13 +12230,38 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Three Chinese companies lead the race to perfect artificial intelligence image recognition: Megvii, Yitu, and SenseTime. But in 2018, SenseTime pulled ahead of the pack, raising $1.2 billion. (It was most recently valued at more than $4.5 billion, the most for any AI company.) Along with the wide range of consumer-facing products that the company’s tech enables, the Chinese government has significantly invested in its tech—which identifies images, objects, and people with startling accuracy—as it seeks novel methods to surveil and control its population.</p><p>SenseTime was launched in 2014 by Tang Xiaoou, a professor at the Chinese University of Hong Kong. In 2015, he appointed Xu Li, a Ph.D. candidate, as CEO of the research initiative–turned–company, igniting three straight years of 400 percent year-over-year growth. Now, SenseTime’s technologies power facial recognition–unlocking in many Chinese smartphone brands; Snapchat-like AR photo filters in the popular app SNOW; software that allows self-driving cars to “see” their surroundings; and real-time, customer-specific analytics for retailers, among many others. </p><p>Perhaps more notorious, however, are the surveillance implementations of SenseTime’s tech, as the Chinese government begins <a href=\\"https://www.independent.co.uk/news/world/asia/china-social-credit-system-flight-booking-blacklisted-beijing-points-a8646316.html\\">rolling out</a> its social credit system, with the aim of giving a holistic rating of an individual’s personal and business reputation—like the infamous “Nosedive” episode of <em>Black Mirror</em>. A growing number of local governments and security agencies, including those in Yunnan Province and the cities of Guangzhou and Shenzhen, use SenseTime software to automatically identify faces passing security cameras and track the movements of groups and cars like a virtual panopticon, among other things.</p><p>Significant concerns have been raised about how such a system could be used for nefarious purposes; facial recognition and other technologies are already being used to track and control the Muslim Uighur population in the Xinjiang region. However, Tang and Xu are outwardly determined to see their technologies be used for good, having teamed up this February with MIT to launch the MIT-SenseTime Alliance on Artificial Intelligence, with the aim of addressing pressing issues related to the rise of AI that will soon face our world.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Three Chinese companies lead the race to perfect artificial intelligence image recognition: Megvii, Yitu, and SenseTime. But in 2018, SenseTime pulled ahead of the pack, raising $1.2 billion. (It was most recently valued at more than $4.5 billion, the most for any AI company.) Along with the wide range of consumer-facing products that the company’s tech enables, the Chinese government has significantly invested in its tech—which identifies images, objects, and people with startling accuracy—as it seeks novel methods to surveil and control its population.
+              </div>
+              <div
+                className="paragraph"
+              >
+                SenseTime was launched in 2014 by Tang Xiaoou, a professor at the Chinese University of Hong Kong. In 2015, he appointed Xu Li, a Ph.D. candidate, as CEO of the research initiative–turned–company, igniting three straight years of 400 percent year-over-year growth. Now, SenseTime’s technologies power facial recognition–unlocking in many Chinese smartphone brands; Snapchat-like AR photo filters in the popular app SNOW; software that allows self-driving cars to “see” their surroundings; and real-time, customer-specific analytics for retailers, among many others. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Perhaps more notorious, however, are the surveillance implementations of SenseTime’s tech, as the Chinese government begins 
+                <a
+                  href="https://www.independent.co.uk/news/world/asia/china-social-credit-system-flight-booking-blacklisted-beijing-points-a8646316.html"
+                >
+                  rolling out
+                </a>
+                 its social credit system, with the aim of giving a holistic rating of an individual’s personal and business reputation—like the infamous “Nosedive” episode of 
+                <em>
+                  Black Mirror
+                </em>
+                . A growing number of local governments and security agencies, including those in Yunnan Province and the cities of Guangzhou and Shenzhen, use SenseTime software to automatically identify faces passing security cameras and track the movements of groups and cars like a virtual panopticon, among other things.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Significant concerns have been raised about how such a system could be used for nefarious purposes; facial recognition and other technologies are already being used to track and control the Muslim Uighur population in the Xinjiang region. However, Tang and Xu are outwardly determined to see their technologies be used for good, having teamed up this February with MIT to launch the MIT-SenseTime Alliance on Artificial Intelligence, with the aim of addressing pressing issues related to the rise of AI that will soon face our world.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -11038,13 +12420,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Set a new benchmark for representation in fashion.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Set a new benchmark for representation in fashion.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -11186,13 +12566,48 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>For designer Becca McCharen-Tran, inclusivity isn’t a trend or marketing ploy, it’s an ethos. Since 2010, before mass-market brands like Aerie began showcasing models of diverse ages, sizes, and abilities, Chromat, the swimwear line that McCharen-Tran founded, championed a radically inclusive approach to fashion.</p><p>This summer, Chromat’s “Pool Rules” ad campaign laid out McCharen-Tran’s fashion philosophy in a playful but serious way. Instead of listing typical pool rules, such as “No Diving,” the rules included injunctions such as “Food-Shaming Not Permitted,” “All Abilities Accepted,” and “Respect Preferred Pronouns.” Dressed as stylish lifeguards in Chromat’s bright, techy suits, the models—which include activist and amputee Mama Cax, breast cancer survivor Ericka Hart, and trans model Geena Rocero—lounge by the pool and stride shoulder-to-shoulder towards the camera, like a team of superheroes who’ve assembled to fight fashion’s narrow standards of beauty. During New York’s fall fashion week, Chromat sent an equally diverse group of models down the runway, including MMA fighter Mia Kang and art-world influencer Kimberly Drew.</p><p>On and off the runway, Chromat continues to set the standard for inclusivity in fashion, offering sizes from XS to 4XL. Perhaps it’s no surprise that McCharen-Tran, who was trained as an architect and has often favored non-traditional fabrics and silhouettes, approaches both business and craft from an uncommon perspective. Yet fashion, however slowly, seems to be following suit.</p><p>When Ed Razek, CMO of L Brands, the parent company of Victoria’s Secret, declared in a November <a href=\\"https://www.vogue.com/article/victorias-secret-ed-razek-monica-mitro-interview\\">interview</a> with <em>Vogue</em> that he didn’t think trans women should appear in the televised Victoria’s Secret fashion show, he came across as profoundly out of touch. In an <a href=\\"https://www.out.com/news-opinion/2018/11/12/victorias-secret-empire-built-women-hating-themselves\\">essay</a> written for <em>Out</em>, McCharen-Tran countered Razek’s remarks, refuting the male gaze in the design and marketing of lingerie. “Chromat has always designed for a wide range of sizes…and for all different bodies, ages, abilities and places on the gender spectrum,” she wrote. “As a queer woman, I do not focus on designing clothes to make the wearer more appealing to men.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                For designer Becca McCharen-Tran, inclusivity isn’t a trend or marketing ploy, it’s an ethos. Since 2010, before mass-market brands like Aerie began showcasing models of diverse ages, sizes, and abilities, Chromat, the swimwear line that McCharen-Tran founded, championed a radically inclusive approach to fashion.
+              </div>
+              <div
+                className="paragraph"
+              >
+                This summer, Chromat’s “Pool Rules” ad campaign laid out McCharen-Tran’s fashion philosophy in a playful but serious way. Instead of listing typical pool rules, such as “No Diving,” the rules included injunctions such as “Food-Shaming Not Permitted,” “All Abilities Accepted,” and “Respect Preferred Pronouns.” Dressed as stylish lifeguards in Chromat’s bright, techy suits, the models—which include activist and amputee Mama Cax, breast cancer survivor Ericka Hart, and trans model Geena Rocero—lounge by the pool and stride shoulder-to-shoulder towards the camera, like a team of superheroes who’ve assembled to fight fashion’s narrow standards of beauty. During New York’s fall fashion week, Chromat sent an equally diverse group of models down the runway, including MMA fighter Mia Kang and art-world influencer Kimberly Drew.
+              </div>
+              <div
+                className="paragraph"
+              >
+                On and off the runway, Chromat continues to set the standard for inclusivity in fashion, offering sizes from XS to 4XL. Perhaps it’s no surprise that McCharen-Tran, who was trained as an architect and has often favored non-traditional fabrics and silhouettes, approaches both business and craft from an uncommon perspective. Yet fashion, however slowly, seems to be following suit.
+              </div>
+              <div
+                className="paragraph"
+              >
+                When Ed Razek, CMO of L Brands, the parent company of Victoria’s Secret, declared in a November 
+                <a
+                  href="https://www.vogue.com/article/victorias-secret-ed-razek-monica-mitro-interview"
+                >
+                  interview
+                </a>
+                 with 
+                <em>
+                  Vogue
+                </em>
+                 that he didn’t think trans women should appear in the televised Victoria’s Secret fashion show, he came across as profoundly out of touch. In an 
+                <a
+                  href="https://www.out.com/news-opinion/2018/11/12/victorias-secret-empire-built-women-hating-themselves"
+                >
+                  essay
+                </a>
+                 written for 
+                <em>
+                  Out
+                </em>
+                , McCharen-Tran countered Razek’s remarks, refuting the male gaze in the design and marketing of lingerie. “Chromat has always designed for a wide range of sizes…and for all different bodies, ages, abilities and places on the gender spectrum,” she wrote. “As a queer woman, I do not focus on designing clothes to make the wearer more appealing to men.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -11351,13 +12766,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Represented female empowerment for the #MeToo era.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Represented female empowerment for the #MeToo era.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -11385,13 +12798,81 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In late September, after Dr. Christine Blasey Ford testified before the U.S. Senate Judiciary Committee that then–Supreme Court nominee Judge Brett Kavanaugh had assaulted her as a young woman, the 17th-century paintings of <a href=\\"https://www.artsy.net/artist/artemisia-gentileschi\\">Artemisia Gentileschi</a> began to circulate through Twitter and Instagram. Supporters of Dr. Ford showed their compassion and fury through disseminating the <a href=\\"https://www.artsy.net/gene/baroque\\">Baroque</a> artist’s fierce <em>Judith Slaying Holofernes—</em>two paintings, both from around 1614–20, that have been read as depictions of Gentileschi herself avenging her rapist. (Gentileschi was raped at age 17 by her teacher, artist Agostino Tassi, who was convicted and exiled from Rome, but his sentence was never enforced.)</p><p>The Italian painter’s renewed relevance has been steady throughout 2018, penetrating popular culture and the art world. Her striking portraiture and depictions of biblical heroines have surfaced as emblems of female empowerment, resonating loudly in the #MeToo era. It’s a fitting resurgence as the artist was a trailblazing woman in her own day: Gentileschi was the first woman to attend Florence’s Accademia delle Arti del Disegno and the only female follower of <a href=\\"https://www.artsy.net/artist/michelangelo-merisi-da-caravaggio\\">Caravaggio</a>; she even earned commissions from such notable patrons as the Medicis and King Charles I of England.</p><p>“Artemisia Gentileschi’s reputation developed first as a victim of sexual assault and then as one of the most interesting painters of the early 17th century,” noted Judith W. Mann, a curator of European art at the <a href=\\"https://www.artsy.net/stlartmuseum\\">Saint Louis Art Museum</a> and the editor of a 2005 collection of essays on the artist. “Her best works are powerful reminders of the power of women, making her a perfect emblem for these times.”</p><p>As interest in the long under-recognized artist has grown, so too has her <a href=\\"https://www.artsy.net/article/artsy-editorial-artemisia-gentileschis-market-gains-steam-collectors-catch-art-historians\\">market</a>. In July, London’s <a href=\\"https://www.artsy.net/the-national-gallery-london\\">National Gallery</a> acquired Gentileschi’s <em>Self Portrait as Saint Catherine of Alexandria</em> (ca. 1615–17)—the museum’s first acquisition of a work by a female artist in 27 years. And this fall, her <em>Lucretia</em> (ca. 1630–45) sold at the Dorotheum auction house in Vienna for €1.8 million ($2.1 million), more than twice its presale estimate. </p><p>Though Gentileschi’s art has long been inseparable from her sexual assault, the present moment tells us that can change—that her legacy will be tied to her esteem as an artist, and as a force to be reckoned with.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In late September, after Dr. Christine Blasey Ford testified before the U.S. Senate Judiciary Committee that then–Supreme Court nominee Judge Brett Kavanaugh had assaulted her as a young woman, the 17th-century paintings of 
+                <a
+                  href="https://www.artsy.net/artist/artemisia-gentileschi"
+                >
+                  Artemisia Gentileschi
+                </a>
+                 began to circulate through Twitter and Instagram. Supporters of Dr. Ford showed their compassion and fury through disseminating the 
+                <a
+                  href="https://www.artsy.net/gene/baroque"
+                >
+                  Baroque
+                </a>
+                 artist’s fierce 
+                <em>
+                  Judith Slaying Holofernes—
+                </em>
+                two paintings, both from around 1614–20, that have been read as depictions of Gentileschi herself avenging her rapist. (Gentileschi was raped at age 17 by her teacher, artist Agostino Tassi, who was convicted and exiled from Rome, but his sentence was never enforced.)
+              </div>
+              <div
+                className="paragraph"
+              >
+                The Italian painter’s renewed relevance has been steady throughout 2018, penetrating popular culture and the art world. Her striking portraiture and depictions of biblical heroines have surfaced as emblems of female empowerment, resonating loudly in the #MeToo era. It’s a fitting resurgence as the artist was a trailblazing woman in her own day: Gentileschi was the first woman to attend Florence’s Accademia delle Arti del Disegno and the only female follower of 
+                <a
+                  href="https://www.artsy.net/artist/michelangelo-merisi-da-caravaggio"
+                >
+                  Caravaggio
+                </a>
+                ; she even earned commissions from such notable patrons as the Medicis and King Charles I of England.
+              </div>
+              <div
+                className="paragraph"
+              >
+                “Artemisia Gentileschi’s reputation developed first as a victim of sexual assault and then as one of the most interesting painters of the early 17th century,” noted Judith W. Mann, a curator of European art at the 
+                <a
+                  href="https://www.artsy.net/stlartmuseum"
+                >
+                  Saint Louis Art Museum
+                </a>
+                 and the editor of a 2005 collection of essays on the artist. “Her best works are powerful reminders of the power of women, making her a perfect emblem for these times.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                As interest in the long under-recognized artist has grown, so too has her 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-artemisia-gentileschis-market-gains-steam-collectors-catch-art-historians"
+                >
+                  market
+                </a>
+                . In July, London’s 
+                <a
+                  href="https://www.artsy.net/the-national-gallery-london"
+                >
+                  National Gallery
+                </a>
+                 acquired Gentileschi’s 
+                <em>
+                  Self Portrait as Saint Catherine of Alexandria
+                </em>
+                 (ca. 1615–17)—the museum’s first acquisition of a work by a female artist in 27 years. And this fall, her 
+                <em>
+                  Lucretia
+                </em>
+                 (ca. 1630–45) sold at the Dorotheum auction house in Vienna for €1.8 million ($2.1 million), more than twice its presale estimate. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Though Gentileschi’s art has long been inseparable from her sexual assault, the present moment tells us that can change—that her legacy will be tied to her esteem as an artist, and as a force to be reckoned with.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -11550,13 +13031,15 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Became the first black photographer to shoot the cover of <em>Vogue</em>.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Became the first black photographer to shoot the cover of 
+                <em>
+                  Vogue
+                </em>
+                .
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -11698,13 +13181,74 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Sharing the spotlight with Beyoncé is no easy feat, but when <em>Vogue</em>’s September cover was revealed in August, 23-year-old <a href=\\"https://www.artsy.net/artist/tyler-mitchell\\">Tyler Mitchell</a> found himself doing just that. Overnight, Mitchell went from an emerging photographer (<em>Artsy</em> featured him in <a href=\\"https://www.artsy.net/series/artsy-vanguard\\">The Artsy Vanguard</a>, our annual survey of artists to watch, in May) to the first black photographer to shoot a <em>Vogue</em> cover in the magazine’s 126-year history, capturing Queen Bey herself in a supremely honest and raw light. </p><p>In one of his images of Beyoncé (which would become one of two covers), she sits against a draped sheet in the light of the golden hour, wearing a white ruffled dress, a cornucopia of flowers framing her face. She shifts between roles in the series, evoking a matriarch in front of a clothesline and a sun deity draped in gold. Artist and curator <a href=\\"https://www.artsy.net/artist/deborah-willis\\">Deborah Willis</a>, who taught Mitchell at NYU, noted that the series nods to artists and models of 19th-century Parisian salons, but also “introduces a captivating narrative about beauty and desire.” Willis has been a champion of Mitchell’s, noting that she recognized early “how deeply Tyler was committed to changing existing visual narratives about being black, creative, and young.” </p><p>Mitchell’s other work in 2018 included fashion editorials for <em>More or Less Magazine</em> in May and <em>Document Journal</em>’s fall/winter issue. Earlier in the year, Mitchell had a much different assignment for <em>Teen Vogue</em>: taking portraits and video of nine young activists for gun reform, including students Emma González, Sarah Chadwick, Jaclyn Corin, and Nick Joseph, who had survived the Marjory Stoneman Douglas High School shooting that garnered national attention in February. In Mitchell’s portraits and video, the students’ determination and vivacity is amplified—these are the young adults who will effect change in policy. </p><p>Mitchell was born into the same generation—one that is resolved to uproot the status quo. “There was a ladder for the people who came before me, and there’s a ladder now—it’s just a new ladder,” Mitchell told <em>Vogue</em> in a behind-the-scenes interview about the Beyoncé shoot. “I want to open the eyes of the kids younger than me; show them that they can do this, too.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Sharing the spotlight with Beyoncé is no easy feat, but when 
+                <em>
+                  Vogue
+                </em>
+                ’s September cover was revealed in August, 23-year-old 
+                <a
+                  href="https://www.artsy.net/artist/tyler-mitchell"
+                >
+                  Tyler Mitchell
+                </a>
+                 found himself doing just that. Overnight, Mitchell went from an emerging photographer (
+                <em>
+                  Artsy
+                </em>
+                 featured him in 
+                <a
+                  href="https://www.artsy.net/series/artsy-vanguard"
+                >
+                  The Artsy Vanguard
+                </a>
+                , our annual survey of artists to watch, in May) to the first black photographer to shoot a 
+                <em>
+                  Vogue
+                </em>
+                 cover in the magazine’s 126-year history, capturing Queen Bey herself in a supremely honest and raw light. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                In one of his images of Beyoncé (which would become one of two covers), she sits against a draped sheet in the light of the golden hour, wearing a white ruffled dress, a cornucopia of flowers framing her face. She shifts between roles in the series, evoking a matriarch in front of a clothesline and a sun deity draped in gold. Artist and curator 
+                <a
+                  href="https://www.artsy.net/artist/deborah-willis"
+                >
+                  Deborah Willis
+                </a>
+                , who taught Mitchell at NYU, noted that the series nods to artists and models of 19th-century Parisian salons, but also “introduces a captivating narrative about beauty and desire.” Willis has been a champion of Mitchell’s, noting that she recognized early “how deeply Tyler was committed to changing existing visual narratives about being black, creative, and young.” 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Mitchell’s other work in 2018 included fashion editorials for 
+                <em>
+                  More or Less Magazine
+                </em>
+                 in May and 
+                <em>
+                  Document Journal
+                </em>
+                ’s fall/winter issue. Earlier in the year, Mitchell had a much different assignment for 
+                <em>
+                  Teen Vogue
+                </em>
+                : taking portraits and video of nine young activists for gun reform, including students Emma González, Sarah Chadwick, Jaclyn Corin, and Nick Joseph, who had survived the Marjory Stoneman Douglas High School shooting that garnered national attention in February. In Mitchell’s portraits and video, the students’ determination and vivacity is amplified—these are the young adults who will effect change in policy. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Mitchell was born into the same generation—one that is resolved to uproot the status quo. “There was a ladder for the people who came before me, and there’s a ladder now—it’s just a new ladder,” Mitchell told 
+                <em>
+                  Vogue
+                </em>
+                 in a behind-the-scenes interview about the Beyoncé shoot. “I want to open the eyes of the kids younger than me; show them that they can do this, too.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -11863,13 +13407,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Lent his likeness and activist message to the iconic “Just Do It” ad campaign.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Lent his likeness and activist message to the iconic “Just Do It” ad campaign.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -11900,13 +13442,45 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>When does a man become an icon? Possibly when he files for a copyright of his own profile. In October, Colin Kaepernick, whose name became synonymous with NFL players kneeling during the national anthem as a protest against police violence, filed to trademark a black-and-white image of his face and hair. According to the filing, the image could be used for commercial products, TV and film production, and for providing workshops in self-empowerment and how to safely interact with law enforcement.</p><p>A month prior, the former quarterback became the latest in a 30-year history of inspirational athletes who have lent their likenesses to Nike’s iconic “Just Do It” ad campaign. The ad shows a tightly cropped black-and-white portrait of Kaepernick, lips pressed together and eyes meeting the camera with a determined gaze. “Believe in something,” the ad copy reads. “Even if it means sacrificing everything.”</p><p>In the days that followed, the ad became a flashpoint for Twitter outrage (where some of Kaepernick’s critics recorded themselves setting their own Nikes on fire), and its format became a popular meme, often with a political bent. “Believe in something. Even if you just made it up,” one meme-maker <a href=\\"https://me.me/i/believe-in-something-even-if-you-just-made-it-up-960d33e1fd3d487d815ba64b212bbc37\\">inscribed</a> across a frowning photograph of the 45th president’s face.</p><p><a href=\\"https://www.thenation.com/article/on-colin-kaepernicks-nike-ad-will-the-revolution-be-branded/\\">Some</a> questioned the ultimate value of a corporate giant co-opting a social movement, and whether Nike’s progressivism was merely a strategy to engage the younger consumers who make up the majority of the brand’s customer base. Critics also pointed to the company’s own policies and labor practices, which they suggested were at odds with the ad’s progressive positioning. One <a href=\\"https://imgur.com/7x3qydX\\">meme</a> memorably added the campaign’s inspirational copy to a photograph of a woman working in a Nike factory. “Just do it,” read the tagline, “for $0.23 per hour.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                When does a man become an icon? Possibly when he files for a copyright of his own profile. In October, Colin Kaepernick, whose name became synonymous with NFL players kneeling during the national anthem as a protest against police violence, filed to trademark a black-and-white image of his face and hair. According to the filing, the image could be used for commercial products, TV and film production, and for providing workshops in self-empowerment and how to safely interact with law enforcement.
+              </div>
+              <div
+                className="paragraph"
+              >
+                A month prior, the former quarterback became the latest in a 30-year history of inspirational athletes who have lent their likenesses to Nike’s iconic “Just Do It” ad campaign. The ad shows a tightly cropped black-and-white portrait of Kaepernick, lips pressed together and eyes meeting the camera with a determined gaze. “Believe in something,” the ad copy reads. “Even if it means sacrificing everything.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                In the days that followed, the ad became a flashpoint for Twitter outrage (where some of Kaepernick’s critics recorded themselves setting their own Nikes on fire), and its format became a popular meme, often with a political bent. “Believe in something. Even if you just made it up,” one meme-maker 
+                <a
+                  href="https://me.me/i/believe-in-something-even-if-you-just-made-it-up-960d33e1fd3d487d815ba64b212bbc37"
+                >
+                  inscribed
+                </a>
+                 across a frowning photograph of the 45th president’s face.
+              </div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.thenation.com/article/on-colin-kaepernicks-nike-ad-will-the-revolution-be-branded/"
+                >
+                  Some
+                </a>
+                 questioned the ultimate value of a corporate giant co-opting a social movement, and whether Nike’s progressivism was merely a strategy to engage the younger consumers who make up the majority of the brand’s customer base. Critics also pointed to the company’s own policies and labor practices, which they suggested were at odds with the ad’s progressive positioning. One 
+                <a
+                  href="https://imgur.com/7x3qydX"
+                >
+                  meme
+                </a>
+                 memorably added the campaign’s inspirational copy to a photograph of a woman working in a Nike factory. “Just do it,” read the tagline, “for $0.23 per hour.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -12065,13 +13639,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Proved that age, gender, and flash need not dictate the future of architecture. </blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Proved that age, gender, and flash need not dictate the future of architecture. 
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -12213,13 +13785,53 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>This year, at 39 years old, <a href=\\"https://www.artsy.net/artist/frida-escobedo\\">Frida Escobedo</a> became the youngest architect to ever design the prestigious Serpentine Pavilion in London. The annual commission to design a temporary structure that sits beside the <a href=\\"https://www.artsy.net/serpentineuk\\">Serpentine Galleries</a> in Kensington Gardens has been bestowed upon legends like <a href=\\"https://www.artsy.net/artist/frank-gehry\\">Frank Gehry</a>, <a href=\\"https://www.artsy.net/artist/jean-nouvel\\">Jean Nouvel</a>, Peter Zumthor, and <a href=\\"https://www.artsy.net/artist/zaha-hadid\\">Zaha Hadid</a>. Of the 18 pavilions created since 2000, this was only the second to be designed solely by a woman (Hadid being the first). But Escobedo’s work stands in elegant contrast to the flash and bang of starchitecture. </p><p>With her Mexico City–based firm and expertise in both architecture and public art, Escobedo has made her name through thoughtful designs for esteemed cultural centers like the art space La Tallera in Cuernavaca, Mexico, and a renovation of the Octavio Paz Library in Guadalajara. She has consistently exhibited a reverence for everyday materials, as well as a flair for respecting both local and global sensibilities. Her Serpentine Pavilion, a meditative structure, was made up of straightforward building materials: simple grey roof tiles, like those typical of British houses. The humble cement rectangles were stacked to form walls that allowed sunlight to filter through their perforations, and were situated around a central courtyard—a key feature of domestic architecture in Escobedo’s native Mexico. The tranquil interior featured a triangular pool, which reflected light brilliantly against the mirrored finish of a curved steel roof. </p><p>Serpentine Galleries CEO Yana Peel described the structure as “an exquisite intimate public space in the park—a mix of communion and quiet contemplation,” which felt “both local and placeless,” she said. “Frida has said that her buildings are never finished, and this summer, we witnessed the power of performance, discussion, and visitors in their hundreds of thousands complete what she had started.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                This year, at 39 years old, 
+                <a
+                  href="https://www.artsy.net/artist/frida-escobedo"
+                >
+                  Frida Escobedo
+                </a>
+                 became the youngest architect to ever design the prestigious Serpentine Pavilion in London. The annual commission to design a temporary structure that sits beside the 
+                <a
+                  href="https://www.artsy.net/serpentineuk"
+                >
+                  Serpentine Galleries
+                </a>
+                 in Kensington Gardens has been bestowed upon legends like 
+                <a
+                  href="https://www.artsy.net/artist/frank-gehry"
+                >
+                  Frank Gehry
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/jean-nouvel"
+                >
+                  Jean Nouvel
+                </a>
+                , Peter Zumthor, and 
+                <a
+                  href="https://www.artsy.net/artist/zaha-hadid"
+                >
+                  Zaha Hadid
+                </a>
+                . Of the 18 pavilions created since 2000, this was only the second to be designed solely by a woman (Hadid being the first). But Escobedo’s work stands in elegant contrast to the flash and bang of starchitecture. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                With her Mexico City–based firm and expertise in both architecture and public art, Escobedo has made her name through thoughtful designs for esteemed cultural centers like the art space La Tallera in Cuernavaca, Mexico, and a renovation of the Octavio Paz Library in Guadalajara. She has consistently exhibited a reverence for everyday materials, as well as a flair for respecting both local and global sensibilities. Her Serpentine Pavilion, a meditative structure, was made up of straightforward building materials: simple grey roof tiles, like those typical of British houses. The humble cement rectangles were stacked to form walls that allowed sunlight to filter through their perforations, and were situated around a central courtyard—a key feature of domestic architecture in Escobedo’s native Mexico. The tranquil interior featured a triangular pool, which reflected light brilliantly against the mirrored finish of a curved steel roof. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Serpentine Galleries CEO Yana Peel described the structure as “an exquisite intimate public space in the park—a mix of communion and quiet contemplation,” which felt “both local and placeless,” she said. “Frida has said that her buildings are never finished, and this summer, we witnessed the power of performance, discussion, and visitors in their hundreds of thousands complete what she had started.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -12378,13 +13990,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Designed the flag that has become a calling card against Brexit and Euroscepticism.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Designed the flag that has become a calling card against Brexit and Euroscepticism.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -12415,13 +14025,23 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>During October’s People’s Vote march in London, nearly 700,000 people took to the streets to demand a second vote on Brexit. The massive crowds, which gridlocked parts of the city, was a sea of blue with points of yellow stars. The EU flag was waved in the air, draped around shoulders, and printed onto T-shirts, protest signs, and banners. Like the pink pussy hat at the 2017 Women’s March, it was the single visual that most clearly unified the crowd.</p><p>“Against the blue sky of the Western world, the stars represent the peoples of Europe in a circle, a symbol of unity,” wrote the Council of Europe when adopting EU flag as its symbol in 1955. (The thorny phrase “Western world” was later removed.) “Their number shall be invariably set at twelve, the symbol of completeness and perfection.” The flag’s design was the result of the combined efforts of Arsène Heitz, an employee of the Council’s postal service, and Paul M. G. Lévy, the Council’s director of press and information services at the time. </p><p>The EU flag’s continued power lies in its inclusivity. While most flags represent a distinct national identity, the EU flag is a symbol of cooperation between nations. Unlike the American flag’s stars and stripes, the EU’s 12 stars do not signify particular governments (the number of countries in the EU is currently 28), but rather a more abstract notion of unity—a dozen smaller shapes aligning to form a perfectly balanced circle. The flag’s graphic strength has made it both a powerful rallying point and a catnip for streetwear designers. Following the Brexit vote in 2016, the art merch shop König Souvenir, a collaboration of Berlin gallerist Johann König and streetwear brand Souvenir, released the EUNify hoodie, a sweatshirt upon which the flag’s circle of stars is rendered with one star missing—its absence upsetting the balance of the design’s powerful symmetry.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                During October’s People’s Vote march in London, nearly 700,000 people took to the streets to demand a second vote on Brexit. The massive crowds, which gridlocked parts of the city, was a sea of blue with points of yellow stars. The EU flag was waved in the air, draped around shoulders, and printed onto T-shirts, protest signs, and banners. Like the pink pussy hat at the 2017 Women’s March, it was the single visual that most clearly unified the crowd.
+              </div>
+              <div
+                className="paragraph"
+              >
+                “Against the blue sky of the Western world, the stars represent the peoples of Europe in a circle, a symbol of unity,” wrote the Council of Europe when adopting EU flag as its symbol in 1955. (The thorny phrase “Western world” was later removed.) “Their number shall be invariably set at twelve, the symbol of completeness and perfection.” The flag’s design was the result of the combined efforts of Arsène Heitz, an employee of the Council’s postal service, and Paul M. G. Lévy, the Council’s director of press and information services at the time. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The EU flag’s continued power lies in its inclusivity. While most flags represent a distinct national identity, the EU flag is a symbol of cooperation between nations. Unlike the American flag’s stars and stripes, the EU’s 12 stars do not signify particular governments (the number of countries in the EU is currently 28), but rather a more abstract notion of unity—a dozen smaller shapes aligning to form a perfectly balanced circle. The flag’s graphic strength has made it both a powerful rallying point and a catnip for streetwear designers. Following the Brexit vote in 2016, the art merch shop König Souvenir, a collaboration of Berlin gallerist Johann König and streetwear brand Souvenir, released the EUNify hoodie, a sweatshirt upon which the flag’s circle of stars is rendered with one star missing—its absence upsetting the balance of the design’s powerful symmetry.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -12580,13 +14200,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Self-destructed an artwork, hijacking the global news cycle. </blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Self-destructed an artwork, hijacking the global news cycle. 
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -12731,13 +14349,91 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><a href=\\"https://www.artsy.net/artist/banksy\\">Banksy</a> is an anomaly: undoubtedly the world’s most-famous street artist, despite the fact that no one is quite sure who he is. And despite the anti-establishment spirit of Banksy’s favored motifs—kissing cops, giant rats, and protestors tossing Molotov cocktails of flowers—art collectors have continuously shown rabid interest in his work. In October, a small-scale version of his 2006 mural <em>Girl with Balloon</em>, which last year was voted the U.K.’s “<a href=\\"https://www.theguardian.com/artanddesign/2017/jul/26/banksy-balloon-girl-hay-wain-favourite-uk-work-of-art-constable-poll-nation\\">best-loved work of art</a>,” sold at Sotheby’s for $1.3 million.</p><p>But as soon as the auctioneer’s hammer fell, something very odd happened. Banksy had rigged the frame of <em>Girl with Balloon</em> with a remotely triggered device that caused the work to pass through it like a paper shredder, slowly being cut into ribbons. The shredder stopped midway through the process, in what the artist <a href=\\"https://www.artsy.net/news/artsy-editorial-banksy-revealed-malfunctioning-shredder-stopped-painting-completely-destroyed\\">said</a> was a technical error. </p><p>Audiences at Sotheby’s and around the world were alternately stunned and bemused as the story jumped to the top of several major news outlets’ most-read sections. The auction house’s European head of contemporary art, Alex Branczik, quashed rumors that Sotheby’s had advance knowledge of what was to come: “We got Banksy’d,” he <a href=\\"https://www.artsy.net/news/artsy-editorial-artwork-banksy-shredded-selling-13-million-sothebys\\">said</a>.</p><p>Rather than an actual act of self-vandalism, the shredding of <em>Girl with Balloon</em> was recast as a creative act, with Banksy <a href=\\"https://www.artsy.net/news/artsy-editorial-banksy-proclaims-shredded-canvas-new-work-dubbed-love-bin\\">positioning</a> the damaged piece as an entirely new work, which he dubbed <em>Love is in the Bin</em> (2018). And Banksy’s own sales market seems to have gotten an <a href=\\"https://www.artsy.net/article/artsy-editorial-banksy-market-accelerates-shredding-stunt\\">injection of enthusiasm</a>, with an exhibition by Phillips auction house in Hong Kong and an ongoing, <a href=\\"https://www.theglobeandmail.com/arts/art-and-architecture/article-unauthorized-banksy-show-strips-street-art-of-its-power-while-cashing/\\">somewhat controversial</a> touring show, “The Art of Banksy,” which landed in Miami just in time for Art Basel in Miami Beach. Meanwhile, the shredding itself became a popular meme, swiftly <a href=\\"https://www.artsy.net/news/artsy-editorial-mcdonalds-perrier-brands-appropriated-banksys-shredded-painting-ads\\">co-opted</a> for ad campaigns by the likes of McDonald’s and Perrier.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <a
+                  href="https://www.artsy.net/artist/banksy"
+                >
+                  Banksy
+                </a>
+                 is an anomaly: undoubtedly the world’s most-famous street artist, despite the fact that no one is quite sure who he is. And despite the anti-establishment spirit of Banksy’s favored motifs—kissing cops, giant rats, and protestors tossing Molotov cocktails of flowers—art collectors have continuously shown rabid interest in his work. In October, a small-scale version of his 2006 mural 
+                <em>
+                  Girl with Balloon
+                </em>
+                , which last year was voted the U.K.’s “
+                <a
+                  href="https://www.theguardian.com/artanddesign/2017/jul/26/banksy-balloon-girl-hay-wain-favourite-uk-work-of-art-constable-poll-nation"
+                >
+                  best-loved work of art
+                </a>
+                ,” sold at Sotheby’s for $1.3 million.
+              </div>
+              <div
+                className="paragraph"
+              >
+                But as soon as the auctioneer’s hammer fell, something very odd happened. Banksy had rigged the frame of 
+                <em>
+                  Girl with Balloon
+                </em>
+                 with a remotely triggered device that caused the work to pass through it like a paper shredder, slowly being cut into ribbons. The shredder stopped midway through the process, in what the artist 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-banksy-revealed-malfunctioning-shredder-stopped-painting-completely-destroyed"
+                >
+                  said
+                </a>
+                 was a technical error. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Audiences at Sotheby’s and around the world were alternately stunned and bemused as the story jumped to the top of several major news outlets’ most-read sections. The auction house’s European head of contemporary art, Alex Branczik, quashed rumors that Sotheby’s had advance knowledge of what was to come: “We got Banksy’d,” he 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-artwork-banksy-shredded-selling-13-million-sothebys"
+                >
+                  said
+                </a>
+                .
+              </div>
+              <div
+                className="paragraph"
+              >
+                Rather than an actual act of self-vandalism, the shredding of 
+                <em>
+                  Girl with Balloon
+                </em>
+                 was recast as a creative act, with Banksy 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-banksy-proclaims-shredded-canvas-new-work-dubbed-love-bin"
+                >
+                  positioning
+                </a>
+                 the damaged piece as an entirely new work, which he dubbed 
+                <em>
+                  Love is in the Bin
+                </em>
+                 (2018). And Banksy’s own sales market seems to have gotten an 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-banksy-market-accelerates-shredding-stunt"
+                >
+                  injection of enthusiasm
+                </a>
+                , with an exhibition by Phillips auction house in Hong Kong and an ongoing, 
+                <a
+                  href="https://www.theglobeandmail.com/arts/art-and-architecture/article-unauthorized-banksy-show-strips-street-art-of-its-power-while-cashing/"
+                >
+                  somewhat controversial
+                </a>
+                 touring show, “The Art of Banksy,” which landed in Miami just in time for Art Basel in Miami Beach. Meanwhile, the shredding itself became a popular meme, swiftly 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-mcdonalds-perrier-brands-appropriated-banksys-shredded-painting-ads"
+                >
+                  co-opted
+                </a>
+                 for ad campaigns by the likes of McDonald’s and Perrier.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -12896,13 +14592,15 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Illustrated <em>National Geographic</em>’s critical special issue on race.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Illustrated 
+                <em>
+                  National Geographic
+                </em>
+                ’s critical special issue on race.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -13044,13 +14742,55 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>This year, New Zealand–born photographer <a href=\\"https://www.artsy.net/artist/robin-hammond\\">Robin Hammond</a> was assigned the groundbreaking April cover story of <em>National Geographic</em>’s Race Issue. It was an especially important edition, as the editor-in-chief, Susan Goldberg, apologized for the 130-year-old publication’s past coverage, which often promoted stereotypes of marginalized people. </p><p>The Race Issue also had a declaration—that race has no scientific basis. Skin color “is not a binary trait,” as geneticist Alicia Martin is quoted in the cover story. “The 21st-century understanding of human genetics tells us that the whole idea of race is a human invention,” writer Patricia Edmond concludes.</p><p>Shooting the historic issue fit neatly into Hammond’s larger career, which has been marked by his dedication to social issues. He spent much of this year photographing for the ongoing campaign <a href=\\"https://www.instagram.com/whereloveisillegal\\">Where Love is Illegal</a>, launched in 2015 by his own nonprofit, <a href=\\"https://witnesschange.org/\\">Witness Change</a>. The campaign features photographs and testimonies of LGBTQI+ people in countries where they are oppressed; many of the subjects are pictured hiding their faces. </p><p>For The Race Issue, Hammond photographed two powerful stories. For the cover, he featured British fraternal twins Marcia and Millie Biggs, who do not share the same skin tone: Millie is black, and Marcia is white. Likewise, his second shoot, documenting the incredible diversity of various distinct communities in Africa, reinforced the idea that race is not a biological dividing line. In fact, as the writer, Elizabeth Kolbert, stresses, among humans, “the deepest splits” aren’t between people who are black, white, Asian, or Native American. They’re within African populations, “who spent tens of thousands of years separated from one another even before humans left Africa,” she writes. </p><p>Hammond’s images of African people of all ages are stripped-down, classical portraits taken against a white backdrop, with soft lighting. Unlike the magazine’s older coverage, which Goldberg acknowledged “pictured ‘natives’ elsewhere as exotics, famously and frequently unclothed, happy hunters, noble savages—every type of cliché,” Hammond focuses on their beauty and individuality, letting their features shine.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                This year, New Zealand–born photographer 
+                <a
+                  href="https://www.artsy.net/artist/robin-hammond"
+                >
+                  Robin Hammond
+                </a>
+                 was assigned the groundbreaking April cover story of 
+                <em>
+                  National Geographic
+                </em>
+                ’s Race Issue. It was an especially important edition, as the editor-in-chief, Susan Goldberg, apologized for the 130-year-old publication’s past coverage, which often promoted stereotypes of marginalized people. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The Race Issue also had a declaration—that race has no scientific basis. Skin color “is not a binary trait,” as geneticist Alicia Martin is quoted in the cover story. “The 21st-century understanding of human genetics tells us that the whole idea of race is a human invention,” writer Patricia Edmond concludes.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Shooting the historic issue fit neatly into Hammond’s larger career, which has been marked by his dedication to social issues. He spent much of this year photographing for the ongoing campaign 
+                <a
+                  href="https://www.instagram.com/whereloveisillegal"
+                >
+                  Where Love is Illegal
+                </a>
+                , launched in 2015 by his own nonprofit, 
+                <a
+                  href="https://witnesschange.org/"
+                >
+                  Witness Change
+                </a>
+                . The campaign features photographs and testimonies of LGBTQI+ people in countries where they are oppressed; many of the subjects are pictured hiding their faces. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                For The Race Issue, Hammond photographed two powerful stories. For the cover, he featured British fraternal twins Marcia and Millie Biggs, who do not share the same skin tone: Millie is black, and Marcia is white. Likewise, his second shoot, documenting the incredible diversity of various distinct communities in Africa, reinforced the idea that race is not a biological dividing line. In fact, as the writer, Elizabeth Kolbert, stresses, among humans, “the deepest splits” aren’t between people who are black, white, Asian, or Native American. They’re within African populations, “who spent tens of thousands of years separated from one another even before humans left Africa,” she writes. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Hammond’s images of African people of all ages are stripped-down, classical portraits taken against a white backdrop, with soft lighting. Unlike the magazine’s older coverage, which Goldberg acknowledged “pictured ‘natives’ elsewhere as exotics, famously and frequently unclothed, happy hunters, noble savages—every type of cliché,” Hammond focuses on their beauty and individuality, letting their features shine.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -13209,13 +14949,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Organized all-black dress codes at major red-carpet events in a show of solidarity.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Organized all-black dress codes at major red-carpet events in a show of solidarity.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -13357,13 +15095,40 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Leading up to the 75th Golden Globe Awards this January, stylists were tasked with a last-minute dress code: Actresses were opting to wear black, and black alone. Time’s Up, a volunteer-run movement founded by women in Hollywood to fight sexual harassment in the wake of #MeToo, organized a red-carpet blackout.</p><p>Actresses, and a handful of actors, took to social media to spread the word with the hashtag #WhyWeWearBlack. “We wear black to symbolize solidarity—that the death knell has struck on abusive power, and that it’s time to celebrate each other, not just the nominees on our film and television screens, but our storytellers who have bravely come forward and courageously shared their personal stories, which have liberated so many of us,” actress Rosario Dawson <a href=\\"https://www.instagram.com/p/BdldKRPlqKw/?utm_source=ig_embed&amp;utm_campaign=embed_video_watch_again\\">shared</a> in an Instagram post. A few brands that dressed the stars also acknowledged their support, no doubt recognizing the power of “woke” marketing in 2018.</p><p>The visual impact of the protest was amplified by the presence of prominent activists like Ai-jen Poo, director of the National Domestic Workers Alliance, and Tarana Burke, founder of #MeToo, who, among others, were invited by actresses as their guests. Whereas red-carpet conversations usually begin by asking stars what designer they’re wearing, this year, the conversation largely centered around women’s empowerment. “We feel emboldened in this particular moment to stand together in a thick black line dividing then from now,” actress Meryl Streep told reporters.</p><p>As with any convergence of fashion and politics, the blackout wasn’t without controversy, with some questioning the efficacy of a sartorial gesture organized by privileged women. But the goal of the night was to use the spotlight of the Golden Globes—and the platforms of famous women—to send a message of collective power. Time’s Up, launched by 300 volunteers, has since continued to stage red-carpet blackouts at other award shows, like the BAFTAs and the CDGAs, while working toward affecting real change. Among these efforts include a legal defense fund providing assistance to working-class women—which has since <a href=\\"https://www.buzzfeednews.com/article/jtes/gofundme-timesup-metoo-fundraising-record\\">become</a> the most successful GoFundMe campaign in history—and a “50/50 by 2020” project to reach a gender balance among entertainment leadership roles in the next two years. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Leading up to the 75th Golden Globe Awards this January, stylists were tasked with a last-minute dress code: Actresses were opting to wear black, and black alone. Time’s Up, a volunteer-run movement founded by women in Hollywood to fight sexual harassment in the wake of #MeToo, organized a red-carpet blackout.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Actresses, and a handful of actors, took to social media to spread the word with the hashtag #WhyWeWearBlack. “We wear black to symbolize solidarity—that the death knell has struck on abusive power, and that it’s time to celebrate each other, not just the nominees on our film and television screens, but our storytellers who have bravely come forward and courageously shared their personal stories, which have liberated so many of us,” actress Rosario Dawson 
+                <a
+                  href="https://www.instagram.com/p/BdldKRPlqKw/?utm_source=ig_embed&utm_campaign=embed_video_watch_again"
+                >
+                  shared
+                </a>
+                 in an Instagram post. A few brands that dressed the stars also acknowledged their support, no doubt recognizing the power of “woke” marketing in 2018.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The visual impact of the protest was amplified by the presence of prominent activists like Ai-jen Poo, director of the National Domestic Workers Alliance, and Tarana Burke, founder of #MeToo, who, among others, were invited by actresses as their guests. Whereas red-carpet conversations usually begin by asking stars what designer they’re wearing, this year, the conversation largely centered around women’s empowerment. “We feel emboldened in this particular moment to stand together in a thick black line dividing then from now,” actress Meryl Streep told reporters.
+              </div>
+              <div
+                className="paragraph"
+              >
+                As with any convergence of fashion and politics, the blackout wasn’t without controversy, with some questioning the efficacy of a sartorial gesture organized by privileged women. But the goal of the night was to use the spotlight of the Golden Globes—and the platforms of famous women—to send a message of collective power. Time’s Up, launched by 300 volunteers, has since continued to stage red-carpet blackouts at other award shows, like the BAFTAs and the CDGAs, while working toward affecting real change. Among these efforts include a legal defense fund providing assistance to working-class women—which has since 
+                <a
+                  href="https://www.buzzfeednews.com/article/jtes/gofundme-timesup-metoo-fundraising-record"
+                >
+                  become
+                </a>
+                 the most successful GoFundMe campaign in history—and a “50/50 by 2020” project to reach a gender balance among entertainment leadership roles in the next two years. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -13522,13 +15287,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Developed a 3D-printed home that could help solve global homelessness.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Developed a 3D-printed home that could help solve global homelessness.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -13556,13 +15319,34 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>It’s hard to get a sense of how many people in our world do not have a roof over their heads. The most recent <a href=\\"http://www.ipsnews.net/2005/03/human-rights-more-than-100-million-homeless-worldwide/\\">global survey</a> by the UN estimated that 100 million people were homeless in 2005; this century, the number of people living in slums passed 1 billion. Solving global homelessness is a weighty task, but the founders of Austin, Texas–based startup Icon are making every effort to usher in an era of 3D-printed dwellings as the solution.</p><p>All three founders had co-founded companies before forming Icon—Jason Ballard and Evan Loomis started the sustainable home-improvement company TreeHouse in 2010, while Alex Le Roux co-launched Vesta Printers, a manufacturer of 3D printers for construction projects, in 2016. Together, they designed the Vulcan, a mobile printer that will be used by San Francisco nonprofit New Story to print homes in Haiti, El Salvador, and Bolivia, where the organization is currently active. </p><p>The team at New Story had already begun building homes in developing countries, but it took several months and thousands of dollars to construct each one. With the Vulcan, it will be monumentally faster and cheaper: In March, a prototype, running at just a quarter of its projected power, printed a 350-square-foot home in Austin in just 48 hours. (As with most 3D-printed homes, roofs, windows, doors, and plumbing require additional installation.) Armed with the real Vulcan running at full speed, Icon says it will be able to print a 600- to 800-square-foot home in a single day, each costing around $4,000. That will be put to the test in early 2019, when the company plans to print 100 homes with New Story.</p><p>With the Vulcan ready to begin printing, Ballard, Loomis, and Le Roux are looking to the future. Their investors include U.S. homebuilder D.R. Horton and leading Middle Eastern developer Emaar, and they secured $9 million in funding this year. If things go according to plan, we may be seeing first examples of the small, technology-powered homes that could replace the slums of the world.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                It’s hard to get a sense of how many people in our world do not have a roof over their heads. The most recent 
+                <a
+                  href="http://www.ipsnews.net/2005/03/human-rights-more-than-100-million-homeless-worldwide/"
+                >
+                  global survey
+                </a>
+                 by the UN estimated that 100 million people were homeless in 2005; this century, the number of people living in slums passed 1 billion. Solving global homelessness is a weighty task, but the founders of Austin, Texas–based startup Icon are making every effort to usher in an era of 3D-printed dwellings as the solution.
+              </div>
+              <div
+                className="paragraph"
+              >
+                All three founders had co-founded companies before forming Icon—Jason Ballard and Evan Loomis started the sustainable home-improvement company TreeHouse in 2010, while Alex Le Roux co-launched Vesta Printers, a manufacturer of 3D printers for construction projects, in 2016. Together, they designed the Vulcan, a mobile printer that will be used by San Francisco nonprofit New Story to print homes in Haiti, El Salvador, and Bolivia, where the organization is currently active. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The team at New Story had already begun building homes in developing countries, but it took several months and thousands of dollars to construct each one. With the Vulcan, it will be monumentally faster and cheaper: In March, a prototype, running at just a quarter of its projected power, printed a 350-square-foot home in Austin in just 48 hours. (As with most 3D-printed homes, roofs, windows, doors, and plumbing require additional installation.) Armed with the real Vulcan running at full speed, Icon says it will be able to print a 600- to 800-square-foot home in a single day, each costing around $4,000. That will be put to the test in early 2019, when the company plans to print 100 homes with New Story.
+              </div>
+              <div
+                className="paragraph"
+              >
+                With the Vulcan ready to begin printing, Ballard, Loomis, and Le Roux are looking to the future. Their investors include U.S. homebuilder D.R. Horton and leading Middle Eastern developer Emaar, and they secured $9 million in funding this year. If things go according to plan, we may be seeing first examples of the small, technology-powered homes that could replace the slums of the world.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -13721,13 +15505,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Merged African history with Afrofuturism in her costumes for the billion-dollar box-office blockbuster.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Merged African history with Afrofuturism in her costumes for the billion-dollar box-office blockbuster.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -13869,13 +15651,74 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In a career spanning more than 40 films, costume designer Ruth E. Carter has established a reputation for foregrounding clothing as a vital marker of black identity. The effort is especially evident in her collaborations with director Spike Lee, from the statement-making slogan T-shirts in <em>Do the Right Thing</em> (1989) to the title activist’s iconic suit in <em>Malcolm X</em> (1992). While, in her work for period dramas like Steven Spielberg’s <em>Amistad</em> (1997) and Ava DuVernay’s <em>Selma</em> (2014), Carter artfully brought real events of the past into the present. </p><p>But it’s her designs for the billion-dollar box-office blockbuster <em>Black Panther</em> (2018), directed by Ryan Coogler, that catapulted Carter to superstar status—a rare feat for a costume designer. Tasked with imagining the garments of fictional Wakanda—a diverse, technologically advanced nation untouched by European colonization—Carter drew upon traditional tribal garb alongside current fashion trends. Indeed, clothing plays an outsize role in shaping the film’s world, and the characters’ dramatic costumes impart important messages of both individual and community identity.</p><p>Modern updates of indigenous tribal designs and materials abound: W’Kabi, leader of the Border Tribe, dons the Wakandan version of a Lesotho blanket; Queen Ramonda’s magisterial headgear is inspired by a traditional hat worn by married Zulu women; and the Dora Milaje warriors’ costumes borrow from the beadwork of the Turkana and Maasai tribes. But Carter also wanted to represent the modern, cosmopolitan spirit of the fashion of Africa and its diaspora; to that end, she looked to the sartorial elegance of Congolese <em>sapeurs</em> and the transgressive Afropunk festival, even collaborating with vanguard fashion designers like Ozwald Boateng, <a href=\\"https://www.artsy.net/artist/ikire-jones\\">Ikiré Jones</a>, and Duro Olowu.</p><p>In advance of the film’s release, “What are you wearing to the Black Panther premiere?” became a trending topic on social media, with enthusiastic black Twitter users <a href=\\"https://www.essence.com/entertainment/what-wear-watch-black-panther-black-twitter-fashion/\\">sharing memes</a> and outfit inspiration. The influence of the film’s costumes have inspired a <a href=\\"https://www.heinzhistorycenter.org/exhibits/heroes-and-sheroes-ruth-e-carter\\">traveling exhibition</a>, and this February, the Costume Designers Guild Awards will honor Carter with the Career Achievement Award. Such accolades recognize the uncharted territory she entered with <em>Black Panther</em> by bringing the political power of black fashion to the mainstream.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In a career spanning more than 40 films, costume designer Ruth E. Carter has established a reputation for foregrounding clothing as a vital marker of black identity. The effort is especially evident in her collaborations with director Spike Lee, from the statement-making slogan T-shirts in 
+                <em>
+                  Do the Right Thing
+                </em>
+                 (1989) to the title activist’s iconic suit in 
+                <em>
+                  Malcolm X
+                </em>
+                 (1992). While, in her work for period dramas like Steven Spielberg’s 
+                <em>
+                  Amistad
+                </em>
+                 (1997) and Ava DuVernay’s 
+                <em>
+                  Selma
+                </em>
+                 (2014), Carter artfully brought real events of the past into the present. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                But it’s her designs for the billion-dollar box-office blockbuster 
+                <em>
+                  Black Panther
+                </em>
+                 (2018), directed by Ryan Coogler, that catapulted Carter to superstar status—a rare feat for a costume designer. Tasked with imagining the garments of fictional Wakanda—a diverse, technologically advanced nation untouched by European colonization—Carter drew upon traditional tribal garb alongside current fashion trends. Indeed, clothing plays an outsize role in shaping the film’s world, and the characters’ dramatic costumes impart important messages of both individual and community identity.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Modern updates of indigenous tribal designs and materials abound: W’Kabi, leader of the Border Tribe, dons the Wakandan version of a Lesotho blanket; Queen Ramonda’s magisterial headgear is inspired by a traditional hat worn by married Zulu women; and the Dora Milaje warriors’ costumes borrow from the beadwork of the Turkana and Maasai tribes. But Carter also wanted to represent the modern, cosmopolitan spirit of the fashion of Africa and its diaspora; to that end, she looked to the sartorial elegance of Congolese 
+                <em>
+                  sapeurs
+                </em>
+                 and the transgressive Afropunk festival, even collaborating with vanguard fashion designers like Ozwald Boateng, 
+                <a
+                  href="https://www.artsy.net/artist/ikire-jones"
+                >
+                  Ikiré Jones
+                </a>
+                , and Duro Olowu.
+              </div>
+              <div
+                className="paragraph"
+              >
+                In advance of the film’s release, “What are you wearing to the Black Panther premiere?” became a trending topic on social media, with enthusiastic black Twitter users 
+                <a
+                  href="https://www.essence.com/entertainment/what-wear-watch-black-panther-black-twitter-fashion/"
+                >
+                  sharing memes
+                </a>
+                 and outfit inspiration. The influence of the film’s costumes have inspired a 
+                <a
+                  href="https://www.heinzhistorycenter.org/exhibits/heroes-and-sheroes-ruth-e-carter"
+                >
+                  traveling exhibition
+                </a>
+                , and this February, the Costume Designers Guild Awards will honor Carter with the Career Achievement Award. Such accolades recognize the uncharted territory she entered with 
+                <em>
+                  Black Panther
+                </em>
+                 by bringing the political power of black fashion to the mainstream.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -14034,13 +15877,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Photographed the front lines of the U.S. immigration crisis.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Photographed the front lines of the U.S. immigration crisis.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -14182,13 +16023,40 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>It was nighttime in June, and photojournalist John Moore watched as a U.S. Border Patrol unit apprehended women and children on the banks of the Rio Grande. One Honduran woman, who was breastfeeding her two-year-old in the headlights of the patrol vehicles, told Moore that she and her daughter had been traveling for a month. The next day, one of the photographs that Moore took of them—an image of the daughter crying as her mother was searched by the agents—went viral.Moore’s image came at a time when tensions over immigration in the U.S. were at a breaking point, following the Trump administration’s zero-tolerance policy, enacted in April, which had separated thousands of children from their parents after they crossed the border. Though it was later confirmed that this young girl was not taken from her mother, the image of her fear seemed to encapsulate the feelings of horror that the policy elicited from many across the political spectrum.</p><p>The image spread like wildfire on social media and made the front page of the<em> New York Times</em>, while an edited version graced the cover of <em>Time</em> magazine. It’s just one of the thousands of images Moore has taken that communicate the human side of immigration policy. Now based in New York, Moore has spent nearly a decade traveling to the border and to immigrant communities. In March, he released a book, <em>Undocumented</em>, that shows a more complete picture of his ongoing coverage.</p><p>It would be hard to find an immigration story this year that didn’t feature Moore’s images. While spending six days with ICE in New York, he captured the fear that undocumented immigrants live with daily. He captured the joy and relief of nine Guatemalan children who were reunited with their parents after months of detainment. He has also photographed both of the recent caravans of migrants making their way to the border after arduous weeks-long journeys on foot. </p><p>Though many photographers are covering the immigration crisis, Moore has set the benchmark, and our news is better for it.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                It was nighttime in June, and photojournalist John Moore watched as a U.S. Border Patrol unit apprehended women and children on the banks of the Rio Grande. One Honduran woman, who was breastfeeding her two-year-old in the headlights of the patrol vehicles, told Moore that she and her daughter had been traveling for a month. The next day, one of the photographs that Moore took of them—an image of the daughter crying as her mother was searched by the agents—went viral.Moore’s image came at a time when tensions over immigration in the U.S. were at a breaking point, following the Trump administration’s zero-tolerance policy, enacted in April, which had separated thousands of children from their parents after they crossed the border. Though it was later confirmed that this young girl was not taken from her mother, the image of her fear seemed to encapsulate the feelings of horror that the policy elicited from many across the political spectrum.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The image spread like wildfire on social media and made the front page of the
+                <em>
+                   New York Times
+                </em>
+                , while an edited version graced the cover of 
+                <em>
+                  Time
+                </em>
+                 magazine. It’s just one of the thousands of images Moore has taken that communicate the human side of immigration policy. Now based in New York, Moore has spent nearly a decade traveling to the border and to immigrant communities. In March, he released a book, 
+                <em>
+                  Undocumented
+                </em>
+                , that shows a more complete picture of his ongoing coverage.
+              </div>
+              <div
+                className="paragraph"
+              >
+                It would be hard to find an immigration story this year that didn’t feature Moore’s images. While spending six days with ICE in New York, he captured the fear that undocumented immigrants live with daily. He captured the joy and relief of nine Guatemalan children who were reunited with their parents after months of detainment. He has also photographed both of the recent caravans of migrants making their way to the border after arduous weeks-long journeys on foot. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Though many photographers are covering the immigration crisis, Moore has set the benchmark, and our news is better for it.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -14347,13 +16215,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Directed the first Hollywood film to feature an all-Asian leading cast in 25 years.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Directed the first Hollywood film to feature an all-Asian leading cast in 25 years.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -14495,13 +16361,61 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>When #OscarsSoWhite went viral in 2016, Jon M. Chu had a moment of reckoning. Asian-Americans were increasingly demanding greater on-screen representation, and Chu realized he needed to play a part in the cause. Directing <em>Crazy Rich Asians</em> (2018)—an adaption of the best-selling 2013 novel by Kevin Kwan—presented the perfect opportunity.</p><p><em>Crazy Rich Asians</em> was not only the first Hollywood film in 25 years to feature an all-Asian leading cast, it also became the top-grossing romantic comedy in the U.S. in a decade. It represented a breakthrough moment in an industry that has historically either stereotyped Asian characters or cast white actors in their roles. “To see them play <em>all</em> the roles…not just the villains or the side characters—and to see them in such glorious complexities: that’s a huge contribution to Hollywood’s representation of Asians and Asian-Americans,” said sociologist Nancy Wang Yuen, the author of <em>Reel Inequality: Hollywood Actors and Racism</em>.</p><p>Many of the themes addressed in the film—feeling caught between cultures; the struggle between love and familial duty—are topics that struck a chord with Asian-American viewers, and with Chu. Chu was born in California, the son of first-generation immigrants who own and operate a popular Chinese restaurant in Los Altos, California. The director has been candid in interviews about his previous reluctance to explore his Asian heritage in film. “I didn’t want to be seen as this ‘other’ thing,” he <a href=\\"https://www.huffingtonpost.com/entry/crazy-rich-asians-director-jon-m-chu_us_5b688fc5e4b0b15abaa5c133\\">has</a> said. “I didn’t realize that came from a place from what society was telling me and that I had a responsibility to the people who’d carried me to this place.”</p><p>The success of <em>Crazy Rich Asians</em>, as with any project, of course, can’t be attributed to one person alone. Fans of the film have followed the cast—from Michelle Yeoh of <em>Crouching Tiger, Hidden Dragon</em> fame and <em>Fresh Off the Boat</em> actress Constance Wu to cinema newcomer Henry Golding—as they’ve become a family of sorts, and a collective force in the fight for diversity in Hollywood. Together, they are inspiring a new generation of Asian creatives to make their voices heard.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                When #OscarsSoWhite went viral in 2016, Jon M. Chu had a moment of reckoning. Asian-Americans were increasingly demanding greater on-screen representation, and Chu realized he needed to play a part in the cause. Directing 
+                <em>
+                  Crazy Rich Asians
+                </em>
+                 (2018)—an adaption of the best-selling 2013 novel by Kevin Kwan—presented the perfect opportunity.
+              </div>
+              <div
+                className="paragraph"
+              >
+                <em>
+                  Crazy Rich Asians
+                </em>
+                 was not only the first Hollywood film in 25 years to feature an all-Asian leading cast, it also became the top-grossing romantic comedy in the U.S. in a decade. It represented a breakthrough moment in an industry that has historically either stereotyped Asian characters or cast white actors in their roles. “To see them play 
+                <em>
+                  all
+                </em>
+                 the roles…not just the villains or the side characters—and to see them in such glorious complexities: that’s a huge contribution to Hollywood’s representation of Asians and Asian-Americans,” said sociologist Nancy Wang Yuen, the author of 
+                <em>
+                  Reel Inequality: Hollywood Actors and Racism
+                </em>
+                .
+              </div>
+              <div
+                className="paragraph"
+              >
+                Many of the themes addressed in the film—feeling caught between cultures; the struggle between love and familial duty—are topics that struck a chord with Asian-American viewers, and with Chu. Chu was born in California, the son of first-generation immigrants who own and operate a popular Chinese restaurant in Los Altos, California. The director has been candid in interviews about his previous reluctance to explore his Asian heritage in film. “I didn’t want to be seen as this ‘other’ thing,” he 
+                <a
+                  href="https://www.huffingtonpost.com/entry/crazy-rich-asians-director-jon-m-chu_us_5b688fc5e4b0b15abaa5c133"
+                >
+                  has
+                </a>
+                 said. “I didn’t realize that came from a place from what society was telling me and that I had a responsibility to the people who’d carried me to this place.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                The success of 
+                <em>
+                  Crazy Rich Asians
+                </em>
+                , as with any project, of course, can’t be attributed to one person alone. Fans of the film have followed the cast—from Michelle Yeoh of 
+                <em>
+                  Crouching Tiger, Hidden Dragon
+                </em>
+                 fame and 
+                <em>
+                  Fresh Off the Boat
+                </em>
+                 actress Constance Wu to cinema newcomer Henry Golding—as they’ve become a family of sorts, and a collective force in the fight for diversity in Hollywood. Together, they are inspiring a new generation of Asian creatives to make their voices heard.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -14660,13 +16574,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Created the first statue of a woman in London’s Parliament Square.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Created the first statue of a woman in London’s Parliament Square.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -14694,13 +16606,47 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><em>NPR</em> recently <a href=\\"https://www.npr.org/2018/12/03/673057831/nyc-has-just-5-statues-of-historic-women-thats-about-to-change\\">reported</a> that only five public sculptures in New York City depict real, historical women. Not 50 percent, nor even 5 percent—just five in total. (Imaginary women such as Greek goddesses, towering symbols of liberty, and dancing nymphs don’t count.) This absence ignores vital contributions made by women to history, social progress, and civic life.</p><p>But this missing history is not unique to New York, and municipal governments are finally beginning to take action. The initiative She Built NYC will begin commissioning public monuments that honor historical New York women, beginning with a statue of Shirley Chisholm, the first black woman to serve in Congress. San Francisco also announced a new ordinance this year, mandating that at least 30 percent of public statues of historical figures must be women.</p><p>In London, Caroline Criado-Perez, a feminist activist who helmed the successful campaign to add Jane Austen’s portrait to the £10 British banknote, led the charge to have a statue of British suffragist Millicent Fawcett added to the all-male array of figures in Parliament Square. Criado-Perez’s petition to include Fawcett, who fought for votes and higher education access for women, was endorsed by Mayor Sadiq Khan and Prime Minister Theresa May. Both leaders were present at the statue’s unveiling in April. </p><p>Created by Turner Prize–winning artist <a href=\\"https://www.artsy.net/artist/gillian-wearing\\">Gillian Wearing</a>, the Fawcett statue is both the first sculpture of a woman and the first sculpture <em>by</em> a woman to grace London’s Parliament Square, where it joins the figures Winston Churchill, Abraham Lincoln, and Mahatma Gandhi, among others, in an exclusive coterie that overlooks the houses of British government. Depicted at age 50, the bronze figure of Fawcett has a gravitas equal to that of her male neighbors. She has a lined brow, a determined gaze, and holds a banner that reads what might be viewed as a rallying cry for communities everywhere to bravely address the underrepresentation of women in civic art: “Courage calls to courage everywhere.”</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <em>
+                  NPR
+                </em>
+                 recently 
+                <a
+                  href="https://www.npr.org/2018/12/03/673057831/nyc-has-just-5-statues-of-historic-women-thats-about-to-change"
+                >
+                  reported
+                </a>
+                 that only five public sculptures in New York City depict real, historical women. Not 50 percent, nor even 5 percent—just five in total. (Imaginary women such as Greek goddesses, towering symbols of liberty, and dancing nymphs don’t count.) This absence ignores vital contributions made by women to history, social progress, and civic life.
+              </div>
+              <div
+                className="paragraph"
+              >
+                But this missing history is not unique to New York, and municipal governments are finally beginning to take action. The initiative She Built NYC will begin commissioning public monuments that honor historical New York women, beginning with a statue of Shirley Chisholm, the first black woman to serve in Congress. San Francisco also announced a new ordinance this year, mandating that at least 30 percent of public statues of historical figures must be women.
+              </div>
+              <div
+                className="paragraph"
+              >
+                In London, Caroline Criado-Perez, a feminist activist who helmed the successful campaign to add Jane Austen’s portrait to the £10 British banknote, led the charge to have a statue of British suffragist Millicent Fawcett added to the all-male array of figures in Parliament Square. Criado-Perez’s petition to include Fawcett, who fought for votes and higher education access for women, was endorsed by Mayor Sadiq Khan and Prime Minister Theresa May. Both leaders were present at the statue’s unveiling in April. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                Created by Turner Prize–winning artist 
+                <a
+                  href="https://www.artsy.net/artist/gillian-wearing"
+                >
+                  Gillian Wearing
+                </a>
+                , the Fawcett statue is both the first sculpture of a woman and the first sculpture 
+                <em>
+                  by
+                </em>
+                 a woman to grace London’s Parliament Square, where it joins the figures Winston Churchill, Abraham Lincoln, and Mahatma Gandhi, among others, in an exclusive coterie that overlooks the houses of British government. Depicted at age 50, the bronze figure of Fawcett has a gravitas equal to that of her male neighbors. She has a lined brow, a determined gaze, and holds a banner that reads what might be viewed as a rallying cry for communities everywhere to bravely address the underrepresentation of women in civic art: “Courage calls to courage everywhere.”
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -14859,13 +16805,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Set a significant, new high mark for black artists’ markets when he purchased the Kerry James Marshall painting.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Set a significant, new high mark for black artists’ markets when he purchased the Kerry James Marshall painting.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -15007,13 +16951,116 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>On May 16th, <a href=\\"https://www.artsy.net/artist/kerry-james-marshall\\">Kerry James Marshall</a>’s <em>Past Times </em>(1997) <a href=\\"https://www.artsy.net/article/artsy-editorial-black-artists-shatter-multiple-records-3923-million-sothebys-sale\\">sold at Sotheby’s</a> for $21.1 million, with fees. The result nearly doubled the previous record for an artwork by a living African-American artist, itself only set months before <a href=\\"https://www.artsy.net/article/artsy-editorial-phillips-notches-best-sale-record-breaking-bradford-42-million-picasso\\">at Phillips’s March sale</a> in London, when <a href=\\"https://www.artsy.net/artist/mark-bradford\\">Mark Bradford</a>’s <em>Helter Skelter I </em>(2007) sold for £8.6 million (nearly $12 million). The Marshall’s new owner? None other than <a href=\\"https://www.artsy.net/news/artsy-editorial-sean-diddy-combs-revealed-buyer-weeks-record-breaking-21-million-kerry-james-marshall\\">Sean “Diddy” Combs</a>, the Grammy-winning music producer and entrepreneur. </p><p>The increase in prices for black artists’ work has been one of the most significant art market narratives of 2018. In the same May auction where Combs purchased <em>Past Times</em>, records for the late portraitist <a href=\\"https://www.artsy.net/artist/barkley-l-hendricks\\">Barkley L. Hendricks</a> and the 35-year-old painter <a href=\\"https://www.artsy.net/artist/njideka-akunyili-crosby\\">Njideka Akunyili Crosby</a> were also set. And <a href=\\"https://www.artsy.net/article/artsy-editorial-multiple-records-set-black-artists-3625-million-night-sothebys\\">record-setting works</a> by 60-year-old <a href=\\"https://www.artsy.net/artist/henry-taylor\\">Henry Taylor</a>, the late modernist painter <a href=\\"https://www.artsy.net/artist/jacob-lawrence\\">Jacob Lawrence</a>, and <a href=\\"https://www.artsy.net/artist/jack-whitten\\">Jack Whitten</a>, who passed away in January, were among the November auctions’ best performers. This market momentum has been brought on by increasing institutional recognition of work that was often overlooked by those same institutions when it was originally produced, as well as a steady influx of black collectors like Combs into the very white art world. </p><p>“We are going through a moment where there is a rewriting of art history to include women and black artists, as well as the peers of other critically acclaimed and celebrated artists,” and collectors are following in tow, said Jacqueline Wachter, vice president of private sales at Sotheby’s, who bid on behalf of Combs in the sale. “Black collectors are a big part of this shift in focus and expansion of the market. As a broader variety of collectors enter the game, the market is starting to expand our definitions of ‘great,’ ‘important,’ and ‘masterpiece.’” </p><p>The Marshall record may only be less than a quarter of that set for a living artist by <a href=\\"https://www.artsy.net/artist/david-hockney\\">David Hockney</a> in November, when his <em>Portrait of an Artist (Pool With Two Figures)</em> (1972) sold at Christie’s for $90.3 million. But it’s clear that this is just the beginning of a sea-change for the art world—and contemporary art as we know it. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                On May 16th, 
+                <a
+                  href="https://www.artsy.net/artist/kerry-james-marshall"
+                >
+                  Kerry James Marshall
+                </a>
+                ’s 
+                <em>
+                  Past Times 
+                </em>
+                (1997) 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-black-artists-shatter-multiple-records-3923-million-sothebys-sale"
+                >
+                  sold at Sotheby’s
+                </a>
+                 for $21.1 million, with fees. The result nearly doubled the previous record for an artwork by a living African-American artist, itself only set months before 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-phillips-notches-best-sale-record-breaking-bradford-42-million-picasso"
+                >
+                  at Phillips’s March sale
+                </a>
+                 in London, when 
+                <a
+                  href="https://www.artsy.net/artist/mark-bradford"
+                >
+                  Mark Bradford
+                </a>
+                ’s 
+                <em>
+                  Helter Skelter I 
+                </em>
+                (2007) sold for £8.6 million (nearly $12 million). The Marshall’s new owner? None other than 
+                <a
+                  href="https://www.artsy.net/news/artsy-editorial-sean-diddy-combs-revealed-buyer-weeks-record-breaking-21-million-kerry-james-marshall"
+                >
+                  Sean “Diddy” Combs
+                </a>
+                , the Grammy-winning music producer and entrepreneur. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The increase in prices for black artists’ work has been one of the most significant art market narratives of 2018. In the same May auction where Combs purchased 
+                <em>
+                  Past Times
+                </em>
+                , records for the late portraitist 
+                <a
+                  href="https://www.artsy.net/artist/barkley-l-hendricks"
+                >
+                  Barkley L. Hendricks
+                </a>
+                 and the 35-year-old painter 
+                <a
+                  href="https://www.artsy.net/artist/njideka-akunyili-crosby"
+                >
+                  Njideka Akunyili Crosby
+                </a>
+                 were also set. And 
+                <a
+                  href="https://www.artsy.net/article/artsy-editorial-multiple-records-set-black-artists-3625-million-night-sothebys"
+                >
+                  record-setting works
+                </a>
+                 by 60-year-old 
+                <a
+                  href="https://www.artsy.net/artist/henry-taylor"
+                >
+                  Henry Taylor
+                </a>
+                , the late modernist painter 
+                <a
+                  href="https://www.artsy.net/artist/jacob-lawrence"
+                >
+                  Jacob Lawrence
+                </a>
+                , and 
+                <a
+                  href="https://www.artsy.net/artist/jack-whitten"
+                >
+                  Jack Whitten
+                </a>
+                , who passed away in January, were among the November auctions’ best performers. This market momentum has been brought on by increasing institutional recognition of work that was often overlooked by those same institutions when it was originally produced, as well as a steady influx of black collectors like Combs into the very white art world. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                “We are going through a moment where there is a rewriting of art history to include women and black artists, as well as the peers of other critically acclaimed and celebrated artists,” and collectors are following in tow, said Jacqueline Wachter, vice president of private sales at Sotheby’s, who bid on behalf of Combs in the sale. “Black collectors are a big part of this shift in focus and expansion of the market. As a broader variety of collectors enter the game, the market is starting to expand our definitions of ‘great,’ ‘important,’ and ‘masterpiece.’” 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The Marshall record may only be less than a quarter of that set for a living artist by 
+                <a
+                  href="https://www.artsy.net/artist/david-hockney"
+                >
+                  David Hockney
+                </a>
+                 in November, when his 
+                <em>
+                  Portrait of an Artist (Pool With Two Figures)
+                </em>
+                 (1972) sold at Christie’s for $90.3 million. But it’s clear that this is just the beginning of a sea-change for the art world—and contemporary art as we know it. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -15172,13 +17219,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Created branding that’s helping fuel the direct-to-consumer retail revolution.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Created branding that’s helping fuel the direct-to-consumer retail revolution.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -15320,13 +17365,50 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c62"
             color="#000"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>In 2018, direct-to-consumer brands continued to chip away at the market share of their legacy competitors. With consumers tending to make more purchases online and on mobile, these new brands are responding to the move from the shelf to the feed. Gone is the loud, cluttered visual landscape of products promising “New and Improved Formula!” or “30% More Free!” compared to their competitors sitting inches away—it’s since been replaced by a more minimalist aesthetic that emphasizes a sense of the brand’s narrative in a way that content-hungry millennial and Gen-Z consumers crave. </p><p>The creative agency Red Antler, founded in 2007 by Emily Heyward, JB Osborne, and Simon Endres, has, along with <a href=\\"https://www.adweek.com/brand-marketing/meet-the-surprisingly-small-group-of-branding-shops-behind-todays-top-challenger-brands/?utm_source=feedburner&amp;utm_medium=feed&amp;utm_campaign=Feed%3A+adweek%2Fthe-press+%28Adweek+Digital%29\\">equally formidable</a> competitor Gin Lane, <a href=\\"https://www.fastcompany.com/40545905/the-cult-brand-whisperer-behind-casper-allbirds-and-birchbox\\">helped craft</a> this transformation, creating the top-to-bottom brand strategy of some of the most iconic direct-to-consumer brands, such as Casper, Allbirds, and Birchbox. “People used to view a brand as a logo, font, and colors. Red Antler knows that a brand is literally everything you do,” said Ben Lerer, a partner at the venture capital firm Lerer Hippeau, a number of whose portfolio companies have tapped Red Antler early on to help craft a compelling brand for today’s marketplace. </p><p>He explained that these companies are often pre-launch—they’re a seed of an idea with a small, highly capable team, but none of the wrapping that will initially draw customers in. “From positioning and naming these businesses to creating the storytelling, visuals, and the full consumer-facing experience, Red Antler brought these companies to market in a magical way, which allowed them to grow massively out of the starting gate,” Lerer said. </p><p>While not part of Lerer’s portfolio, one such company is Brandless, the consumer packaged-goods company known for each of its 400 products only costing $3. Red Antler developed the brand’s minimalist and fact-forward packaging to respond to health-conscious millennial consumers wary of traditional marketing messaging. In April, Brandless was named startup of the year by <em>Ad Age</em>, and in July, the company announced that it had <a href=\\"https://www.bloomberg.com/news/articles/2018-07-31/brandless-is-battling-amazon-with-240-million-from-softbank\\">landed</a> $240 million in fresh funding from the SoftBank Vision Fund—a significant vote of confidence that the honest, no-nonsense branding Red Antler developed could go head-to-head with Amazon and win. </p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                In 2018, direct-to-consumer brands continued to chip away at the market share of their legacy competitors. With consumers tending to make more purchases online and on mobile, these new brands are responding to the move from the shelf to the feed. Gone is the loud, cluttered visual landscape of products promising “New and Improved Formula!” or “30% More Free!” compared to their competitors sitting inches away—it’s since been replaced by a more minimalist aesthetic that emphasizes a sense of the brand’s narrative in a way that content-hungry millennial and Gen-Z consumers crave. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                The creative agency Red Antler, founded in 2007 by Emily Heyward, JB Osborne, and Simon Endres, has, along with 
+                <a
+                  href="https://www.adweek.com/brand-marketing/meet-the-surprisingly-small-group-of-branding-shops-behind-todays-top-challenger-brands/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+adweek%2Fthe-press+%28Adweek+Digital%29"
+                >
+                  equally formidable
+                </a>
+                 competitor Gin Lane, 
+                <a
+                  href="https://www.fastcompany.com/40545905/the-cult-brand-whisperer-behind-casper-allbirds-and-birchbox"
+                >
+                  helped craft
+                </a>
+                 this transformation, creating the top-to-bottom brand strategy of some of the most iconic direct-to-consumer brands, such as Casper, Allbirds, and Birchbox. “People used to view a brand as a logo, font, and colors. Red Antler knows that a brand is literally everything you do,” said Ben Lerer, a partner at the venture capital firm Lerer Hippeau, a number of whose portfolio companies have tapped Red Antler early on to help craft a compelling brand for today’s marketplace. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                He explained that these companies are often pre-launch—they’re a seed of an idea with a small, highly capable team, but none of the wrapping that will initially draw customers in. “From positioning and naming these businesses to creating the storytelling, visuals, and the full consumer-facing experience, Red Antler brought these companies to market in a magical way, which allowed them to grow massively out of the starting gate,” Lerer said. 
+              </div>
+              <div
+                className="paragraph"
+              >
+                While not part of Lerer’s portfolio, one such company is Brandless, the consumer packaged-goods company known for each of its 400 products only costing $3. Red Antler developed the brand’s minimalist and fact-forward packaging to respond to health-conscious millennial consumers wary of traditional marketing messaging. In April, Brandless was named startup of the year by 
+                <em>
+                  Ad Age
+                </em>
+                , and in July, the company announced that it had 
+                <a
+                  href="https://www.bloomberg.com/news/articles/2018-07-31/brandless-is-battling-amazon-with-240-million-from-softbank"
+                >
+                  landed
+                </a>
+                 $240 million in fresh funding from the SoftBank Vision Fund—a significant vote of confidence that the honest, no-nonsense branding Red Antler developed could go head-to-head with Amazon and win. 
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -15485,13 +17567,11 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<blockquote>Mounted the largest collaborative creative project in U.S. history.</blockquote>",
-                }
-              }
-            />
+            <div>
+              <blockquote>
+                Mounted the largest collaborative creative project in U.S. history.
+              </blockquote>
+            </div>
           </div>
         </div>
       </div>
@@ -15633,13 +17713,110 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>For Freedoms began in early 2016 as a super PAC aimed at increasing civic engagement. The organization, founded by artists <a href=\\"https://www.artsy.net/artist/hank-willis-thomas\\">Hank Willis Thomas</a> and <a href=\\"https://www.artsy.net/artist/eric-gottesman\\">Eric Gottesman</a>, mounted billboards in 10 states, as well as an exhibition at <a href=\\"https://www.artsy.net/jack-shainman-gallery\\">Jack Shainman Gallery</a> for Super Tuesday that year. The efforts garnered attention in the art world, but were overshadowed in wider conversation by the theatrics of the presidential campaign. Thomas and Gottesman redoubled their efforts ahead of the 2018 midterms, launching the 50 State Initiative, which For Freedoms claims is not only the largest public art project, but also the largest creative collaboration in U.S. history.</p><p>The group has organized talks, panel discussions, exhibitions, and town halls in <a href=\\"https://forfreedoms.org/explore/\\">locations across the country</a>, with at least one event in every U.S. state, plus Washington, D.C., and Puerto Rico. They mounted billboards in all 50 states with messaging and imagery designed by a diverse set of artists like <a href=\\"https://www.artsy.net/artist/jr\\">JR</a>, <a href=\\"https://www.artsy.net/artist/rashid-johnson\\">Rashid Johnson</a>, <a href=\\"https://www.artsy.net/artist/trevor-paglen\\">Trevor Paglen</a>, Stuart Sheldon, <a href=\\"https://www.artsy.net/artist/carrie-mae-weems\\">Carrie Mae Weems</a>, <a href=\\"https://www.artsy.net/artist/awol-erizku\\">Awol Erizku</a>, and <a href=\\"https://www.artsy.net/artist/christine-sun-kim\\">Christine Sun Kim</a>. And they released a series of 82 images, created by Thomas and photographers Emily Shur and <a href=\\"https://www.artsy.net/artist/wyatt-gallery\\">Wyatt Gallery</a>, that reimagined <a href=\\"https://www.artsy.net/artist/norman-rockwell\\">Norman Rockwell</a>’s iconic 1943 series “Four Freedoms”—which gave the group its name—in a more inclusive light, reflective of America in 2018. Just after the midterms, <em>Time</em> <a href=\\"http://time.com/longform/four-freedoms/\\">picked up</a> one of the images for its cover.</p><p>In the divisive and polarized environment that is American politics today, For Freedoms’s emphasis on breaking down entrenched political dichotomies is refreshing. “We’re not non-partisan—we’re anti-partisan,” said Gottesman. “We’re trying to challenge these binaries of left and right, red and blue, black and white.” Thomas said the goal isn’t to form some kind of consensus, but to instead celebrate the fact that American history has been built upon honoring different viewpoints. “If there’s no tension, then we become stagnant and dead as a society,” he said. “We may not agree with each other, but we need to recognize our differences—that there is as much value in conserving some things as there is in progress elsewhere.”</p><p>To achieve that, the pair intentionally involved collaborators from both sides of the aisle. “We don’t agree with all of the artists we work with,” he said. “That’s the fundamental root of the project.” As Gottesman put it, fundamentally, their goal is to push forward the idea that creativity—and the gray areas that art allows us to inhabit——can help bridge the gap.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                For Freedoms began in early 2016 as a super PAC aimed at increasing civic engagement. The organization, founded by artists 
+                <a
+                  href="https://www.artsy.net/artist/hank-willis-thomas"
+                >
+                  Hank Willis Thomas
+                </a>
+                 and 
+                <a
+                  href="https://www.artsy.net/artist/eric-gottesman"
+                >
+                  Eric Gottesman
+                </a>
+                , mounted billboards in 10 states, as well as an exhibition at 
+                <a
+                  href="https://www.artsy.net/jack-shainman-gallery"
+                >
+                  Jack Shainman Gallery
+                </a>
+                 for Super Tuesday that year. The efforts garnered attention in the art world, but were overshadowed in wider conversation by the theatrics of the presidential campaign. Thomas and Gottesman redoubled their efforts ahead of the 2018 midterms, launching the 50 State Initiative, which For Freedoms claims is not only the largest public art project, but also the largest creative collaboration in U.S. history.
+              </div>
+              <div
+                className="paragraph"
+              >
+                The group has organized talks, panel discussions, exhibitions, and town halls in 
+                <a
+                  href="https://forfreedoms.org/explore/"
+                >
+                  locations across the country
+                </a>
+                , with at least one event in every U.S. state, plus Washington, D.C., and Puerto Rico. They mounted billboards in all 50 states with messaging and imagery designed by a diverse set of artists like 
+                <a
+                  href="https://www.artsy.net/artist/jr"
+                >
+                  JR
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/rashid-johnson"
+                >
+                  Rashid Johnson
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/trevor-paglen"
+                >
+                  Trevor Paglen
+                </a>
+                , Stuart Sheldon, 
+                <a
+                  href="https://www.artsy.net/artist/carrie-mae-weems"
+                >
+                  Carrie Mae Weems
+                </a>
+                , 
+                <a
+                  href="https://www.artsy.net/artist/awol-erizku"
+                >
+                  Awol Erizku
+                </a>
+                , and 
+                <a
+                  href="https://www.artsy.net/artist/christine-sun-kim"
+                >
+                  Christine Sun Kim
+                </a>
+                . And they released a series of 82 images, created by Thomas and photographers Emily Shur and 
+                <a
+                  href="https://www.artsy.net/artist/wyatt-gallery"
+                >
+                  Wyatt Gallery
+                </a>
+                , that reimagined 
+                <a
+                  href="https://www.artsy.net/artist/norman-rockwell"
+                >
+                  Norman Rockwell
+                </a>
+                ’s iconic 1943 series “Four Freedoms”—which gave the group its name—in a more inclusive light, reflective of America in 2018. Just after the midterms, 
+                <em>
+                  Time
+                </em>
+                 
+                <a
+                  href="http://time.com/longform/four-freedoms/"
+                >
+                  picked up
+                </a>
+                 one of the images for its cover.
+              </div>
+              <div
+                className="paragraph"
+              >
+                In the divisive and polarized environment that is American politics today, For Freedoms’s emphasis on breaking down entrenched political dichotomies is refreshing. “We’re not non-partisan—we’re anti-partisan,” said Gottesman. “We’re trying to challenge these binaries of left and right, red and blue, black and white.” Thomas said the goal isn’t to form some kind of consensus, but to instead celebrate the fact that American history has been built upon honoring different viewpoints. “If there’s no tension, then we become stagnant and dead as a society,” he said. “We may not agree with each other, but we need to recognize our differences—that there is as much value in conserving some things as there is in progress elsewhere.”
+              </div>
+              <div
+                className="paragraph"
+              >
+                To achieve that, the pair intentionally involved collaborators from both sides of the aisle. “We don’t agree with all of the artists we work with,” he said. “That’s the fundamental root of the project.” As Gottesman put it, fundamentally, their goal is to push forward the idea that creativity—and the gray areas that art allows us to inhabit——can help bridge the gap.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -15667,13 +17844,15 @@ exports[`EditorialFeature EOY_2018_CULTURE Matches snapshot 1`] = `
             className="article__text-section c42 c43"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><em>Visual design by Wax Studios.</em></p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <em>
+                  Visual design by Wax Studios.
+                </em>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/NewsLayout.test.tsx.snap
@@ -725,13 +725,34 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p><strong>The design for the as-yet-uncompleted sculpture</strong>, <span style='text-decoration:line-through;'><em>Bouquet of Tulips</em></span>, was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, <a href='#'>one of the world’s richest living artists</a>, didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” </p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              <strong>
+                The design for the as-yet-uncompleted sculpture
+              </strong>
+              , 
+              <span
+                style={
+                  Object {
+                    "textDecoration": "line-through",
+                  }
+                }
+              >
+                <em>
+                  Bouquet of Tulips
+                </em>
+              </span>
+              , was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, 
+              <a
+                href="#"
+              >
+                one of the world’s richest living artists
+              </a>
+              , didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” 
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -746,13 +767,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -763,13 +782,11 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -780,13 +797,15 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote><a href='#'>The Guardian</a></blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              <a
+                href="#"
+              >
+                The Guardian
+              </a>
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -797,13 +816,17 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the <em>New York Times</em>.</p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the 
+              <em>
+                New York Times
+              </em>
+              .
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -818,13 +841,20 @@ exports[`News Layout renders the news layout on mobile 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<h3><strong>Takeaway</strong></h3><h3>Should Prince lose at trial and on appeal the resulting precedent would reign in the broader <em>fair use interpretations</em> now afforded to artists.</h3>",
-              }
-            }
-          />
+          <div>
+            <h3>
+              <strong>
+                Takeaway
+              </strong>
+            </h3>
+            <h3>
+              Should Prince lose at trial and on appeal the resulting precedent would reign in the broader 
+              <em>
+                fair use interpretations
+              </em>
+               now afforded to artists.
+            </h3>
+          </div>
         </div>
       </div>
       <div
@@ -1683,13 +1713,34 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p><strong>The design for the as-yet-uncompleted sculpture</strong>, <span style='text-decoration:line-through;'><em>Bouquet of Tulips</em></span>, was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, <a href='#'>one of the world’s richest living artists</a>, didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” </p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              <strong>
+                The design for the as-yet-uncompleted sculpture
+              </strong>
+              , 
+              <span
+                style={
+                  Object {
+                    "textDecoration": "line-through",
+                  }
+                }
+              >
+                <em>
+                  Bouquet of Tulips
+                </em>
+              </span>
+              , was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, 
+              <a
+                href="#"
+              >
+                one of the world’s richest living artists
+              </a>
+              , didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” 
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -1704,13 +1755,11 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -1721,13 +1770,11 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -1738,13 +1785,15 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote><a href='#'>The Guardian</a></blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              <a
+                href="#"
+              >
+                The Guardian
+              </a>
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -1755,13 +1804,17 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the <em>New York Times</em>.</p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the 
+              <em>
+                New York Times
+              </em>
+              .
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -1776,13 +1829,20 @@ exports[`News Layout renders the news layout properly 1`] = `
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<h3><strong>Takeaway</strong></h3><h3>Should Prince lose at trial and on appeal the resulting precedent would reign in the broader <em>fair use interpretations</em> now afforded to artists.</h3>",
-              }
-            }
-          />
+          <div>
+            <h3>
+              <strong>
+                Takeaway
+              </strong>
+            </h3>
+            <h3>
+              Should Prince lose at trial and on appeal the resulting precedent would reign in the broader 
+              <em>
+                fair use interpretations
+              </em>
+               now afforded to artists.
+            </h3>
+          </div>
         </div>
       </div>
       <div
@@ -2672,13 +2732,34 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p><strong>The design for the as-yet-uncompleted sculpture</strong>, <span style='text-decoration:line-through;'><em>Bouquet of Tulips</em></span>, was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, <a href='#'>one of the world’s richest living artists</a>, didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” </p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              <strong>
+                The design for the as-yet-uncompleted sculpture
+              </strong>
+              , 
+              <span
+                style={
+                  Object {
+                    "textDecoration": "line-through",
+                  }
+                }
+              >
+                <em>
+                  Bouquet of Tulips
+                </em>
+              </span>
+              , was donated by Koons to the French capital in November 2016 as a memorial to the recent terrorist attacks that have taken place in the city. But Koons, 
+              <a
+                href="#"
+              >
+                one of the world’s richest living artists
+              </a>
+              , didn’t donate the $4.3 million needed to create 40-foot-tall sculpture, which was raised separately via donations. And the work, slated for installation in front of the Palais de Tokyo and Paris’s Museum of Modern Art, has attracted opposition. In a letter published in the French newspaper Libération on Sunday, signatories—including Frédéric Mitterrand, the country’s former culture minister—demanded that the city halt its plans to install the sculpture, calling it “shocking.” 
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -2693,13 +2774,11 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              It is understood the [British Museum] has been in talks about a possible loan of the tapestry for several years, but there will be other contenders to host it.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -2710,13 +2789,11 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote>The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.</blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              The bookmaker Ladbrokes is offering odds on where it might go, with the British Museum evens favourite, followed by Westminster Cathedral at 3/1, Canterbury Cathedral at 5/1 and Hastings at 8/1.
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -2727,13 +2804,15 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<blockquote><a href='#'>The Guardian</a></blockquote>",
-              }
-            }
-          />
+          <div>
+            <blockquote>
+              <a
+                href="#"
+              >
+                The Guardian
+              </a>
+            </blockquote>
+          </div>
         </div>
       </div>
       <div
@@ -2744,13 +2823,17 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the <em>New York Times</em>.</p>",
-              }
-            }
-          />
+          <div>
+            <div
+              className="paragraph"
+            >
+              It further criticized Koons for using the opportunity as a publicity stunt, as the sculpture’s planned location is in a tourist-heavy area far from where the 2015 terrorist attacks actually took place. “We appreciate gifts, [but ones that are] free, unconditional, and without ulterior motives,” the letter said. In any case, Parisian officials have not yet granted authorization to install the sculpture, according to the 
+              <em>
+                New York Times
+              </em>
+              .
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -2765,13 +2848,20 @@ exports[`News Layout with display ads renders the news layout properly with disp
           className="article__text-section c13"
           color="black"
         >
-          <div
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<h3><strong>Takeaway</strong></h3><h3>Should Prince lose at trial and on appeal the resulting precedent would reign in the broader <em>fair use interpretations</em> now afforded to artists.</h3>",
-              }
-            }
-          />
+          <div>
+            <h3>
+              <strong>
+                Takeaway
+              </strong>
+            </h3>
+            <h3>
+              Should Prince lose at trial and on appeal the resulting precedent would reign in the broader 
+              <em>
+                fair use interpretations
+              </em>
+               now afforded to artists.
+            </h3>
+          </div>
         </div>
       </div>
       <div

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/SeriesLayout.test.tsx.snap
@@ -1541,13 +1541,29 @@ exports[`series layout renders a series 1`] = `
               className="article__text-section c41"
               color="white"
             >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                  }
-                }
-              />
+              <div>
+                <div
+                  className="paragraph"
+                >
+                  Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+                  <a
+                    href="http://artsy.net"
+                  >
+                    Curabitur blandit
+                  </a>
+                   tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </div>
+                <div
+                  className="paragraph"
+                >
+                  Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+                </div>
+                <div
+                  className="paragraph"
+                >
+                  Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -3275,13 +3291,29 @@ exports[`series layout renders a sponsored series 1`] = `
               className="article__text-section c48"
               color="white"
             >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                  }
-                }
-              />
+              <div>
+                <div
+                  className="paragraph"
+                >
+                  Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+                  <a
+                    href="http://artsy.net"
+                  >
+                    Curabitur blandit
+                  </a>
+                   tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </div>
+                <div
+                  className="paragraph"
+                >
+                  Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+                </div>
+                <div
+                  className="paragraph"
+                >
+                  Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+                </div>
+              </div>
             </div>
           </div>
           <div

--- a/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
+++ b/src/Components/Publishing/Layouts/__tests__/__snapshots__/VideoLayout.test.tsx.snap
@@ -1333,13 +1333,32 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
             className="article__text-section c45 c46"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <b>
+                  Director
+                </b>
+              </div>
+              <div
+                className="paragraph"
+              >
+                Marina Cashdan
+              </div>
+              <div
+                className="paragraph"
+              >
+                <b>
+                  Featuring
+                </b>
+              </div>
+              <div
+                className="paragraph"
+              >
+                Trevor Paglan
+              </div>
+            </div>
           </div>
           <div
             className="fresnel-container fresnel-greaterThanOrEqual-md"
@@ -1491,13 +1510,29 @@ exports[`Video Layout Video Layout ads renders the video layout properly with ad
             className="article__text-section c45 c46"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Integer posuere erat a ante venenatis 
+                <a
+                  href="artsy.net"
+                >
+                  dapibus posuere velit
+                </a>
+                 aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+              </div>
+            </div>
           </div>
           <div
             className="fresnel-container fresnel-lessThan-md"
@@ -3530,13 +3565,32 @@ exports[`Video Layout matches the snapshot 1`] = `
             className="article__text-section c45 c46"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                <b>
+                  Director
+                </b>
+              </div>
+              <div
+                className="paragraph"
+              >
+                Marina Cashdan
+              </div>
+              <div
+                className="paragraph"
+              >
+                <b>
+                  Featuring
+                </b>
+              </div>
+              <div
+                className="paragraph"
+              >
+                Trevor Paglan
+              </div>
+            </div>
           </div>
           <div
             className="fresnel-container fresnel-greaterThanOrEqual-md"
@@ -3688,13 +3742,29 @@ exports[`Video Layout matches the snapshot 1`] = `
             className="article__text-section c45 c46"
             color="white"
           >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                }
-              }
-            />
+            <div>
+              <div
+                className="paragraph"
+              >
+                Integer posuere erat a ante venenatis 
+                <a
+                  href="artsy.net"
+                >
+                  dapibus posuere velit
+                </a>
+                 aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+              </div>
+              <div
+                className="paragraph"
+              >
+                Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+              </div>
+            </div>
           </div>
           <div
             className="fresnel-container fresnel-lessThan-md"
@@ -4279,13 +4349,29 @@ exports[`Video Layout matches the snapshot 1`] = `
                   className="article__text-section c45 c46"
                   color="white"
                 >
-                  <div
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-                      }
-                    }
-                  />
+                  <div>
+                    <div
+                      className="paragraph"
+                    >
+                      Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+                      <a
+                        href="http://artsy.net"
+                      >
+                        Curabitur blandit
+                      </a>
+                       tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    </div>
+                    <div
+                      className="paragraph"
+                    >
+                      Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+                    </div>
+                    <div
+                      className="paragraph"
+                    >
+                      Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+                    </div>
+                  </div>
                 </div>
               </div>
               <div

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -189,7 +189,6 @@ export class Sections extends Component<Props, State> {
           layout={article.layout}
           isContentStart={index === this.getContentStartIndex()}
           isContentEnd={index === this.getContentEndIndex()}
-          isMobile={isMobile}
           showTooltips={showTooltips}
         />
       ),

--- a/src/Components/Publishing/Sections/Sections.tsx
+++ b/src/Components/Publishing/Sections/Sections.tsx
@@ -189,6 +189,7 @@ export class Sections extends Component<Props, State> {
           layout={article.layout}
           isContentStart={index === this.getContentStartIndex()}
           isContentEnd={index === this.getContentEndIndex()}
+          isMobile={isMobile}
           showTooltips={showTooltips}
         />
       ),

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -15,6 +15,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   layout: ArticleLayout
   postscript?: boolean
   showTooltips?: boolean
+  isMobile?: boolean
 }
 
 interface State {
@@ -25,6 +26,7 @@ export class Text extends Component<Props, State> {
   static defaultProps = {
     color: "black",
     showTooltips: false,
+    isMobile: false,
   }
 
   static contextTypes = {
@@ -132,6 +134,8 @@ export class Text extends Component<Props, State> {
   renderArtistFollowButton = (node: Element) => {
     // Dont include relay components unless necessary
     // To avoid 'regeneratorRuntime' error
+    const MobileFollowButton = require("../../FollowButton/MobileFollowArtistButton")
+      .MobileFollowArtistButtonQueryRenderer
     const FollowButton = require("../../FollowButton/FollowArtistButton")
       .FollowArtistButtonFragmentContainer
 
@@ -141,7 +145,11 @@ export class Text extends Component<Props, State> {
 
     return (
       <FollowContainer key={artistId}>
-        <FollowButton {...props} />
+        {this.props.isMobile ? (
+          <MobileFollowButton artistId={artistId} />
+        ) : (
+          <FollowButton {...props} />
+        )}
       </FollowContainer>
     )
   }
@@ -158,7 +166,7 @@ export class Text extends Component<Props, State> {
       if (this.isArtistFollow(node)) {
         return this.renderArtistFollowButton(node)
       }
-      if (this.shouldShowTooltipForURL(node)) {
+      if (this.props.showTooltips && this.shouldShowTooltipForURL(node)) {
         return this.renderLinkWithToolTip(node, index)
       }
     }
@@ -185,13 +193,7 @@ export class Text extends Component<Props, State> {
         showTooltips={showTooltips}
       >
         {html.length ? (
-          showTooltips ? (
-            <div>
-              {ReactHtmlParser(html, { transform: this.transformNode })}
-            </div>
-          ) : (
-            <div dangerouslySetInnerHTML={{ __html: html }} />
-          )
+          <div>{ReactHtmlParser(html, { transform: this.transformNode })}</div>
         ) : (
           children
         )}

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -15,7 +15,6 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   layout: ArticleLayout
   postscript?: boolean
   showTooltips?: boolean
-  isMobile?: boolean
 }
 
 interface State {
@@ -145,7 +144,7 @@ export class Text extends Component<Props, State> {
 
     return (
       <FollowContainer key={artistId}>
-        {this.props.isMobile ? (
+        {!this.props.showTooltips ? (
           <MobileFollowButton artistId={artistId} />
         ) : (
           <FollowButton {...props} />

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -144,10 +144,10 @@ export class Text extends Component<Props, State> {
 
     return (
       <FollowContainer key={artistId}>
-        {!this.props.showTooltips ? (
-          <MobileFollowButton artistId={artistId} />
-        ) : (
+        {this.props.showTooltips ? (
           <FollowButton {...props} />
+        ) : (
+          <MobileFollowButton artistId={artistId} />
         )}
       </FollowContainer>
     )

--- a/src/Components/Publishing/Sections/Text.tsx
+++ b/src/Components/Publishing/Sections/Text.tsx
@@ -25,7 +25,6 @@ export class Text extends Component<Props, State> {
   static defaultProps = {
     color: "black",
     showTooltips: false,
-    isMobile: false,
   }
 
   static contextTypes = {

--- a/src/Components/Publishing/Sections/__tests__/Text.test.tsx
+++ b/src/Components/Publishing/Sections/__tests__/Text.test.tsx
@@ -83,8 +83,8 @@ describe("Text", () => {
         testProps.isContentEnd = true
         const wrapper = mount(getWrapper(testProps))
 
-        expect(wrapper.html()).toMatch(
-          `<p>The end of the article<span class=\"content-end\"> </span></p><h3>An h3 after</h3>`
+        expect(wrapper.html()).toContain(
+          '<div class="paragraph">The end of the article<span class="content-end"> </span></div><h3>An h3 after</h3></div>'
         )
       })
 

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/SectionContainer.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/SectionContainer.test.tsx.snap
@@ -279,13 +279,13 @@ exports[`SectionContainer Snapshots renders column_width properly 1`] = `
     className="article__text-section c1"
     color="black"
   >
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>Hello, world!</p>",
-        }
-      }
-    />
+    <div>
+      <div
+        className="paragraph"
+      >
+        Hello, world!
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -569,13 +569,13 @@ exports[`SectionContainer Snapshots renders fillwidth properly 1`] = `
     className="article__text-section c1"
     color="black"
   >
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>Hello, world!</p>",
-        }
-      }
-    />
+    <div>
+      <div
+        className="paragraph"
+      >
+        Hello, world!
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -859,13 +859,13 @@ exports[`SectionContainer Snapshots renders overflow_fillwidth properly 1`] = `
     className="article__text-section c1"
     color="black"
   >
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>Hello, world!</p>",
-        }
-      }
-    />
+    <div>
+      <div
+        className="paragraph"
+      >
+        Hello, world!
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
+++ b/src/Components/Publishing/Sections/__tests__/__snapshots__/Sections.test.tsx.snap
@@ -994,13 +994,46 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p><a href='https://www.artsy.net/artist/pablo-picasso'>What would Antoine Court</a>’s de Gébelin think of the Happy Squirrel? </p><p>De Gébelin was a Protestant minister born in the 18th century. He authored the multi-volume tome <em>Le Monde primitif</em>, which insisted that the tarot deck contained secrets of the ancient Egyptians, whose priests had distilled their occult wisdom into the cards’ illustrations, imbuing them with great mystical power. Before that point, tarot was primarily a card game—meant for fun, not prophecy.</p><p>It was a bold and somewhat absurd assertion, given that de Gébelin could not read Egyptian hieroglyphics (no one could at the time, since they weren’t deciphered until the 19th century). Despite a total lack of historical evidence to back his claim, the theory stuck: Tarot decks, once a novelty, became popular tools for divination after the publication of de Gébelin’s book.</p><p>Which brings us back to the Happy Squirrel, a relatively recent addition to the tarot’s Major Arcana, and one whose provenance is less hazy: it originated on season six of <em>The Simpsons</em>. Lisa visits a fortune teller who is unconcerned when Lisa picks Death, but gasps in horror when the next card she draws is the Happy Squirrel. (When Lisa asks if the fuzzy rodent is a bad sign, the fortune teller demurs, saying that “the cards are vague and mysterious.”) Although it began as a cartoon joke, the Happy Squirrel card has made its way into over a dozen commercially available tarot decks. </p><p>So what would de Gébelin’s reaction be? The answer depends on whether tarot is a collection of timeless, mystical wisdom—or a flexible framework that has endured by changing with the times. Although tarot imagery employs supposedly universal archetypes, new decks are constantly being invented, and old decks altered. The art of tarot cards can never fully transcend its milieu. Which begs a second question: How do the cards’ art and design relate to the social changes, technological advances, and aesthetic sensibilities of their particular eras?</p>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          <a
+            href="https://www.artsy.net/artist/pablo-picasso"
+          >
+            What would Antoine Court
+          </a>
+          ’s de Gébelin think of the Happy Squirrel? 
+        </div>
+        <div
+          className="paragraph"
+        >
+          De Gébelin was a Protestant minister born in the 18th century. He authored the multi-volume tome 
+          <em>
+            Le Monde primitif
+          </em>
+          , which insisted that the tarot deck contained secrets of the ancient Egyptians, whose priests had distilled their occult wisdom into the cards’ illustrations, imbuing them with great mystical power. Before that point, tarot was primarily a card game—meant for fun, not prophecy.
+        </div>
+        <div
+          className="paragraph"
+        >
+          It was a bold and somewhat absurd assertion, given that de Gébelin could not read Egyptian hieroglyphics (no one could at the time, since they weren’t deciphered until the 19th century). Despite a total lack of historical evidence to back his claim, the theory stuck: Tarot decks, once a novelty, became popular tools for divination after the publication of de Gébelin’s book.
+        </div>
+        <div
+          className="paragraph"
+        >
+          Which brings us back to the Happy Squirrel, a relatively recent addition to the tarot’s Major Arcana, and one whose provenance is less hazy: it originated on season six of 
+          <em>
+            The Simpsons
+          </em>
+          . Lisa visits a fortune teller who is unconcerned when Lisa picks Death, but gasps in horror when the next card she draws is the Happy Squirrel. (When Lisa asks if the fuzzy rodent is a bad sign, the fortune teller demurs, saying that “the cards are vague and mysterious.”) Although it began as a cartoon joke, the Happy Squirrel card has made its way into over a dozen commercially available tarot decks. 
+        </div>
+        <div
+          className="paragraph"
+        >
+          So what would de Gébelin’s reaction be? The answer depends on whether tarot is a collection of timeless, mystical wisdom—or a flexible framework that has endured by changing with the times. Although tarot imagery employs supposedly universal archetypes, new decks are constantly being invented, and old decks altered. The art of tarot cards can never fully transcend its milieu. Which begs a second question: How do the cards’ art and design relate to the social changes, technological advances, and aesthetic sensibilities of their particular eras?
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -1010,13 +1043,24 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<h3><strong>Galleries Section, Booth 10221</strong></h3><h2>neugerriemschneider</h2><h3>With works by Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White</h3><p>The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.</p>",
-          }
-        }
-      />
+      <div>
+        <h3>
+          <strong>
+            Galleries Section, Booth 10221
+          </strong>
+        </h3>
+        <h2>
+          neugerriemschneider
+        </h2>
+        <h3>
+          With works by Franz Ackermann, Ai Weiwei, Pawel Althamer, Billy Childish, Keith Edmier, Olafur Eliasson, Andreas Eriksson, Noa Eshkol, Mario García Torres, Renata Lucas, Michel Majerus, Mike Nelson, Jorge Pardo, Elizabeth Peyton, Tobias Rehberger, Thaddeus Strode, Rirkrit Tiravanija, Pae White
+        </h3>
+        <div
+          className="paragraph"
+        >
+          The resultant work allows Salley the chance to recount her experiences of the aftermath of her scandal in her own words. In the film, Fujiwara and Salley are shown meeting professionals from public relations, advertising, and fashion companies as they seek to construct a new public image for her. Alongside the film, light boxes display fashion photographer Andreas Larsson’s pictures of Salley, which were taken as part of the project to rebuild her profile. While the show tackles public identity, female iconography, and Salley’s voice as an artist, the pair’s close working relationship—one in which the conventional power relationship has been overturned—no doubt aided their collaboration.
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -1026,13 +1070,11 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<blockquote>The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions.</blockquote>",
-          }
-        }
-      />
+      <div>
+        <blockquote>
+          The fixed stars exhibit no regular arrangement, either in their magnitudes, distances, or positions.
+        </blockquote>
+      </div>
     </div>
   </div>
   <div
@@ -1042,13 +1084,11 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<h2>A Wealthy Family’s Trick-Taking Game</h2>",
-          }
-        }
-      />
+      <div>
+        <h2>
+          A Wealthy Family’s Trick-Taking Game
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -1408,13 +1448,41 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Despite their aura of mystery, medieval tarot cards were not used for divination, and were probably <em>not</em> created by ancient Egyptian magicians. The earliest surviving tarot decks—now preserved in various museum collections—are Italian, and were commissioned by wealthy patrons, the same way one might have hired an artist to paint a portrait or illuminated prayerbook. </p><p>The Visconti-Sforza Tarot is a collection of decks, none complete, commissioned by the Visconti and Sforza families from the workshop of Milanese court painter Bonifacio Bembo. Cards such as Death, who rides a horse and swings a giant scythe like a player in the world’s most high-stakes polo match, will seem familiar to contemporary enthusiasts. So will the Pope, who sits on a golden throne; and the Lovers, who hold hands beneath a string of heraldic flags. Rather than looking to these cards for mystic guidance, the Visconti and Sforza families would have used them to play a trick-taking card game similar to modern-day Bridge. (Although it’s unlikely—given the good condition of the decks—that they were ever handled with much frequency).</p><p>The cards each have intricately tooled gold backgrounds that glow like the luxury items that they were. Bembo is believed to have included portraits of the families in many of the cards, as well as adding the Visconti family motto here and there for good measure. Akin to the work of <a href=\\"https://www.artsy.net/artist/fra-angelico\\">Fra Angelico</a> and other early-Renaissance artists, the cards are opulent but pictorially flat, although the bodies appear in naturalistic perspective and their clothing billows around them, suggesting volume and form. </p><p><br></p><h2>The 18th-Century Conver Classic</h2>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          Despite their aura of mystery, medieval tarot cards were not used for divination, and were probably 
+          <em>
+            not
+          </em>
+           created by ancient Egyptian magicians. The earliest surviving tarot decks—now preserved in various museum collections—are Italian, and were commissioned by wealthy patrons, the same way one might have hired an artist to paint a portrait or illuminated prayerbook. 
+        </div>
+        <div
+          className="paragraph"
+        >
+          The Visconti-Sforza Tarot is a collection of decks, none complete, commissioned by the Visconti and Sforza families from the workshop of Milanese court painter Bonifacio Bembo. Cards such as Death, who rides a horse and swings a giant scythe like a player in the world’s most high-stakes polo match, will seem familiar to contemporary enthusiasts. So will the Pope, who sits on a golden throne; and the Lovers, who hold hands beneath a string of heraldic flags. Rather than looking to these cards for mystic guidance, the Visconti and Sforza families would have used them to play a trick-taking card game similar to modern-day Bridge. (Although it’s unlikely—given the good condition of the decks—that they were ever handled with much frequency).
+        </div>
+        <div
+          className="paragraph"
+        >
+          The cards each have intricately tooled gold backgrounds that glow like the luxury items that they were. Bembo is believed to have included portraits of the families in many of the cards, as well as adding the Visconti family motto here and there for good measure. Akin to the work of 
+          <a
+            href="https://www.artsy.net/artist/fra-angelico"
+          >
+            Fra Angelico
+          </a>
+           and other early-Renaissance artists, the cards are opulent but pictorially flat, although the bodies appear in naturalistic perspective and their clothing billows around them, suggesting volume and form. 
+        </div>
+        <div
+          className="paragraph"
+        >
+          <br />
+        </div>
+        <h2>
+          The 18th-Century Conver Classic
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -1749,13 +1817,27 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Produced in 1760, French engraver Nicolas Conver’s deck of delicate woodcuts, the Tarot de Marseille, is the template on which many contemporary decks are based. Like the Visconti-Sforza Tarot, the deck’s design likely originated in 15th-century Italy before traveling north to France. It’s a favorite of many tarot enthusiasts, most notably the cult film director Alejandro Jodorowsky, who <a href=\\"http://www.nytimes.com/2011/11/13/fashion/alejandro-jodorowsky-and-his-tarot-de-marseille.html?mcubz=1\\">designed his own deck</a> based on the style. While the Conver deck wasn’t the first to be called the Tarot de Marseille, it’s highly prized by collectors for its delicate color palette of sky blues and minty greens. The graphic black outlines and blunt shading of the prints give the cards a simple and rough-hewn appearance, which adds to the ambience of ancient wisdom. The popularity of the tarot grew due to advances in printing technology and via the writings of 19th-century French occultists such as Éliphas Lévi and Etteilla, which popularized the use of tarot as a method of fortune-telling and assigned additional divinatory meaning to the cards.</p><p><br></p><h2>The New Mystics</h2>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          Produced in 1760, French engraver Nicolas Conver’s deck of delicate woodcuts, the Tarot de Marseille, is the template on which many contemporary decks are based. Like the Visconti-Sforza Tarot, the deck’s design likely originated in 15th-century Italy before traveling north to France. It’s a favorite of many tarot enthusiasts, most notably the cult film director Alejandro Jodorowsky, who 
+          <a
+            href="http://www.nytimes.com/2011/11/13/fashion/alejandro-jodorowsky-and-his-tarot-de-marseille.html?mcubz=1"
+          >
+            designed his own deck
+          </a>
+           based on the style. While the Conver deck wasn’t the first to be called the Tarot de Marseille, it’s highly prized by collectors for its delicate color palette of sky blues and minty greens. The graphic black outlines and blunt shading of the prints give the cards a simple and rough-hewn appearance, which adds to the ambience of ancient wisdom. The popularity of the tarot grew due to advances in printing technology and via the writings of 19th-century French occultists such as Éliphas Lévi and Etteilla, which popularized the use of tarot as a method of fortune-telling and assigned additional divinatory meaning to the cards.
+        </div>
+        <div
+          className="paragraph"
+        >
+          <br />
+        </div>
+        <h2>
+          The New Mystics
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -1867,13 +1949,44 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>The Rider-Waite Smith deck, which debuted in 1909, remains the most recognizable and popular today. Designed by artist Pamela Colman Smith under the direction of the mystic A.E. Waite, it was the first to be mass-produced in English, and was intended for divination rather than gameplay. Smith and Waite were both active members of the Order of the Golden Dawn, a secretive organization devoted to the exploration of the paranormal and occult (allegedly Bram Stoker, Aleister Crowley, and Sir Arthur Conan Doyle were also members). </p><p>In addition to Smith’s occult bonafides, she was also an accomplished artist, championed by <a href=\\"https://www.artsy.net/artist/alfred-stieglitz\\">Alfred Stieglitz</a>, who collected her work and showed it at his gallery. Smith created fully-realized illustrations of all 78 cards that made the deck a treasure-trove for cartomancers, who now had a much richer store of images to work with. (Previously, only the 22 Major Arcana cards such as the Fool, the Magician, and the Lovers had been elaborately illustrated—traditionally, the Minor Arcana cards, which are roughly analogous to the suits in a deck of modern playing cards, were not.) The Major Arcana were based on the Tarot de Marseille drawings, but rendered in an illustrative <a href=\\"https://www.artsy.net/gene/art-nouveau\\">Art Nouveau</a> style rich with patterns. Even the Fool looks debonaire; he carelessly approaches the cliff, a feather in his cap and a blooming rose in his elegant fingers, wearing a floral tunic that looks straight out of <a href=\\"https://www.artsy.net/artist/william-morris\\">William Morris</a>’s workshop.</p><p><br></p><h2>An Occultist’s Pure Geometry</h2>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          The Rider-Waite Smith deck, which debuted in 1909, remains the most recognizable and popular today. Designed by artist Pamela Colman Smith under the direction of the mystic A.E. Waite, it was the first to be mass-produced in English, and was intended for divination rather than gameplay. Smith and Waite were both active members of the Order of the Golden Dawn, a secretive organization devoted to the exploration of the paranormal and occult (allegedly Bram Stoker, Aleister Crowley, and Sir Arthur Conan Doyle were also members). 
+        </div>
+        <div
+          className="paragraph"
+        >
+          In addition to Smith’s occult bonafides, she was also an accomplished artist, championed by 
+          <a
+            href="https://www.artsy.net/artist/alfred-stieglitz"
+          >
+            Alfred Stieglitz
+          </a>
+          , who collected her work and showed it at his gallery. Smith created fully-realized illustrations of all 78 cards that made the deck a treasure-trove for cartomancers, who now had a much richer store of images to work with. (Previously, only the 22 Major Arcana cards such as the Fool, the Magician, and the Lovers had been elaborately illustrated—traditionally, the Minor Arcana cards, which are roughly analogous to the suits in a deck of modern playing cards, were not.) The Major Arcana were based on the Tarot de Marseille drawings, but rendered in an illustrative 
+          <a
+            href="https://www.artsy.net/gene/art-nouveau"
+          >
+            Art Nouveau
+          </a>
+           style rich with patterns. Even the Fool looks debonaire; he carelessly approaches the cliff, a feather in his cap and a blooming rose in his elegant fingers, wearing a floral tunic that looks straight out of 
+          <a
+            href="https://www.artsy.net/artist/william-morris"
+          >
+            William Morris
+          </a>
+          ’s workshop.
+        </div>
+        <div
+          className="paragraph"
+        >
+          <br />
+        </div>
+        <h2>
+          An Occultist’s Pure Geometry
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -1894,13 +2007,55 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>The Thoth deck, named for the Ibis-faced Egyptian god more commonly known as Horus, was painted by the artist Frieda Harris based on direction from the infamous occultist-about-town Aleister Crowley. Completed in the early 1940s, but not widely available until 1969, it features <a href=\\"https://www.artsy.net/gene/art-deco\\">Art Deco</a> borders resembling the pattern of a butterfly wing. </p><p>The deck is an aesthetic departure from the Rider-Waite’s homey <a href=\\"https://www.artsy.net/gene/arts-and-crafts-movement\\">Arts and Crafts</a> aesthetic. Shaped by Harris’s interest in pure geometry, the cards are reminiscent of the work of Swedish painter <a href=\\"https://www.artsy.net/artist/hilma-af-klint\\">Hilma af Klint</a> (a visionary artist who shared Harris’s interest in spiritualism and the writings of Austrian philosopher Rudolf Steiner, both popular subjects of study among the middle and upper classes in the early 20th century). Harris’s shaded orbs and compass-inscribed curves that fill the background of each card bear more than a passing resemblance to Klint’s highly-saturated geometries. Klint, considered by some to be Europe’s first abstract painter, believed that her luminous compositions were the created under the influence of spirits. (The same could easily be said of Harris because she was taking direction from Crowley, who was believed to be a medium, able to channel ancient and magical forces.) </p><p>It’s no coincidence that Klint’s paintings and Harris’s Thoth illustrations were shown in the same pavilion at the 2013 Venice Biennale, which was intended to amplify voices that had previously been excluded and “cover 100 years of dreams and visions,” <a href=\\"http://www.nytimes.com/2013/05/26/arts/design/massimiliano-gioni-of-venice-biennale.html\\">according</a> to curator Massimiliano Gioni.</p><p><br></p><h2>Sex &amp; Self-Help, ’70s Style</h2>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          The Thoth deck, named for the Ibis-faced Egyptian god more commonly known as Horus, was painted by the artist Frieda Harris based on direction from the infamous occultist-about-town Aleister Crowley. Completed in the early 1940s, but not widely available until 1969, it features 
+          <a
+            href="https://www.artsy.net/gene/art-deco"
+          >
+            Art Deco
+          </a>
+           borders resembling the pattern of a butterfly wing. 
+        </div>
+        <div
+          className="paragraph"
+        >
+          The deck is an aesthetic departure from the Rider-Waite’s homey 
+          <a
+            href="https://www.artsy.net/gene/arts-and-crafts-movement"
+          >
+            Arts and Crafts
+          </a>
+           aesthetic. Shaped by Harris’s interest in pure geometry, the cards are reminiscent of the work of Swedish painter 
+          <a
+            href="https://www.artsy.net/artist/hilma-af-klint"
+          >
+            Hilma af Klint
+          </a>
+           (a visionary artist who shared Harris’s interest in spiritualism and the writings of Austrian philosopher Rudolf Steiner, both popular subjects of study among the middle and upper classes in the early 20th century). Harris’s shaded orbs and compass-inscribed curves that fill the background of each card bear more than a passing resemblance to Klint’s highly-saturated geometries. Klint, considered by some to be Europe’s first abstract painter, believed that her luminous compositions were the created under the influence of spirits. (The same could easily be said of Harris because she was taking direction from Crowley, who was believed to be a medium, able to channel ancient and magical forces.) 
+        </div>
+        <div
+          className="paragraph"
+        >
+          It’s no coincidence that Klint’s paintings and Harris’s Thoth illustrations were shown in the same pavilion at the 2013 Venice Biennale, which was intended to amplify voices that had previously been excluded and “cover 100 years of dreams and visions,” 
+          <a
+            href="http://www.nytimes.com/2013/05/26/arts/design/massimiliano-gioni-of-venice-biennale.html"
+          >
+            according
+          </a>
+           to curator Massimiliano Gioni.
+        </div>
+        <div
+          className="paragraph"
+        >
+          <br />
+        </div>
+        <h2>
+          Sex & Self-Help, ’70s Style
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -2203,13 +2358,49 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Created by the artist Bill Greer under the direction of Lloyd Morgan, the Morgan-Greer deck is, like the 1970s themselves, both opulent and optimistic. The Magician sports a mustache that would make Tom Selleck blush, and the naked and embracing Lovers would fit right in with the hirsute and curvaceous illustrations in the original 1972 edition of <em>The Joy of Sex</em>.</p><p>The ‘70s enthusiasm for all things New Age created a renewed interest in tarot as a tool for self-discovery, and the Morgan Greer deck was there to greet it. The cards’ colors are lush and the lines are fluid. Greer chose to crop his figures tightly and removed the borders, allowing the illustrations to extend to the edges. The effect is fresh and personal. Formally, the Morgan-Greer illustrations have more in common with Jefferson Starship’s <em>Spitfire</em> (1976) album cover than with contemporary painting of the same period—the pendulum had swung away from figuration and would take a few years longer to swing back—but it’s possible to find a resonance between this deck’s art and a work like <a href=\\"https://www.artsy.net/artist/judy-chicago\\">Judy </a><a href=\\"https://www.artsy.net/artist/judy-chicago\\">Chicago</a>’s <em>Dinner Party </em>(1979), with its powerful goddess and blooming flowers. Greer’s strong women and frank sexuality make the deck very much of its time.</p><p><br></p><h2>Minimalism &amp; Identity in the Present Day</h2>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          Created by the artist Bill Greer under the direction of Lloyd Morgan, the Morgan-Greer deck is, like the 1970s themselves, both opulent and optimistic. The Magician sports a mustache that would make Tom Selleck blush, and the naked and embracing Lovers would fit right in with the hirsute and curvaceous illustrations in the original 1972 edition of 
+          <em>
+            The Joy of Sex
+          </em>
+          .
+        </div>
+        <div
+          className="paragraph"
+        >
+          The ‘70s enthusiasm for all things New Age created a renewed interest in tarot as a tool for self-discovery, and the Morgan Greer deck was there to greet it. The cards’ colors are lush and the lines are fluid. Greer chose to crop his figures tightly and removed the borders, allowing the illustrations to extend to the edges. The effect is fresh and personal. Formally, the Morgan-Greer illustrations have more in common with Jefferson Starship’s 
+          <em>
+            Spitfire
+          </em>
+           (1976) album cover than with contemporary painting of the same period—the pendulum had swung away from figuration and would take a few years longer to swing back—but it’s possible to find a resonance between this deck’s art and a work like 
+          <a
+            href="https://www.artsy.net/artist/judy-chicago"
+          >
+            Judy 
+          </a>
+          <a
+            href="https://www.artsy.net/artist/judy-chicago"
+          >
+            Chicago
+          </a>
+          ’s 
+          <em>
+            Dinner Party 
+          </em>
+          (1979), with its powerful goddess and blooming flowers. Greer’s strong women and frank sexuality make the deck very much of its time.
+        </div>
+        <div
+          className="paragraph"
+        >
+          <br />
+        </div>
+        <h2>
+          Minimalism & Identity in the Present Day
+        </h2>
+      </div>
     </div>
   </div>
   <div
@@ -2333,13 +2524,18 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Created by graphic designer Kati Forner for a Los Angeles-based fashion retailer, the Dreslyn tarot is the epitome of techno-minimalism. Although the deck is lovingly printed with high-gloss embossing, its illustrations are simple enough to be mistaken for the icon of an elegant iPhone app. It’s a radical departure from the historical approach, where each card is full to bursting with details, signs, and symbols—instead, each card has been paired down the bare minimum. The Dreslyn’s Lovers image is just two slender circles bisecting a line; its Eight of Wands is simply eight diagonal rules. The deck’s aesthetic mirrors the contemporary fear of clutter, as well as the increasing simplicity of the interfaces we use every day.</p><p>Tarot decks have also increasingly become more personal, and occasionally political, while reflecting a greater diversity. Illustrator John Elisle, in a commission for Missy Magazine, created seven all-women tarot cards, a chic sci-fi universe that includes a dominatrix Devil and a psychedelic High Priestess.</p>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          Created by graphic designer Kati Forner for a Los Angeles-based fashion retailer, the Dreslyn tarot is the epitome of techno-minimalism. Although the deck is lovingly printed with high-gloss embossing, its illustrations are simple enough to be mistaken for the icon of an elegant iPhone app. It’s a radical departure from the historical approach, where each card is full to bursting with details, signs, and symbols—instead, each card has been paired down the bare minimum. The Dreslyn’s Lovers image is just two slender circles bisecting a line; its Eight of Wands is simply eight diagonal rules. The deck’s aesthetic mirrors the contemporary fear of clutter, as well as the increasing simplicity of the interfaces we use every day.
+        </div>
+        <div
+          className="paragraph"
+        >
+          Tarot decks have also increasingly become more personal, and occasionally political, while reflecting a greater diversity. Illustrator John Elisle, in a commission for Missy Magazine, created seven all-women tarot cards, a chic sci-fi universe that includes a dominatrix Devil and a psychedelic High Priestess.
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -2451,13 +2647,18 @@ exports[`Sections snapshots tests renders properly 1`] = `
       className="article__text-section c2"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>The Black Power Tarot was conceived by musician King Khan in consultation with Alejandro Jodorowsky, and designed by illustrator Michael Eaton in 2015. The deck celebrates the strength and achievements of Black musicians, artists, and activists while staying faithful to the imagery and composition of the classic Tarot de Marseilles. The familiar faces of Malcolm X, James Brown, Tina Turner, Howlin’ Wolf, Sister Rosetta Tharpe, and others emerge from the Major Arcana. Sun Ra is there too, appropriately imagined as the Sun card. At a time when Black Americans are at a high risk of being the victims of state-sponsored violence, the Black Power Tarot feels especially urgent. By situating these figures within a centuries-old framework of esoteric wisdom, Khan affirms their value and influence, the importance of their legacy. By placing them on cards used for fortune-telling, he extends their power into the future.<span class=\\"content-end\\"> </span></p>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          The Black Power Tarot was conceived by musician King Khan in consultation with Alejandro Jodorowsky, and designed by illustrator Michael Eaton in 2015. The deck celebrates the strength and achievements of Black musicians, artists, and activists while staying faithful to the imagery and composition of the classic Tarot de Marseilles. The familiar faces of Malcolm X, James Brown, Tina Turner, Howlin’ Wolf, Sister Rosetta Tharpe, and others emerge from the Major Arcana. Sun Ra is there too, appropriately imagined as the Sun card. At a time when Black Americans are at a high risk of being the victims of state-sponsored violence, the Black Power Tarot feels especially urgent. By situating these figures within a centuries-old framework of esoteric wisdom, Khan affirms their value and influence, the importance of their legacy. By placing them on cards used for fortune-telling, he extends their power into the future.
+          <span
+            className="content-end"
+          >
+             
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
+++ b/src/Components/Publishing/Series/__tests__/__snapshots__/SeriesAbout.test.tsx.snap
@@ -575,13 +575,29 @@ exports[`SeriesAbout snapshots Renders properly 1`] = `
         className="article__text-section c7"
         color="black"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-            }
-          }
-        />
+        <div>
+          <div
+            className="paragraph"
+          >
+            Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+            <a
+              href="http://artsy.net"
+            >
+              Curabitur blandit
+            </a>
+             tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -1755,13 +1771,29 @@ exports[`SeriesAbout snapshots Renders with editSubTitle 1`] = `
         className="article__text-section c7"
         color="black"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-            }
-          }
-        />
+        <div>
+          <div
+            className="paragraph"
+          >
+            Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+            <a
+              href="http://artsy.net"
+            >
+              Curabitur blandit
+            </a>
+             tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -2410,13 +2442,29 @@ exports[`SeriesAbout snapshots Renders with sponsor 1`] = `
         className="article__text-section c11"
         color="black"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. <a href='http://artsy.net'>Curabitur blandit</a> tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-            }
-          }
-        />
+        <div>
+          <div
+            className="paragraph"
+          >
+            Integer posuere erat a ante venenatis dapibus posuere velit aliquet. 
+            <a
+              href="http://artsy.net"
+            >
+              Curabitur blandit
+            </a>
+             tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+          </div>
+          <div
+            className="paragraph"
+          >
+            Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
+++ b/src/Components/Publishing/Video/__tests__/__snapshots__/VideoAbout.test.tsx.snap
@@ -444,13 +444,32 @@ exports[`Video About matches the snapshot 1`] = `
       className="article__text-section c3 c4"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p><b>Director</b></p><p>Marina Cashdan</p><p><b>Featuring</b></p><p>Trevor Paglan</p>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          <b>
+            Director
+          </b>
+        </div>
+        <div
+          className="paragraph"
+        >
+          Marina Cashdan
+        </div>
+        <div
+          className="paragraph"
+        >
+          <b>
+            Featuring
+          </b>
+        </div>
+        <div
+          className="paragraph"
+        >
+          Trevor Paglan
+        </div>
+      </div>
     </div>
     <div
       className="fresnel-container fresnel-greaterThanOrEqual-md"
@@ -602,13 +621,29 @@ exports[`Video About matches the snapshot 1`] = `
       className="article__text-section c3 c4"
       color="black"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>Integer posuere erat a ante venenatis <a href='artsy.net'>dapibus posuere velit</a> aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.</p><p>Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.</p>",
-          }
-        }
-      />
+      <div>
+        <div
+          className="paragraph"
+        >
+          Integer posuere erat a ante venenatis 
+          <a
+            href="artsy.net"
+          >
+            dapibus posuere velit
+          </a>
+           aliquet. Curabitur blandit tempus porttitor. Donec ullamcorper nulla non metus auctor fringilla. Donec ullamcorper nulla non metus auctor fringilla. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </div>
+        <div
+          className="paragraph"
+        >
+          Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Nullam quis risus eget urna mollis ornare vel eu leo.
+        </div>
+        <div
+          className="paragraph"
+        >
+          Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Nulla vitae elit libero, a pharetra augue.
+        </div>
+      </div>
     </div>
     <div
       className="fresnel-container fresnel-lessThan-md"

--- a/src/__generated__/MobileFollowArtistButtonQuery.graphql.ts
+++ b/src/__generated__/MobileFollowArtistButtonQuery.graphql.ts
@@ -1,0 +1,167 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MobileFollowArtistButtonQueryVariables = {
+    artistId: string;
+};
+export type MobileFollowArtistButtonQueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
+    } | null;
+};
+export type MobileFollowArtistButtonQuery = {
+    readonly response: MobileFollowArtistButtonQueryResponse;
+    readonly variables: MobileFollowArtistButtonQueryVariables;
+};
+
+
+
+/*
+query MobileFollowArtistButtonQuery(
+  $artistId: String!
+) {
+  artist(id: $artistId) {
+    ...FollowArtistButton_artist
+    id
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistId",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistId"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MobileFollowArtistButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FollowArtistButton_artist"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "MobileFollowArtistButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "is_followed",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "MobileFollowArtistButtonQuery",
+    "operationKind": "query",
+    "text": "query MobileFollowArtistButtonQuery(\n  $artistId: String!\n) {\n  artist(id: $artistId) {\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'e249ef453f7f1400e7405137c158d6c1';
+export default node;


### PR DESCRIPTION
## Description

Fixes a bug preventing artist follow buttons from working in mobile context for editorial articles

- Adds a MobileFollowButton wrapped in a QueryRenderer 
- Parses html into react components for all cases and instead just doesn't add tooltips in mobile contexts

https://artsyproduct.atlassian.net/browse/FX-2282

### TODO:

- [ ] Link into positron to make sure this is working 
- [ ] Are there any cases we still need to just set raw html?  
- [x] Fix tests
