### PR TITLE
fix: Update URL parsing to more precisely extract slug

### DIFF
--- a/src/Components/Publishing/Constants.ts
+++ b/src/Components/Publishing/Constants.ts
@@ -1,6 +1,5 @@
-import { compact, last, uniq } from "lodash"
+import { compact, uniq } from "lodash"
 import { DateTime } from "luxon"
-import url from "url"
 import { ArticleData, DateFormat } from "../Publishing/Typings"
 
 const APP_URL = process.env.APP_URL || "https://www.artsy.net"
@@ -189,9 +188,9 @@ export const getArtsySlugsFromHTML = (
   const slugs: string[] = []
   doc.querySelectorAll("a").forEach(anchor => {
     const href = anchor.getAttribute("href")
-    if (href && href.match(`artsy.net/${model}`)) {
-      const path = url.parse(href).pathname.replace("/works-for-sale", "")
-      slugs.push(last(path.split("/")))
+    if (href) {
+      const match = href.match(`\/${model}\/(?<slug>.*?)(\/|$|\\?)`)
+      slugs.push(match?.groups?.slug)
     }
   })
 

--- a/src/Components/Publishing/__tests__/Constants.test.ts
+++ b/src/Components/Publishing/__tests__/Constants.test.ts
@@ -150,15 +150,6 @@ describe("getArtsySlugs", () => {
     expect(artists[0]).toBe("jennie-jieun-lee")
   })
 
-  it("#getArtsySlugsFromHTML can strip '/works-for-sale' from artist links", () => {
-    const html =
-      "<p><a href='artsy.net/artist/andy-warhol/works-for-sale'>Andy Warhol</a></p>"
-    const artists = getArtsySlugsFromHTML(html, "artist")
-
-    expect(artists.length).toBe(1)
-    expect(artists[0]).toBe("andy-warhol")
-  })
-
   it("#getArtsySlugsFromHTML can return linked genes from html", () => {
     const html =
       "<p><a href='artsy.net/gene/capitalist-realism'>Capitalist Realism</a></p>"
@@ -168,9 +159,35 @@ describe("getArtsySlugs", () => {
     expect(genes[0]).toBe("capitalist-realism")
   })
 
-  it("#getArtsySlugsFromHTML can strip '/works-for-sale' from artist links", () => {
+  it("#getArtsySlugsFromHTML can strip other routes that occur after the slug", () => {
     const html =
       "<p><a href='artsy.net/artist/andy-warhol/works-for-sale'>Andy Warhol</a></p>"
+    const artists = getArtsySlugsFromHTML(html, "artist")
+
+    expect(artists.length).toBe(1)
+    expect(artists[0]).toBe("andy-warhol")
+  })
+
+  it("#getArtsySlugsFromHTML can strip any query params that occur after the slug", () => {
+    const html =
+      "<p><a href='artsy.net/artist/andy-warhol?foo=bar'>Andy Warhol</a></p>"
+    const artists = getArtsySlugsFromHTML(html, "artist")
+
+    expect(artists.length).toBe(1)
+    expect(artists[0]).toBe("andy-warhol")
+  })
+
+  it("#getArtsySlugsFromHTML only matches the given model and not similarly named models", () => {
+    const html =
+      "<p><a href='artsy.net/artist-series/banksy-rats'>Banksy rats</a></p>"
+    const artists = getArtsySlugsFromHTML(html, "artist")
+
+    expect(artists.length).toBe(0)
+  })
+
+  it("#getArtsySlugsFromHTML correctly parses links ending in /", () => {
+    const html =
+      "<p><a href='artsy.net/artist/andy-warhol/'>Andy Warhol</a></p>"
     const artists = getArtsySlugsFromHTML(html, "artist")
 
     expect(artists.length).toBe(1)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-64

## Problem

`getArtsySlugsFromHTML` incorrectly parses some links in Editorial articles resulting in (1) users being unable to click on any artist link in the article and (2) tooltips for artist links not showing up. 

For example, links like `/artist-series/slug` were incorrectly interpreted as an artist slug and and links like `/artist/slug/` were incorrectly interpreted to not be an artist link.

## Solution

Update `getArtsySlugsFromHTML` to use a regex that correctly parses a greater variety of inputs. Links including trailing slashes, artist app subroutes (`/works-for-you`, `/auction-results`) and query params will now be correctly parsed.

~**DoNotMerge** until I've validated (1) I've covered all the known cases of broken links and (2) I've confirmed that showing tooltip links for links to artist app subroutes is what we want.~