### PR TITLE
bugfix: Fix overflow text

### DIFF
--- a/src/Components/Publishing/Header/Layouts/Components/FeatureSplitHeader.tsx
+++ b/src/Components/Publishing/Header/Layouts/Components/FeatureSplitHeader.tsx
@@ -150,6 +150,7 @@ export const FeatureSplitHeaderContainer = styled(Flex)<{
   hasNav?: boolean
 }>`
   height: ${props => (props.hasNav ? "100vh" : "calc(100vh - 61px)")};
+  overflow: hidden;
   min-height: fit-content;
 
   ${props =>


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/GRO-370

Fixes an issue where the copy text would overlap the header image on mobile. Now we just run overflow:hidden over it and be done with it. Works well enough. 

⚠️  Note: was not able to get article pages running in force without commenting out [client-side mount code here](https://github.com/artsy/force/blob/1d3a83449f2224b3c190a082f83b1b28e7a3b0e2/src/desktop/apps/article/client/article.tsx#L9-L13). For whatever reason after the SSR pass the screen blanks out on client-side mount. I couldn't figure out how to fix. 

Before:
 
<img width="404" alt="Screen Shot 2021-08-12 at 2 32 00 PM" src="https://user-images.githubusercontent.com/236943/129272868-472e9160-c9c8-405f-87a4-5f1bf6534fa9.png">

After: 

![overflow](https://user-images.githubusercontent.com/236943/129272821-ca2df353-de83-4834-89ee-98ce27d5f7e0.gif)
