### PR TITLE
chore: move cohesion out of dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.2",
-    "@artsy/cohesion": "1.45.0",
     "@artsy/lint-changed": "3.1.0",
     "@artsy/palette": "13.15.0",
     "@babel/cli": "7.0.0",
@@ -167,6 +166,7 @@
     "yalc": "1.0.0-pre.34"
   },
   "dependencies": {
+    "@artsy/cohesion": "1.45.0",
     "@artsy/detect-responsive-traits": "^0.0.5",
     "@artsy/fresnel": "^1.0.13",
     "@artsy/react-html-parser": "^3.0.2",


### PR DESCRIPTION
Moves Cohesion out of dev dependencies and into regular dependencies. 

Cohesion is a real dependency for reaction, so the dev placement is inaccurate. I believe this was added when Reaction was more actively worked on to cut down on CI builds during office hours.

This change will allow us to remove Cohesion from Positron's dependencies.