### PR TITLE
feat: Render article ads conditionally

### DIFF
--- a/src/Components/Publishing/Layouts/SeriesLayout.tsx
+++ b/src/Components/Publishing/Layouts/SeriesLayout.tsx
@@ -20,13 +20,20 @@ interface Props {
   color?: string
   relatedArticles?: any
   isMobile?: boolean
+  shouldAdRender?: boolean
 }
 
 export class SeriesLayout extends Component<Props, null> {
   public static defaultProps: Partial<Props>
 
   render() {
-    const { article, backgroundColor, relatedArticles, isMobile } = this.props
+    const {
+      article,
+      backgroundColor,
+      relatedArticles,
+      isMobile,
+      shouldAdRender,
+    } = this.props
 
     const { hero_section, sponsor } = article
     const isSponsored = isEditorialSponsored(sponsor)
@@ -62,20 +69,22 @@ export class SeriesLayout extends Component<Props, null> {
             <SeriesAbout article={article} color={this.props.color} />
           </Box>
         </SeriesContent>
-        <DisplayAd
-          adUnit={
-            isMobile
-              ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
-              : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-          }
-          adDimension={adDimension}
-          targetingData={targetingData(
-            article,
-            isSponsored ? "sponsorlanding" : "standardseries"
-          )}
-          isSeries
-          articleSlug={article.slug}
-        />
+        {shouldAdRender && (
+          <DisplayAd
+            adUnit={
+              isMobile
+                ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
+                : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+            }
+            adDimension={adDimension}
+            targetingData={targetingData(
+              article,
+              isSponsored ? "sponsorlanding" : "standardseries"
+            )}
+            isSeries
+            articleSlug={article.slug}
+          />
+        )}
       </SeriesContainer>
     )
   }
@@ -84,6 +93,7 @@ export class SeriesLayout extends Component<Props, null> {
 SeriesLayout.defaultProps = {
   backgroundColor: color("black100"),
   color: "white",
+  shouldAdRender: true,
 }
 
 interface ContainerProps {

--- a/src/Components/Publishing/Layouts/StandardLayout.tsx
+++ b/src/Components/Publishing/Layouts/StandardLayout.tsx
@@ -31,6 +31,7 @@ export class StandardLayout extends React.Component<
     isSuper: false,
     article: {},
     isTruncated: false,
+    shouldAdRender: true,
   }
 
   constructor(props) {
@@ -64,9 +65,9 @@ export class StandardLayout extends React.Component<
   }
 
   renderSideRailDisplayAd(isMobileAd: boolean) {
-    const { article, isSuper } = this.props
+    const { article, isSuper, shouldAdRender } = this.props
 
-    if (isSuper) {
+    if (isSuper || !shouldAdRender) {
       return
     }
 
@@ -87,12 +88,12 @@ export class StandardLayout extends React.Component<
   }
 
   renderTopRailDisplayAd(isMobileAd: boolean) {
-    const { article, isSuper } = this.props
+    const { article, isSuper, shouldAdRender } = this.props
     const adDimension = isMobileAd
       ? AdDimension.Mobile_InContentMR1
       : AdDimension.Desktop_TopLeaderboard
 
-    if (isSuper) {
+    if (isSuper || !shouldAdRender) {
       return
     }
 

--- a/src/Components/Publishing/Layouts/VideoLayout.tsx
+++ b/src/Components/Publishing/Layouts/VideoLayout.tsx
@@ -22,6 +22,7 @@ interface Props {
   seriesArticle?: ArticleData
   relatedArticles?: any
   isMobile?: boolean
+  shouldAdRender?: boolean
 }
 
 interface State {
@@ -42,6 +43,10 @@ interface State {
   }
 )
 export class VideoLayout extends Component<Props, State> {
+  static defaultProps = {
+    shouldAdRender: true,
+  }
+
   state = {
     isPlaying: false,
     hideCover: false,
@@ -77,7 +82,7 @@ export class VideoLayout extends Component<Props, State> {
   }
 
   render() {
-    const { article, isMobile, relatedArticles } = this.props
+    const { article, isMobile, relatedArticles, shouldAdRender } = this.props
     const { media, seriesArticle } = article
     const sponsor = seriesArticle ? seriesArticle.sponsor : article.sponsor
     const isSponsored = isEditorialSponsored(sponsor)
@@ -120,20 +125,22 @@ export class VideoLayout extends Component<Props, State> {
             </Box>
           )}
         </Box>
-        <DisplayAd
-          adUnit={
-            isMobile
-              ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
-              : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
-          }
-          adDimension={adDimension}
-          targetingData={targetingData(
-            article,
-            isSponsored ? "sponsorfeature" : "video"
-          )}
-          isSeries
-          articleSlug={article.slug}
-        />
+        {shouldAdRender && (
+          <DisplayAd
+            adUnit={
+              isMobile
+                ? AdUnit.Mobile_SponsoredSeriesLandingPageAndVideoPage_Bottom
+                : AdUnit.Desktop_SponsoredSeriesLandingPageAndVideoPage_LeaderboardBottom
+            }
+            adDimension={adDimension}
+            targetingData={targetingData(
+              article,
+              isSponsored ? "sponsorfeature" : "video"
+            )}
+            isSeries
+            articleSlug={article.slug}
+          />
+        )}
       </VideoLayoutContainer>
     )
   }


### PR DESCRIPTION
Addresses [CX-1585]

## Context

This PR contributes towards not showing ads in articles on the app anymore.

## Description

The `shouldAdRender` isn't passed from the `Articles` component to the layout components. With this PR the prop get's passed to the layout components and ads get rendered conditionally. 

To keep things safe `shouldAdRender` defaults to `true`.

[CX-1585]: https://artsyproduct.atlassian.net/browse/CX-1585