### PR TITLE
fix: Add white-space CSS property to fix overflowing descriptions

### DIFF
--- a/src/Components/Publishing/ToolTip/Components/Description.tsx
+++ b/src/Components/Publishing/ToolTip/Components/Description.tsx
@@ -34,4 +34,5 @@ const Description = styled.div`
     ${garamond("s15")};
   }
   padding-bottom: 10px;
+  white-space: initial;
 `


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-65

cc @artsy/grow-devs 

## Problem

Descriptions in artist tooltips in articles occasionally overflow out of the container instead of being properly truncated, leading to a visually poor user experience.

## Solution

Add `white-space: initial` to the artist tooltip description container.

## Screenshots

**Before**

![Screen Shot 2021-01-13 at 6 55 47 PM](https://user-images.githubusercontent.com/4432348/104526652-f82a1c80-55d0-11eb-9084-976b5b6b1886.png)

**After**

![Screen Shot 2021-01-13 at 6 51 37 PM](https://user-images.githubusercontent.com/4432348/104526627-e6e11000-55d0-11eb-8410-41e69e2583f8.png)
