### PR TITLE
feat: add marketing collection types

### DIFF
--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -116,6 +116,7 @@ export interface ArticleData {
 }
 
 export type SectionType =
+  | "collection"
   | "image_collection"
   | "image" // TODO: to be deprecated
   | "image_set"
@@ -137,6 +138,8 @@ export interface SectionData {
   title?: string
   mobile_height?: number
   height?: number
+  name?: string // for collection
+  image_url?: string // for collection
 }
 
 export type ImagesData = ImageData[]

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -116,7 +116,7 @@ export interface ArticleData {
 }
 
 export type SectionType =
-  | "collection"
+  | "marketing_collection"
   | "image_collection"
   | "image" // TODO: to be deprecated
   | "image_set"
@@ -138,8 +138,8 @@ export interface SectionData {
   title?: string
   mobile_height?: number
   height?: number
-  name?: string // for collection
-  image_url?: string // for collection
+  name?: string // for marketing_collection
+  image_url?: string // for marketing_collection
 }
 
 export type ImagesData = ImageData[]

--- a/src/Components/Publishing/Typings.ts
+++ b/src/Components/Publishing/Typings.ts
@@ -116,30 +116,30 @@ export interface ArticleData {
 }
 
 export type SectionType =
-  | "marketing_collection"
-  | "image_collection"
-  | "image" // TODO: to be deprecated
-  | "image_set"
+  | "default"
   | "embed"
-  | "social_embed"
+  | "image_collection"
+  | "image_set"
+  | "image" // TODO: to be deprecated
+  | "marketing_collection"
   | "slideshow" // TODO: to be deprecated
+  | "social_embed"
   | "text"
   | "video"
-  | "default"
 
 export interface SectionData {
-  type: SectionType
-  layout?: SectionLayout
-  images?: ImagesData
   body?: string
-  url?: string
   caption?: string
   cover_image_url?: string
-  title?: string
-  mobile_height?: number
   height?: number
-  name?: string // for marketing_collection
   image_url?: string // for marketing_collection
+  images?: ImagesData
+  layout?: SectionLayout
+  mobile_height?: number
+  name?: string // for marketing_collection
+  title?: string
+  type: SectionType
+  url?: string
 }
 
 export type ImagesData = ImageData[]


### PR DESCRIPTION
This PR supports hackathon work in `positron` (see Draft [PR](https://github.com/artsy/positron/pull/3169/files)) to add a marketing collection rail to our editorial articles. See [hackathon card](https://www.notion.so/artsy/Integrating-Collections-and-Editorial-177cab0764a08047a447e162cd60e2e6?pvs=4). These type additions will allow me to finish the draft PR. 

I also alphabetized the declarations. See commit e439074cb8f64fc5a9bc0567d5b6f380899dbcf3 for easier view of what actually was added. 